### PR TITLE
Fix full text search switch in settings

### DIFF
--- a/ForumSettings.ascx.cs
+++ b/ForumSettings.ascx.cs
@@ -148,6 +148,10 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     Utilities.SelectListItemByValue(rdEnableURLRewriter, FriendlyURLs);
 
                     Utilities.SelectListItemByValue(rdFullTextSearch, FullTextSearch && FullTextStatus == 1); // 1 = Enabled Status
+				
+                    //rdFullTextSearch.SelectedIndex = FullTextSearch 
+                    //    ? rdFullTextSearch.Items.IndexOf(rdFullTextSearch.Items.FindByValue("True"))
+                    //    : rdFullTextSearch.Items.IndexOf(rdFullTextSearch.Items.FindByValue("False"));
 
                     Utilities.SelectListItemByValue(rdMailQueue, MailQueue);
                     Utilities.SelectListItemByValue(rdPoints, EnablePoints);

--- a/components/Common/ForumSettingsBase.cs
+++ b/components/Common/ForumSettingsBase.cs
@@ -318,7 +318,11 @@ namespace DotNetNuke.Modules.ActiveForums
 			set
 			{
 				UpdateModuleSettingCaseSensitive(SettingKeys.FullText, value.ToString());
-			}
+                if (Settings.ContainsKey(SettingKeys.FullText))
+                    Settings[SettingKeys.FullText] = value.ToString();
+                else
+                    Settings.Add(SettingKeys.FullText, value.ToString());
+            }
 		}
 
 		public bool MailQueue


### PR DESCRIPTION
Closes #111

This PR fixes the working of the Full Text switch in the settings of the module.

Cause of the issue was that the new value was read from the control, but actually enabling/disabling full text search in the DB was done based on the old value of the setting.

Close #111 