### PR TITLE
Fix weird looking Preview pop-up #64

### DIFF
--- a/CustomControls/UserControls/SubmitForm.cs
+++ b/CustomControls/UserControls/SubmitForm.cs
@@ -963,7 +963,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                         editor.ChooseRender = false;
                         editor.Mode = "RICH";
                         editor.Width = editorWidth;
-                        editor.HtmlEncode = false; // Turn thi soff to correctly load exising encoded HTML, but that will not save the HTML correctly.. :-(
+                        editor.HtmlEncode = false; // Turn Encoding off or passed already Encoded HTML will not be saved correctly.
                         editor.Height = editorHeight;
                         plhEditor.Controls.Add(editor);
                         _clientId = editor.ClientID;

--- a/CustomControls/UserControls/SubmitForm.cs
+++ b/CustomControls/UserControls/SubmitForm.cs
@@ -963,7 +963,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                         editor.ChooseRender = false;
                         editor.Mode = "RICH";
                         editor.Width = editorWidth;
-                        editor.HtmlEncode = false; // Turn Encoding off or passed already Encoded HTML will not be saved correctly.
+                        editor.HtmlEncode = false; // Turn Encoding off or passed already Encoded HTML.
                         editor.Height = editorHeight;
                         plhEditor.Controls.Add(editor);
                         _clientId = editor.ClientID;

--- a/CustomControls/UserControls/SubmitForm.cs
+++ b/CustomControls/UserControls/SubmitForm.cs
@@ -963,6 +963,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                         editor.ChooseRender = false;
                         editor.Mode = "RICH";
                         editor.Width = editorWidth;
+                        editor.HtmlEncode = false; // Turn thi soff to correctly load exising encoded HTML, but that will not save the HTML correctly.. :-(
                         editor.Height = editorHeight;
                         plhEditor.Controls.Add(editor);
                         _clientId = editor.ClientID;

--- a/class/Utilities.cs
+++ b/class/Utilities.cs
@@ -460,12 +460,13 @@ namespace DotNetNuke.Modules.ActiveForums
 
         public static string CleanString(int portalId, string text, bool allowHTML, EditorTypes editorType, bool useFilter, bool allowScript, int moduleId, string themePath, bool processEmoticons)
         {
-            var sClean = HttpContext.Current.Server.HtmlDecode(text);
+
+            var sClean = text;
+
+            // If HTML is not allowed or if this comes from the TextBox editor (quick reply), the HTML needs to be encoded.
             if (sClean != string.Empty)
             {
-                if (!allowHTML)
-                    sClean = HTMLEncode(sClean);
-
+                
                 sClean = editorType == EditorTypes.TEXTBOX ? CleanTextBox(portalId, sClean, allowHTML, useFilter, moduleId, themePath, processEmoticons) : CleanEditor(portalId, sClean, useFilter, moduleId, themePath, processEmoticons);
 
                 var regExp = new Regex(@"(<a [^>]*>)(?'url'(\S*?))(</a>)", RegexOptions.IgnoreCase);
@@ -497,7 +498,8 @@ namespace DotNetNuke.Modules.ActiveForums
 
         private static string CleanTextBox(int portalId, string text, bool allowHTML, bool useFilter, int moduleId, string themePath, bool processEmoticons)
         {
-            var strMessage = HTMLDecode(text);
+             
+            var strMessage = HTMLEncode(text);
 
             if (strMessage != string.Empty)
             {
@@ -550,7 +552,8 @@ namespace DotNetNuke.Modules.ActiveForums
 
         private static string CleanEditor(int portalId, string text, bool useFilter, int moduleId, string themePath, bool processEmoticons)
         {
-            var strMessage = HTMLDecode(text);
+
+            var strMessage = text;
 
             if ((strMessage.ToUpper().IndexOf("<CODE", StringComparison.Ordinal)) >= 0)
             {

--- a/controls/af_post.ascx
+++ b/controls/af_post.ascx
@@ -130,7 +130,7 @@ function showLoading(button){
 	var pt = document.getElementById("divPreviewText");
 	var afPos = getPreviewPosition(out.parentNode);
 	pt.innerHTML = '';
-	out.style.height = '300px';
+	out.style.height = '302px';
 	out.style.width = out.parentNode.offsetWidth + 'px';
 	pt.style.overflow = 'auto';
 	pt.style.height = '280px';

--- a/themes/_default/module.css
+++ b/themes/_default/module.css
@@ -734,7 +734,6 @@ td.af-forumdetail a:link,td.af-forumdetail a:visited,td.af-subforumdetail a:link
 .afpreview {
 	border: solid 1px #666;
 	width: 90%;
-	position: absolute;
 	display: none;
 	background-color: #FFF;
 }
@@ -751,6 +750,10 @@ td.af-forumdetail a:link,td.af-forumdetail a:visited,td.af-subforumdetail a:link
 	font-size: 11px;
 }
 
+.afpreviewbar img{
+	
+	cursor: pointer;
+}		  
 .afpreviewtext {
 	width: 100%;
 	padding: 2px;


### PR DESCRIPTION
### The preview window looke weird and was positioned absolute which is not smart in the Responsive world..
## Changes made
- Removed position Absolute
- Made the height of the div a bit higher so the border at the bottom shows correctly
- Made sure the "close" icon shows the correct cursor (pointer).
Please note that some of these change are done in module.css in the theme folder meaning that you need to fix your custom theme too.


## PR Template Checklist

- [x] Fixes Bug
- [ ] Feature solution
- [ ] Other


## Please mark which issue is solved

Close #64