### PR TITLE
Fix HTML Encode & Decode issues #73

### DIFF
--- a/CustomControls/UserControls/SubmitForm.cs
+++ b/CustomControls/UserControls/SubmitForm.cs
@@ -963,7 +963,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                         editor.ChooseRender = false;
                         editor.Mode = "RICH";
                         editor.Width = editorWidth;
-                        editor.HtmlEncode = false; // Turn thi soff to correctly load exising encoded HTML, but that will not save the HTML correctly.. :-(
+                        editor.HtmlEncode = false; // Turn Encoding off or passed already Encoded HTML will not be saved correctly.
                         editor.Height = editorHeight;
                         plhEditor.Controls.Add(editor);
                         _clientId = editor.ClientID;

--- a/CustomControls/UserControls/SubmitForm.cs
+++ b/CustomControls/UserControls/SubmitForm.cs
@@ -963,7 +963,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                         editor.ChooseRender = false;
                         editor.Mode = "RICH";
                         editor.Width = editorWidth;
-                        editor.HtmlEncode = false; // Turn Encoding off or passed already Encoded HTML will not be saved correctly.
+                        editor.HtmlEncode = false; // Turn Encoding off or passed already Encoded HTML.
                         editor.Height = editorHeight;
                         plhEditor.Controls.Add(editor);
                         _clientId = editor.ClientID;

--- a/CustomControls/UserControls/SubmitForm.cs
+++ b/CustomControls/UserControls/SubmitForm.cs
@@ -963,6 +963,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                         editor.ChooseRender = false;
                         editor.Mode = "RICH";
                         editor.Width = editorWidth;
+                        editor.HtmlEncode = false; // Turn thi soff to correctly load exising encoded HTML, but that will not save the HTML correctly.. :-(
                         editor.Height = editorHeight;
                         plhEditor.Controls.Add(editor);
                         _clientId = editor.ClientID;

--- a/class/Utilities.cs
+++ b/class/Utilities.cs
@@ -460,12 +460,13 @@ namespace DotNetNuke.Modules.ActiveForums
 
         public static string CleanString(int portalId, string text, bool allowHTML, EditorTypes editorType, bool useFilter, bool allowScript, int moduleId, string themePath, bool processEmoticons)
         {
-            var sClean = HttpContext.Current.Server.HtmlDecode(text);
+
+            var sClean = text;
+
+            // If HTML is not allowed or if this comes from the TextBox editor (quick reply), the HTML needs to be encoded.
             if (sClean != string.Empty)
             {
-                if (!allowHTML)
-                    sClean = HTMLEncode(sClean);
-
+                
                 sClean = editorType == EditorTypes.TEXTBOX ? CleanTextBox(portalId, sClean, allowHTML, useFilter, moduleId, themePath, processEmoticons) : CleanEditor(portalId, sClean, useFilter, moduleId, themePath, processEmoticons);
 
                 var regExp = new Regex(@"(<a [^>]*>)(?'url'(\S*?))(</a>)", RegexOptions.IgnoreCase);
@@ -497,7 +498,8 @@ namespace DotNetNuke.Modules.ActiveForums
 
         private static string CleanTextBox(int portalId, string text, bool allowHTML, bool useFilter, int moduleId, string themePath, bool processEmoticons)
         {
-            var strMessage = HTMLDecode(text);
+             
+            var strMessage = HTMLEncode(text);
 
             if (strMessage != string.Empty)
             {
@@ -550,7 +552,8 @@ namespace DotNetNuke.Modules.ActiveForums
 
         private static string CleanEditor(int portalId, string text, bool useFilter, int moduleId, string themePath, bool processEmoticons)
         {
-            var strMessage = HTMLDecode(text);
+
+            var strMessage = text;
 
             if ((strMessage.ToUpper().IndexOf("<CODE", StringComparison.Ordinal)) >= 0)
             {


### PR DESCRIPTION
This is the fix for HTML being decoded after posting.
It would be good to check the new code (for security) as I removed a few encodes and decodes

### Description of PR...

## Changes made
- The removed Decodes in class/Utilities.cs were not needed and they were preventing posting code example in the editor from being saved correctly
- CustomControls/UserControls/SubmitForm.cs > editor.HtmlEncode = false; 
Could now be set to false, because the unneeded Decodes above weer removed


## PR Template Checklist

- [x] Fixes Bug
- [ ] Feature solution
- [ ] Other


## Please mark which issue is solved
fixes #73 