### PR TITLE
Fixed Flood support #fixes #79

### DIFF
--- a/class/UserProfile.cs
+++ b/class/UserProfile.cs
@@ -271,7 +271,13 @@ namespace DotNetNuke.Modules.ActiveForums
 		{
             DataProvider.Instance().Profiles_Save(ui.PortalId, ui.ModuleId, ui.UserID, ui.TopicCount, ui.ReplyCount, ui.ViewCount, ui.AnswerCount, ui.RewardPoints, ui.UserCaption, ui.Signature, ui.SignatureDisabled, ui.TrustLevel, ui.AdminWatch, ui.AttachDisabled, ui.Avatar, (int)ui.AvatarType, ui.AvatarDisabled, ui.PrefDefaultSort, ui.PrefDefaultShowReplies, ui.PrefJumpLastPost, ui.PrefTopicSubscribe, (int)ui.PrefSubscriptionType, ui.PrefUseAjax, ui.PrefBlockAvatars, ui.PrefBlockSignatures, ui.PrefPageSize, ui.Yahoo, ui.MSN, ui.ICQ, ui.AOL, ui.Occupation, ui.Location, ui.Interests, ui.WebSite, ui.Badges);
 			// KR - clear cache when updated
-			DataCache.CacheClearPrefix(string.Format("AF-prof-{0}", ui.UserID));
+			Profiles_ClearCache(ui.UserID);
+		}
+
+		public static void Profiles_ClearCache(int UserID)
+        {
+			DataCache.CacheClearPrefix(string.Format("AF-prof-{0}", UserID));
+
 		}
 
 	}

--- a/components/Replies/Replies.cs
+++ b/components/Replies/Replies.cs
@@ -204,6 +204,9 @@ namespace DotNetNuke.Modules.ActiveForums
 		}
 		public int Reply_Save(int PortalId, ReplyInfo ri)
 		{
+			// Clear profile Cache to make sure the LastPostDate is updated for Flood Control
+			UserProfileController.Profiles_ClearCache(ri.Content.AuthorId);
+
 			return Convert.ToInt32(DataProvider.Instance().Reply_Save(PortalId, ri.TopicId, ri.ReplyId, ri.ReplyToId, ri.StatusId, ri.IsApproved, ri.IsDeleted, ri.Content.Subject.Trim(), ri.Content.Body.Trim(), ri.Content.DateCreated, ri.Content.DateUpdated, ri.Content.AuthorId, ri.Content.AuthorName, ri.Content.IPAddress));
 		}
 		public ReplyInfo Reply_Get(int PortalId, int ModuleId, int TopicId, int ReplyId)

--- a/components/Topics/Topics.cs
+++ b/components/Topics/Topics.cs
@@ -193,7 +193,11 @@ namespace DotNetNuke.Modules.ActiveForums
         }
 		public int TopicSave(int PortalId, TopicInfo ti)
 		{
-            return Convert.ToInt32(DataProvider.Instance().Topics_Save(PortalId, ti.TopicId, ti.ViewCount, ti.ReplyCount, ti.IsLocked, ti.IsPinned, ti.TopicIcon, ti.StatusId, ti.IsApproved, ti.IsDeleted, ti.IsAnnounce, ti.IsArchived, ti.AnnounceStart, ti.AnnounceEnd, ti.Content.Subject.Trim(), ti.Content.Body.Trim(), ti.Content.Summary.Trim(), ti.Content.DateCreated, ti.Content.DateUpdated, ti.Content.AuthorId, ti.Content.AuthorName, ti.Content.IPAddress, (int)ti.TopicType, ti.Priority, ti.TopicUrl, ti.TopicData));
+			// Clear profile Cache to make sure the LastPostDate is updated for Flood Control
+			UserProfileController.Profiles_ClearCache(ti.Content.AuthorId);
+
+			return Convert.ToInt32(DataProvider.Instance().Topics_Save(PortalId, ti.TopicId, ti.ViewCount, ti.ReplyCount, ti.IsLocked, ti.IsPinned, ti.TopicIcon, ti.StatusId, ti.IsApproved, ti.IsDeleted, ti.IsAnnounce, ti.IsArchived, ti.AnnounceStart, ti.AnnounceEnd, ti.Content.Subject.Trim(), ti.Content.Body.Trim(), ti.Content.Summary.Trim(), ti.Content.DateCreated, ti.Content.DateUpdated, ti.Content.AuthorId, ti.Content.AuthorName, ti.Content.IPAddress, (int)ti.TopicType, ti.Priority, ti.TopicUrl, ti.TopicData));
+
 		}
 		public int Topics_SaveToForum(int ForumId, int TopicId, int PortalId, int ModuleId)
 		{


### PR DESCRIPTION
### Description of PR...
Fixed Flood support
Flood support is based on comparing the LastPostDate with the current date.
Although LastPostDate  is saved correctly after a post the cache for the UserProfile is not cleared.
So Flood support does not work unless you clear the DNN cache.

## Changes made
- Added a Profiles_ClearCache function. 
- Called that from the appropriate locations.


## PR Template Checklist

- [x] Fixes Bug
- [ ] Feature solution
- [ ] Other


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #79