### PR TITLE
Workaround for DNN issue on updating settings

### DIFF
--- a/components/Common/ForumSettingsBase.cs
+++ b/components/Common/ForumSettingsBase.cs
@@ -64,7 +64,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.Mode] = value;
 				UpdateTabModuleSettingCaseSensitive(SettingKeys.Mode, value);
 			}
 		}
@@ -77,7 +76,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.Theme] = value;
 				UpdateModuleSettingCaseSensitive(SettingKeys.Theme, value);
 			}
 		}
@@ -90,7 +88,6 @@ namespace DotNetNuke.Modules.ActiveForums
             }
             set
             {
-                Settings[SettingKeys.TimeFormatString] = value;
                 UpdateModuleSettingCaseSensitive(SettingKeys.TimeFormatString, value);
             }
         }
@@ -103,7 +100,6 @@ namespace DotNetNuke.Modules.ActiveForums
             }
             set
             {
-                Settings[SettingKeys.DateFormatString] = value;
                 UpdateModuleSettingCaseSensitive(SettingKeys.DateFormatString, value);
             }
         }
@@ -116,7 +112,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.ForumTemplateId] = value;
 				UpdateModuleSettingCaseSensitive(SettingKeys.ForumTemplateId, value.ToString());
 			}
 		}
@@ -129,7 +124,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.PageSize] = value;
 				UpdateModuleSettingCaseSensitive(SettingKeys.PageSize, value.ToString());
 			}
 		}
@@ -142,7 +136,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.FloodInterval] = value;
 				UpdateModuleSettingCaseSensitive(SettingKeys.FloodInterval, value.ToString());
 			}
 		}
@@ -155,7 +148,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.EditInterval] = value;
 				UpdateModuleSettingCaseSensitive(SettingKeys.EditInterval, value.ToString());
 			}
 		}
@@ -168,7 +160,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.EnableAutoLink] = value;
 				UpdateModuleSettingCaseSensitive(SettingKeys.EnableAutoLink, value.ToString());
 			}
 		}
@@ -181,7 +172,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.DeleteBehavior] = value;
 				UpdateModuleSettingCaseSensitive(SettingKeys.DeleteBehavior, value.ToString());
 			}
 		}
@@ -194,7 +184,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.AddThisAccount] = value;
 				UpdateModuleSettingCaseSensitive(SettingKeys.AddThisAccount, value);
 			}
 		}
@@ -207,7 +196,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.ProfileVisibility] = value;
 				UpdateModuleSettingCaseSensitive(SettingKeys.ProfileVisibility, value.ToString());
 			}
 		}
@@ -220,7 +208,6 @@ namespace DotNetNuke.Modules.ActiveForums
             }
             set
             {
-                Settings[SettingKeys.PMType] = value;
                 UpdateModuleSettingCaseSensitive(SettingKeys.PMType, value.ToString());
             }
         }
@@ -233,7 +220,6 @@ namespace DotNetNuke.Modules.ActiveForums
             }
             set
             {
-                Settings[SettingKeys.PMTabId] = value;
                 UpdateModuleSettingCaseSensitive(SettingKeys.PMTabId, value.ToString());
             }
         }
@@ -246,7 +232,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.AllowSignatures] = value;
 				UpdateModuleSettingCaseSensitive(SettingKeys.AllowSignatures, value.ToString());
 			}
 		}
@@ -259,7 +244,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.UserNameDisplay] = value;
 				UpdateModuleSettingCaseSensitive(SettingKeys.UserNameDisplay, value);
 			}
 		}
@@ -272,7 +256,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.EnableURLRewriter] = value;
 				UpdateModuleSettingCaseSensitive(SettingKeys.EnableURLRewriter, value.ToString());
 			}
 		}
@@ -285,7 +268,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.PrefixURLBase] = value;
 				UpdateModuleSettingCaseSensitive(SettingKeys.PrefixURLBase, value);
 			}
 		}
@@ -298,7 +280,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.PrefixURLTags] = value;
 				UpdateModuleSettingCaseSensitive(SettingKeys.PrefixURLTags, value);
 			}
 		}
@@ -311,7 +292,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.PrefixURLCategories] = value;
 				UpdateModuleSettingCaseSensitive(SettingKeys.PrefixURLCategories, value);
 			}
 		}
@@ -324,7 +304,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.PrefixURLOther] = value;
 				UpdateModuleSettingCaseSensitive(SettingKeys.PrefixURLOther, value);
 			}
 		}
@@ -337,7 +316,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.FullText] = value;
 				UpdateModuleSettingCaseSensitive(SettingKeys.FullText, value.ToString());
 			}
 		}
@@ -350,7 +328,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.MailQueue] = value;
 				UpdateModuleSettingCaseSensitive(SettingKeys.MailQueue, value.ToString());
 			}
 		}
@@ -363,7 +340,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.EnablePoints] = value;
 				UpdateModuleSettingCaseSensitive(SettingKeys.EnablePoints, value.ToString());
 			}
 		}
@@ -376,7 +352,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.TopicPointValue] = value;
 				UpdateModuleSettingCaseSensitive(SettingKeys.TopicPointValue, value.ToString());
 			}
 		}
@@ -389,7 +364,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.ReplyPointValue] = value;
 				UpdateModuleSettingCaseSensitive(SettingKeys.ReplyPointValue, value.ToString());
 			}
 		}
@@ -402,7 +376,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.AnswerPointValue] = value;
 				UpdateModuleSettingCaseSensitive(SettingKeys.AnswerPointValue, value.ToString());
 			}
 		}
@@ -415,7 +388,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.MarkAnswerPointValue] = value;
 				UpdateModuleSettingCaseSensitive(SettingKeys.MarkAnswerPointValue, value.ToString());
 			}
 		}
@@ -428,7 +400,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.ModPointValue] = value;
 				UpdateModuleSettingCaseSensitive(SettingKeys.ModPointValue, value.ToString());
 			}
 		}
@@ -441,7 +412,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings["ForumGroupTemplate"] = value;
 				//Use Tab Module Setting
 				UpdateTabModuleSettingCaseSensitive("ForumGroupTemplate", value.ToString());
 			}
@@ -455,7 +425,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings["ForumConfig"] = value;
 				UpdateTabModuleSettingCaseSensitive("ForumConfig", value);
 			}
 		}
@@ -468,7 +437,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.AvatarHeight] = value.ToString();
 				UpdateModuleSettingCaseSensitive(SettingKeys.AvatarHeight, value.ToString());
 			}
 		}
@@ -481,7 +449,6 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				Settings[SettingKeys.AvatarWidth] = value.ToString();
 				UpdateModuleSettingCaseSensitive(SettingKeys.AvatarWidth, value.ToString());
 			}
 		}
@@ -494,7 +461,6 @@ namespace DotNetNuke.Modules.ActiveForums
             }
             set
             {
-                Settings[SettingKeys.UsersOnlineEnabled] = value;
                 UpdateModuleSettingCaseSensitive(SettingKeys.UsersOnlineEnabled, value.ToString());
             }
         }
@@ -507,7 +473,6 @@ namespace DotNetNuke.Modules.ActiveForums
             }
             set
             {
-                Settings[SettingKeys.UseSkinBreadCrumb] = value;
                 UpdateModuleSettingCaseSensitive(SettingKeys.UseSkinBreadCrumb, value.ToString());
             }
         }

--- a/components/Common/ForumSettingsBase.cs
+++ b/components/Common/ForumSettingsBase.cs
@@ -25,6 +25,37 @@ namespace DotNetNuke.Modules.ActiveForums
 	{
 		private readonly ModuleController _objModules = new ModuleController();
 
+		/// <summary>
+		/// This method is only needed because of an issue in DNN as of 8.0.4 where settings don't get updated if they are equal when compared case insensitively
+		/// </summary>
+		/// <param name="key"></param>
+		/// <param name="newValue"></param>
+        private void UpdateTabModuleSettingCaseSensitive(string key, string newValue)
+        {
+            var oldValue = Settings.GetString(key);
+            if (oldValue != newValue && oldValue.ToLowerInvariant() == newValue.ToLowerInvariant())
+            {
+				// changed but case-insensitive identical: empty the setting first
+                UpdateTabModuleSettingCaseSensitive(key, "");
+            }
+            UpdateTabModuleSettingCaseSensitive(key, newValue);
+        }
+		/// <summary>
+		/// This method is only needed because of an issue in DNN as of 8.0.4 where settings don't get updated if they are equal when compared case insensitively
+		/// </summary>
+		/// <param name="key"></param>
+		/// <param name="newValue"></param>
+        private void UpdateModuleSettingCaseSensitive(string key, string newValue)
+        {
+            var oldValue = Settings.GetString(key);
+            if (oldValue != newValue && oldValue.ToLowerInvariant() == newValue.ToLowerInvariant())
+            {
+				// changed but case-insensitive identical: empty the setting first
+                _objModules.UpdateModuleSetting(TabModuleId, key, "");
+            }
+            _objModules.UpdateModuleSetting(TabModuleId, key, newValue);
+        }
+
 		public string Mode
 		{
 			get
@@ -34,7 +65,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.Mode] = value;
-				_objModules.UpdateTabModuleSetting(TabModuleId, SettingKeys.Mode, value);
+				UpdateTabModuleSettingCaseSensitive(SettingKeys.Mode, value);
 			}
 		}
 
@@ -47,7 +78,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.Theme] = value;
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.Theme, value);
+				UpdateModuleSettingCaseSensitive(SettingKeys.Theme, value);
 			}
 		}
 
@@ -60,7 +91,7 @@ namespace DotNetNuke.Modules.ActiveForums
             set
             {
                 Settings[SettingKeys.TimeFormatString] = value;
-                _objModules.UpdateModuleSetting(ModuleId, SettingKeys.TimeFormatString, value);
+                UpdateModuleSettingCaseSensitive(SettingKeys.TimeFormatString, value);
             }
         }
 
@@ -73,7 +104,7 @@ namespace DotNetNuke.Modules.ActiveForums
             set
             {
                 Settings[SettingKeys.DateFormatString] = value;
-                _objModules.UpdateModuleSetting(ModuleId, SettingKeys.DateFormatString, value);
+                UpdateModuleSettingCaseSensitive(SettingKeys.DateFormatString, value);
             }
         }
 
@@ -86,7 +117,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.ForumTemplateId] = value;
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.ForumTemplateId, value.ToString());
+				UpdateModuleSettingCaseSensitive(SettingKeys.ForumTemplateId, value.ToString());
 			}
 		}
 
@@ -99,7 +130,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.PageSize] = value;
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.PageSize, value.ToString());
+				UpdateModuleSettingCaseSensitive(SettingKeys.PageSize, value.ToString());
 			}
 		}
 
@@ -112,7 +143,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.FloodInterval] = value;
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.FloodInterval, value.ToString());
+				UpdateModuleSettingCaseSensitive(SettingKeys.FloodInterval, value.ToString());
 			}
 		}
 
@@ -125,7 +156,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.EditInterval] = value;
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.EditInterval, value.ToString());
+				UpdateModuleSettingCaseSensitive(SettingKeys.EditInterval, value.ToString());
 			}
 		}
 
@@ -138,7 +169,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.EnableAutoLink] = value;
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.EnableAutoLink, value.ToString());
+				UpdateModuleSettingCaseSensitive(SettingKeys.EnableAutoLink, value.ToString());
 			}
 		}
 
@@ -151,7 +182,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.DeleteBehavior] = value;
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.DeleteBehavior, value.ToString());
+				UpdateModuleSettingCaseSensitive(SettingKeys.DeleteBehavior, value.ToString());
 			}
 		}
 
@@ -164,7 +195,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.AddThisAccount] = value;
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.AddThisAccount, value);
+				UpdateModuleSettingCaseSensitive(SettingKeys.AddThisAccount, value);
 			}
 		}
 
@@ -177,7 +208,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.ProfileVisibility] = value;
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.ProfileVisibility, value.ToString());
+				UpdateModuleSettingCaseSensitive(SettingKeys.ProfileVisibility, value.ToString());
 			}
 		}
 
@@ -190,7 +221,7 @@ namespace DotNetNuke.Modules.ActiveForums
             set
             {
                 Settings[SettingKeys.PMType] = value;
-                _objModules.UpdateModuleSetting(ModuleId, SettingKeys.PMType, value.ToString());
+                UpdateModuleSettingCaseSensitive(SettingKeys.PMType, value.ToString());
             }
         }
 
@@ -203,7 +234,7 @@ namespace DotNetNuke.Modules.ActiveForums
             set
             {
                 Settings[SettingKeys.PMTabId] = value;
-                _objModules.UpdateModuleSetting(ModuleId, SettingKeys.PMTabId, value.ToString());
+                UpdateModuleSettingCaseSensitive(SettingKeys.PMTabId, value.ToString());
             }
         }
 
@@ -216,7 +247,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.AllowSignatures] = value;
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.AllowSignatures, value.ToString());
+				UpdateModuleSettingCaseSensitive(SettingKeys.AllowSignatures, value.ToString());
 			}
 		}
 
@@ -229,7 +260,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.UserNameDisplay] = value;
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.UserNameDisplay, value);
+				UpdateModuleSettingCaseSensitive(SettingKeys.UserNameDisplay, value);
 			}
 		}
 
@@ -242,7 +273,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.EnableURLRewriter] = value;
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.EnableURLRewriter, value.ToString());
+				UpdateModuleSettingCaseSensitive(SettingKeys.EnableURLRewriter, value.ToString());
 			}
 		}
 
@@ -255,7 +286,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.PrefixURLBase] = value;
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.PrefixURLBase, value);
+				UpdateModuleSettingCaseSensitive(SettingKeys.PrefixURLBase, value);
 			}
 		}
 
@@ -268,7 +299,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.PrefixURLTags] = value;
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.PrefixURLTags, value);
+				UpdateModuleSettingCaseSensitive(SettingKeys.PrefixURLTags, value);
 			}
 		}
 
@@ -281,7 +312,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.PrefixURLCategories] = value;
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.PrefixURLCategories, value);
+				UpdateModuleSettingCaseSensitive(SettingKeys.PrefixURLCategories, value);
 			}
 		}
 
@@ -294,7 +325,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.PrefixURLOther] = value;
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.PrefixURLOther, value);
+				UpdateModuleSettingCaseSensitive(SettingKeys.PrefixURLOther, value);
 			}
 		}
 
@@ -307,7 +338,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.FullText] = value;
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.FullText, value.ToString());
+				UpdateModuleSettingCaseSensitive(SettingKeys.FullText, value.ToString());
 			}
 		}
 
@@ -320,7 +351,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.MailQueue] = value;
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.MailQueue, value.ToString());
+				UpdateModuleSettingCaseSensitive(SettingKeys.MailQueue, value.ToString());
 			}
 		}
 
@@ -333,7 +364,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.EnablePoints] = value;
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.EnablePoints, value.ToString());
+				UpdateModuleSettingCaseSensitive(SettingKeys.EnablePoints, value.ToString());
 			}
 		}
 
@@ -346,7 +377,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.TopicPointValue] = value;
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.TopicPointValue, value.ToString());
+				UpdateModuleSettingCaseSensitive(SettingKeys.TopicPointValue, value.ToString());
 			}
 		}
 
@@ -359,7 +390,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.ReplyPointValue] = value;
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.ReplyPointValue, value.ToString());
+				UpdateModuleSettingCaseSensitive(SettingKeys.ReplyPointValue, value.ToString());
 			}
 		}
 
@@ -372,7 +403,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.AnswerPointValue] = value;
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.AnswerPointValue, value.ToString());
+				UpdateModuleSettingCaseSensitive(SettingKeys.AnswerPointValue, value.ToString());
 			}
 		}
 
@@ -385,7 +416,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.MarkAnswerPointValue] = value;
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.MarkAnswerPointValue, value.ToString());
+				UpdateModuleSettingCaseSensitive(SettingKeys.MarkAnswerPointValue, value.ToString());
 			}
 		}
 
@@ -398,7 +429,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.ModPointValue] = value;
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.ModPointValue, value.ToString());
+				UpdateModuleSettingCaseSensitive(SettingKeys.ModPointValue, value.ToString());
 			}
 		}
 
@@ -412,7 +443,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			{
 				Settings["ForumGroupTemplate"] = value;
 				//Use Tab Module Setting
-				_objModules.UpdateTabModuleSetting(TabModuleId, "ForumGroupTemplate", value.ToString());
+				UpdateTabModuleSettingCaseSensitive("ForumGroupTemplate", value.ToString());
 			}
 		}
 
@@ -425,7 +456,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings["ForumConfig"] = value;
-				_objModules.UpdateTabModuleSetting(TabModuleId, "ForumConfig", value);
+				UpdateTabModuleSettingCaseSensitive("ForumConfig", value);
 			}
 		}
 
@@ -438,7 +469,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.AvatarHeight] = value.ToString();
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.AvatarHeight, value.ToString());
+				UpdateModuleSettingCaseSensitive(SettingKeys.AvatarHeight, value.ToString());
 			}
 		}
 
@@ -451,7 +482,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				Settings[SettingKeys.AvatarWidth] = value.ToString();
-				_objModules.UpdateModuleSetting(ModuleId, SettingKeys.AvatarWidth, value.ToString());
+				UpdateModuleSettingCaseSensitive(SettingKeys.AvatarWidth, value.ToString());
 			}
 		}
 
@@ -464,7 +495,7 @@ namespace DotNetNuke.Modules.ActiveForums
             set
             {
                 Settings[SettingKeys.UsersOnlineEnabled] = value;
-                _objModules.UpdateModuleSetting(ModuleId, SettingKeys.UsersOnlineEnabled, value.ToString());
+                UpdateModuleSettingCaseSensitive(SettingKeys.UsersOnlineEnabled, value.ToString());
             }
         }
 
@@ -477,7 +508,7 @@ namespace DotNetNuke.Modules.ActiveForums
             set
             {
                 Settings[SettingKeys.UseSkinBreadCrumb] = value;
-                _objModules.UpdateModuleSetting(ModuleId, SettingKeys.UseSkinBreadCrumb, value.ToString());
+                UpdateModuleSettingCaseSensitive(SettingKeys.UseSkinBreadCrumb, value.ToString());
             }
         }
 	}


### PR DESCRIPTION
### Description of PR...
This is a workaround for [this issue in DNN](https://github.com/dnnsoftware/Dnn.Platform/issues/3495) that prevents users from saving settings when the new value only changed the casing. It closes #31 

## Changes made
- Created helper functions for updating tabmodulesettings and modulesettings
- removed unnecessary updating of internal settings dictionary (since DNN empties the cache after updating a setting)

## PR Template Checklist

- [x ] Fixes Bug

## Please mark which issue is solved
Close #31 