### PR TITLE
fixes #45

### DIFF
--- a/App_LocalResources/SharedResources.nl-NL.resx
+++ b/App_LocalResources/SharedResources.nl-NL.resx
@@ -1490,7 +1490,7 @@ Van,
 		<value>Beeld</value>
 	</data>
 	<data name="AlertBody.Text" xml:space="preserve">
-		<value>&lt;b&gt; Reden: &lt;/b&gt; [Reden] &lt;br /&gt; &lt;b&gt; Opmerkingen: &lt;/b&gt; [Opmerking] &lt;hr noshade /&gt; [Post] &lt;br /&gt; &lt;br /&gt; &lt;a href = "[ URL] "target =" _ blank "&gt; [URL] &lt;/a&gt; &lt;br /&gt; &lt;br /&gt;</value>
+		<value>&lt;div&gt;&lt;b&gt; Reden: &lt;/b&gt; [Reason] &lt;br /&gt; &lt;b&gt; Opmerkingen: &lt;/b&gt; [Comment] &lt;hr noshade /&gt; [Post] &lt;br /&gt; &lt;br /&gt; &lt;a href = "[URL] "target =" _ blank "&gt; [URL] &lt;/a&gt; &lt;br /&gt; &lt;br /&gt;&lt;/div&gt;</value>
 	</data>
 	<data name="AlertSubject.Text" xml:space="preserve">
 		<value>Een bericht van [DisplayName] is gemarkeerd voor beoordeling door [FlaggedBy]</value>

--- a/App_LocalResources/SharedResources.resx
+++ b/App_LocalResources/SharedResources.resx
@@ -1466,7 +1466,7 @@ From,
     <value>Save</value>
   </data>
   <data name="AlertBody.Text" xml:space="preserve">
-    <value>&lt;b&gt;Reason:&lt;/b&gt; [Reason]&lt;br /&gt;&lt;b&gt;Comments:&lt;/b&gt; [Comment]&lt;hr noshade /&gt;[Post] &lt;br /&gt;&lt;br /&gt;&lt;a href="[URL]" target="_blank"&gt;[URL]&lt;/a&gt;&lt;br /&gt;&lt;br /&gt;</value>
+    <value>&lt;div&gt;&lt;b&gt;Reason:&lt;/b&gt; [Reason]&lt;br /&gt;&lt;b&gt;Comments:&lt;/b&gt; [Comment]&lt;hr noshade /&gt;[Post] &lt;br /&gt;&lt;br /&gt;&lt;a href="[URL]" target="_blank"&gt;[URL]&lt;/a&gt;&lt;br /&gt;&lt;br /&gt;&lt;/div&gt;</value>
   </data>
   <data name="AlertSubject.Text" xml:space="preserve">
     <value>A post by [DisplayName] has been flagged for review by [FlaggedBy]</value>


### PR DESCRIPTION
### Description of PR...
Fixes #45 

## Changes made
- added a wrapping div to SharedResources.resx & SharedResources.nl-NL.resx > <data name="AlertBody.Text" xml:space="preserve">
- In SharedResources.nl-NL.resx
Replaced auto translated tokens with thier original EN values, example: [Reden] > [Reason]

## PR Template Checklist

- [x] Fixes Bug
- [ ] Feature solution
- [ ] Other


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #45