### PR TITLE
Fixes #83

### DIFF
--- a/WhatsNew.ascx.cs
+++ b/WhatsNew.ascx.cs
@@ -135,7 +135,14 @@ namespace DotNetNuke.Modules.ActiveForums
                     var sGroupPrefixUrl = dr["GroupPrefixURL"].ToString();
 
                     var ts = DataCache.MainSettings(topicModuleId);
-                    var timeOffset = (int)UserInfo.Profile.PreferredTimeZone.GetUtcOffset(postDate).TotalMinutes;
+
+                    // The Module Stores the PostDate in the Current Time Zone format of the Server, not in UTC.
+                    // So we need to calculate the difference between the Site UTC Offset  and the Server UTC Offset and the and add that to the displayed time.
+
+                    var dtNow = DateTime.Now;
+                    var timeOffsetServer = (int)TimeZoneInfo.Local.GetUtcOffset(dtNow).TotalMinutes;
+                    var timeOffsetSite = (int)PortalSettings.TimeZone.GetUtcOffset(dtNow).TotalMinutes;
+                    var timeOffset = timeOffsetSite - timeOffsetServer;
 
                     // Use a stringBuilder for better performance;
                     var sbTemplate = new StringBuilder(Settings.Format ?? string.Empty);

--- a/WhatsNew.ascx.cs
+++ b/WhatsNew.ascx.cs
@@ -137,12 +137,14 @@ namespace DotNetNuke.Modules.ActiveForums
                     var ts = DataCache.MainSettings(topicModuleId);
 
                     // The Module Stores the PostDate in the Current Time Zone format of the Server, not in UTC.
-                    // So we need to calculate the difference between the Site UTC Offset  and the Server UTC Offset and the and add that to the displayed time.
+                    // So we need to calculate the difference between the Site UTC Offset  and the Server UTC Offset and Users UTC Offset and the Server offset and add that to the displayed time.
 
                     var dtNow = DateTime.Now;
                     var timeOffsetServer = (int)TimeZoneInfo.Local.GetUtcOffset(dtNow).TotalMinutes;
                     var timeOffsetSite = (int)PortalSettings.TimeZone.GetUtcOffset(dtNow).TotalMinutes;
-                    var timeOffset = timeOffsetSite - timeOffsetServer;
+                    var timeOffsetUser = (int)UserInfo.Profile.PreferredTimeZone.GetUtcOffset(postDate).TotalMinutes;
+
+                    var timeOffset = (timeOffsetSite - timeOffsetServer) + (timeOffsetUser- timeOffsetServer);
 
                     // Use a stringBuilder for better performance;
                     var sbTemplate = new StringBuilder(Settings.Format ?? string.Empty);


### PR DESCRIPTION
### Description of PR...
Currently the Whatsnew module tries to correct for the Timezone offset of the user.
But that leads to the issues in #83 
As the module stores the PostDate in the Server Time zone format and not UTC IMO the most important use case is that you have a site hosted in Timezone X and you set the to time zone of the portal to Y.
That was not considered in the initial solution at all.
Now we consider both site offset and user offset.

## PR Template Checklist

- [x] Fixes Bug
- [ ] Feature solution
- [ ] Other


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #83