### PR TITLE
Remove invalid CSS, fixes #103

### DIFF
--- a/module.css
+++ b/module.css
@@ -154,7 +154,6 @@ mark,
 .afgrid tr {
 width: 100%;
 position: relative;
-display: inline-table;
 }
 
 td.afgrouprow.afgrouprow-f {


### PR DESCRIPTION
### Description of PR...
Removed invalid CSS that made rendering equal width columns fail

## Changes made
changed:

```
.afgrid tr {
width: 100%;
position: relative;
display: inline-table;
}
```

to:

```
.afgrid tr {
width: 100%;
position: relative;
}

```



## PR Template Checklist

- [ ] Fixes Bug
- [ ] Feature solution
- [ ] Other


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #