### PR TITLE
Use getAttribute('class') instead of className to support webpages with SVG elements

### DIFF
--- a/scripts/afadmin.js
+++ b/scripts/afadmin.js
@@ -367,14 +367,15 @@ amcp.Utils = {
         var retVal = new Array();
         var elements = document.getElementsByTagName("*");
         for (var i = 0; i < elements.length; i++) {
-            if (elements[i].className.indexOf(" ") >= 0) {
-                var classes = elements[i].className.split(" ");
+            var className = elements[i].getAttribute('class');
+            if (className && className.indexOf(" ") >= 0) {
+                var classes = className.split(" ");
                 for (var j = 0; j < classes.length; j++) {
                     if (classes[j] == clsName) {
                         retVal.push(elements[i]);
                     };
                 };
-            } else if (elements[i].className == clsName) {
+            } else if (className == clsName) {
                 retVal.push(elements[i]);
             };
         };


### PR DESCRIPTION
### Description of PR...

When there are SVG elements on a page an error is thrown because `elements[i].className` returns a [SVGAnimatedString](https://developer.mozilla.org/en-US/docs/Web/API/SVGAnimatedString). According to the [docs](https://developer.mozilla.org/en-US/docs/Web/API/Element/className#notes), it is better to use `getAttribute('class')` when handling SVG elements.


## Changes made
- Use `getAttribute('class')` instead of `className`


## PR Template Checklist

- [x] Fixes Bug
- [ ] Feature solution
- [ ] Other
