### PR TITLE
Fixes Part of #23 path issues for bin and sql + changed owner for "whatsnew"

### DIFF
--- a/ActiveForums.dnn
+++ b/ActiveForums.dnn
@@ -70,9 +70,10 @@
         </component>
         <component type="Assembly">
           <assemblies>
+			<basePath>bin</basePath>
             <assembly>
               <name>DotNetNuke.Modules.ActiveForums.dll</name>
-              <sourceFileName>DotNetNuke.Modules.ActiveForums.dll</sourceFileName>
+              <sourceFileName>bin\DotNetNuke.Modules.ActiveForums.dll</sourceFileName>
               <version>06.04.00</version>
             </assembly>
           </assemblies>
@@ -89,185 +90,230 @@
           </files>
         </component>
         <component type="Script">
-          <scripts>
+           <scripts>
             <basePath>DesktopModules\ActiveForums\sql</basePath>
             <script type="Install">
+             <path>sql</path>
               <name>04.00.00.SqlDataProvider</name>
               <version>04.00.00</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.00.01.SqlDataProvider</name>
               <version>04.00.01</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.00.02.SqlDataProvider</name>
               <version>04.00.02</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.00.03.SqlDataProvider</name>
               <version>04.00.03</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.00.04.SqlDataProvider</name>
               <version>04.00.04</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.00.05.SqlDataProvider</name>
               <version>04.00.05</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.01.00.SqlDataProvider</name>
               <version>04.01.00</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.01.01.SqlDataProvider</name>
               <version>04.01.01</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.01.04.SqlDataProvider</name>
               <version>04.01.04</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.01.05.SqlDataProvider</name>
               <version>04.01.05</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.01.07.SqlDataProvider</name>
               <version>04.01.07</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.01.08.SqlDataProvider</name>
               <version>04.01.08</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.01.10.SqlDataProvider</name>
               <version>04.01.10</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.01.13.SqlDataProvider</name>
               <version>04.01.13</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.01.15.SqlDataProvider</name>
               <version>04.01.15</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.01.16.SqlDataProvider</name>
               <version>04.01.16</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.01.17.SqlDataProvider</name>
               <version>04.01.17</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.01.18.SqlDataProvider</name>
               <version>04.01.18</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.02.00.SqlDataProvider</name>
               <version>04.02.00</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.02.01.SqlDataProvider</name>
               <version>04.02.01</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.02.03.SqlDataProvider</name>
               <version>04.02.03</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.02.04.SqlDataProvider</name>
               <version>04.02.04</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.02.05.SqlDataProvider</name>
               <version>04.02.05</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.02.06.SqlDataProvider</name>
               <version>04.02.06</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.02.07.SqlDataProvider</name>
               <version>04.02.07</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.03.00.SqlDataProvider</name>
               <version>04.03.00</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.03.01.SqlDataProvider</name>
               <version>04.03.01</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.03.02.SqlDataProvider</name>
               <version>04.03.02</version>
             </script>
             <script type="Install">
+             <path>sql</path>
               <name>04.03.03.SqlDataProvider</name>
               <version>04.03.03</version>
             </script>
             <script type="Install">
+              <path>sql</path>
               <name>04.03.04.SqlDataProvider</name>
               <version>04.03.04</version>
             </script>
             <script type="Install">
+              <path>sql</path>
               <name>04.03.05.SqlDataProvider</name>
               <version>04.03.05</version>
             </script>
             <script type="Install">
+              <path>sql</path>
               <name>04.03.06.SqlDataProvider</name>
               <version>04.03.06</version>
             </script>
             <script type="Install">
+              <path>sql</path>
               <name>04.03.09.SqlDataProvider</name>
               <version>04.03.09</version>
             </script>
             <script type="Install">
+              <path>sql</path>
               <name>05.00.01.SqlDataProvider</name>
               <version>05.00.01</version>
             </script>
             <script type="Install">
+              <path>sql</path>
               <name>05.01.00.SqlDataProvider</name>
               <version>05.01.00</version>
             </script>
             <script type="Install">
+              <path>sql</path>
               <name>05.01.03.SqlDataProvider</name>
               <version>05.01.03</version>
             </script>
             <script type="Install">
+              <path>sql</path>
               <name>05.02.00.SqlDataProvider</name>
               <version>05.02.00</version>
             </script>
             <script type="Install">
+              <path>sql</path>
               <name>05.02.01.SqlDataProvider</name>
               <version>05.02.01</version>
             </script>
             <script type="Install">
+              <path>sql</path>
               <name>06.00.02.SqlDataProvider</name>
               <version>06.00.02</version>
             </script>
             <script type="Install">
+              <path>sql</path>
               <name>06.01.03.SqlDataProvider</name>
               <version>06.01.03</version>
             </script>
             <script type="Install">
+              <path>sql</path>
               <name>06.01.06.SqlDataProvider</name>
               <version>06.01.06</version>
             </script>
             <script type="Install">
+              <path>sql</path>
               <name>06.02.06.SqlDataProvider</name>
               <version>06.02.06</version>
             </script>
             <script type="Install">
+              <path>sql</path>
               <name>06.02.07.SqlDataProvider</name>
               <version>06.02.07</version>
             </script>
             <script type="Install">
+              <path>sql</path>
               <name>06.03.03.SqlDataProvider</name>
               <version>06.03.03</version>
             </script>
             <script type="UnInstall">
+              <path>sql</path>
               <name>Uninstall.SqlDataProvider</name>
               <version>06.04.00</version>
             </script>


### PR DESCRIPTION
#23 is caused by two issues IMO

1. Missing  /bin and /sql base paths in the manifest. > this is fixed in this PR
2. The resources file for the "Whatsnew" module is missing > @hismightiness how would you prefer to fix that?


### Description of PR...

## Changes made
Added \bin and \sql base paths
side note: I also Changed the owner of the WhatsNew Module to DNN community


## PR Template Checklist

- [x] Fixes Bug
- [ ] Feature solution
- [ ] Other


## Please mark which issue is solved
#23 partly

Close #