### PR TITLE
Enable HTML editor by default when enabling HTML; make HTML installation default

### DIFF
--- a/class/ForumGroups.cs
+++ b/class/ForumGroups.cs
@@ -202,9 +202,9 @@ namespace DotNetNuke.Modules.ActiveForums
 			get
 			{
 				EditorTypes parseValue;
-				var val = Enum.TryParse(Utilities.SafeConvertString(GroupSettings[ForumSettingKeys.EditorType], "0"), true, out parseValue)
+				var val = Enum.TryParse(Utilities.SafeConvertString(GroupSettings[ForumSettingKeys.EditorType], EditorTypes.HTMLEDITORPROVIDER.ToString()), true, out parseValue)
 						   ? parseValue
-						   : EditorTypes.TEXTBOX;
+						   : EditorTypes.HTMLEDITORPROVIDER;
 
 				return val;
 				
@@ -221,9 +221,9 @@ namespace DotNetNuke.Modules.ActiveForums
             get
             {
                 EditorTypes parseValue;
-                var val = Enum.TryParse(Utilities.SafeConvertString(GroupSettings[ForumSettingKeys.EditorMobile], "0"), true, out parseValue)
+                var val = Enum.TryParse(Utilities.SafeConvertString(GroupSettings[ForumSettingKeys.EditorMobile], EditorTypes.HTMLEDITORPROVIDER.ToString()), true, out parseValue)
                            ? parseValue
-                           : EditorTypes.TEXTBOX;
+                           : EditorTypes.HTMLEDITORPROVIDER;
 
                 return val;
 

--- a/class/ForumInfo.cs
+++ b/class/ForumInfo.cs
@@ -247,10 +247,16 @@ namespace DotNetNuke.Modules.ActiveForums
 			get { return Utilities.SafeConvertInt(ForumSettings[ForumSettingKeys.EditorStyle], 1); }
 		}
 
-        public int EditorMobile
+        public EditorTypes EditorMobile
         {
-            get { return Utilities.SafeConvertInt(ForumSettings[ForumSettingKeys.EditorMobile], 0); }
-        }
+            get
+			{
+				EditorTypes parseValue;
+				return Enum.TryParse(Utilities.SafeConvertString(ForumSettings[ForumSettingKeys.EditorMobile], EditorTypes.HTMLEDITORPROVIDER.ToString()), true, out parseValue)
+						   ? parseValue
+						   : EditorTypes.HTMLEDITORPROVIDER;
+			}
+		}
 
 		public string EditorToolBar
 		{
@@ -262,9 +268,9 @@ namespace DotNetNuke.Modules.ActiveForums
 			get
 			{
 				EditorTypes parseValue;
-				return Enum.TryParse(Utilities.SafeConvertString(ForumSettings[ForumSettingKeys.EditorType], "0"), true, out parseValue)
+				return Enum.TryParse(Utilities.SafeConvertString(ForumSettings[ForumSettingKeys.EditorType], EditorTypes.HTMLEDITORPROVIDER.ToString()), true, out parseValue)
 						   ? parseValue
-						   : EditorTypes.TEXTBOX;
+						   : EditorTypes.HTMLEDITORPROVIDER;
 			}
 		}
 

--- a/class/ForumsConfig.cs
+++ b/class/ForumsConfig.cs
@@ -222,7 +222,17 @@ namespace DotNetNuke.Modules.ActiveForums
                         Settings.SaveSetting(ModuleId, sKey, ForumSettingKeys.AttachInsertAllowed, "false");
                         Settings.SaveSetting(ModuleId, sKey, ForumSettingKeys.ConvertingToJpegAllowed, "false");
 						Settings.SaveSetting(ModuleId, sKey, ForumSettingKeys.AllowHTML, sAllowHTML);
-						Settings.SaveSetting(ModuleId, sKey, ForumSettingKeys.EditorType, "0");
+						if (sAllowHTML.ToLowerInvariant() == "true")
+						{
+							Settings.SaveSetting(ModuleId, sKey, ForumSettingKeys.EditorType, ((int)EditorTypes.HTMLEDITORPROVIDER).ToString());
+							Settings.SaveSetting(ModuleId, sKey, ForumSettingKeys.EditorMobile, ((int)EditorTypes.HTMLEDITORPROVIDER).ToString());
+						}
+                        else
+						{
+							Settings.SaveSetting(ModuleId, sKey, ForumSettingKeys.EditorType, ((int)EditorTypes.TEXTBOX).ToString());
+							Settings.SaveSetting(ModuleId, sKey, ForumSettingKeys.EditorMobile, ((int)EditorTypes.TEXTBOX).ToString());
+						}
+
 						Settings.SaveSetting(ModuleId, sKey, ForumSettingKeys.EditorHeight, "350");
 						Settings.SaveSetting(ModuleId, sKey, ForumSettingKeys.EditorWidth, "99%");
 						Settings.SaveSetting(ModuleId, sKey, ForumSettingKeys.EditorToolbar, "bold,italic,underline,quote");

--- a/config/defaultsetup.config
+++ b/config/defaultsetup.config
@@ -70,7 +70,7 @@
   </ranks>
   <defaultforums>
     <groups>
-      <group groupid="-1" groupname="Default Group" active="1" hidden="0" sortorder="0">
+      <group groupid="-1" groupname="Default Group" active="1" hidden="0" sortorder="0" allowhtml="true">
         <forum forumid="-1" forumname="Sample Forum 1" forumdesc="Welcome to Active Forums!" active="1" hidden="0" sortorder="0" />
         <forum forumid="-1" forumname="Sample Forum 2" forumdesc="" active="1" hidden="0" sortorder="1" />
         <forum forumid="-1" forumname="Sample Forum 3" forumdesc="" active="1" hidden="0" sortorder="2" />

--- a/controls/admin_manageforums_forumeditor.ascx
+++ b/controls/admin_manageforums_forumeditor.ascx
@@ -185,9 +185,11 @@ function saveSettings(gs){
 		var ed1 = document.getElementById("<%=drpEditorTypes.ClientID%>");
         if (ed1.selectedIndex >= 0) {
             var EditorType = ed1.options[ed1.selectedIndex].value;
+        } else if (AllowHtml==true) {
+            var EditorType = 2;/* default to HTML editor */
         } else {
-            var EditorType = 0;
-        };
+			var EditorType = 0;
+		};
 		var EditorHeight = document.getElementById("<%=txtEditorHeight.ClientID%>").value;
 		var EditorWidth = document.getElementById("<%=txtEditorWidth.ClientID%>").value;
 		var ed6 = document.getElementById("<%=drpPermittedRoles.ClientID%>");
@@ -199,8 +201,10 @@ function saveSettings(gs){
 	    var edm = document.getElementById("<%=drpEditorMobile.ClientID%>");
         if (edm.selectedIndex >= 0) {
             var EditorMobile = edm.options[edm.selectedIndex].value;
-        } else {
-            var EditorMobile = 0;
+        } else if (AllowHtml == true) {
+            var EditorMobile = 2;/* default to HTML editor */
+         } else {
+			var EditorMobile = 0;
         };
 		
 		var IsModerated = document.getElementById("<%=rdModOn.ClientID%>").checked;
@@ -258,18 +262,13 @@ function saveSettings(gs){
 
 
 	<%=cbEditorAction.ClientID%>.Callback(settingsAction, forumid, TopicsTemplateId, TopicTemplateId, EmailAddress, UseFilter, AllowPostIcon, AllowEmoticons, AllowScripts,
-        IndexContent, AllowRSS, AllowAttach, AttachCount, AttachMaxSize, AttachTypeAllowed, EditorMobile, AllowLikes, ReplyPostCount, AttachAllowBrowseSite, AttachInsertAllowed, MaxAttachWidth,
-        MaxAttachHeight, AttachConvertToJGPAllowed, AllowHtml, EditorType, EditorHeight, EditorWidth, CreatePostCount, AutoSubscribeNewTopicsOnly, EditorPermittedRoles, TopicFormId, ReplyFormId,
-        AutoSubscribeRoles, ProfileTemplateId, IsModerated, DefaultTrustLevel, AutoTrustLevel, ModApproveTemplateId, ModRejectTemplateId, ModMoveTemplateId, ModDeleteTemplateId,
-        ModNotifyTemplateId, AutoSubscribeEnabled);
+		IndexContent, AllowRSS, AllowAttach, AttachCount, AttachMaxSize, AttachTypeAllowed, EditorMobile, AllowLikes, ReplyPostCount, AttachAllowBrowseSite, AttachInsertAllowed, MaxAttachWidth,
+		MaxAttachHeight, AttachConvertToJGPAllowed, AllowHtml, EditorType, EditorHeight, EditorWidth, CreatePostCount, AutoSubscribeNewTopicsOnly, EditorPermittedRoles, TopicFormId, ReplyFormId,
+		AutoSubscribeRoles, ProfileTemplateId, IsModerated, DefaultTrustLevel, AutoTrustLevel, ModApproveTemplateId, ModRejectTemplateId, ModMoveTemplateId, ModDeleteTemplateId,
+		ModNotifyTemplateId, AutoSubscribeEnabled);
 
 
 };
-
-
-
-
-
 function toggleEditor(obj){
 	closeAllProp();
 	var editor = document.getElementById("<%=cfgHTML.ClientID%>");
@@ -281,10 +280,10 @@ function toggleEditor(obj){
 		winDiv.style.display = 'none';
 	};
 };
-function toggleEditorFields(){
+<%--function toggleEditorFields(){
 	var ed1 = document.getElementById("<%=drpEditorTypes.ClientID%>");
 	if (ed1.selectedIndex >= 0){ed1 = ed1.options[ed1.selectedIndex].value;}else{ed1 = 0;};
-};
+};--%>
 function toggleMod(obj){
 	closeAllProp();
 	var mod = document.getElementById("<%=cfgMod.ClientID%>");
@@ -1086,9 +1085,9 @@ function afadmin_getProperties() {
 							<img id="Img8" src="~/DesktopModules/ActiveForums/images/tooltip.png" runat="server" onmouseover="amShowTip(this, '[RESX:Tips:AllowHTML]');" onmouseout="amHideTip(this);" /></td>
 						<td class="amcpbold" style="white-space: nowrap">[RESX:AllowHTML]:</td>
 						<td align="center">
-							<asp:RadioButton ID="rdHTMLOn" GroupName="HTML" runat="server" /></td>
+							<asp:RadioButton ID="rdHTMLOn" GroupName="HTML" runat="server" Checked="true" /></td>
 						<td align="center">
-							<asp:RadioButton ID="rdHTMLOff" GroupName="HTML" runat="server" Checked="true" /></td>
+							<asp:RadioButton ID="rdHTMLOff" GroupName="HTML" runat="server" /></td>
 						<td width="100%">
 							<div id="cfgHTML" runat="server" class="amcfgbtn" style="display: none;"></div>
 						</td>
@@ -1258,9 +1257,9 @@ function afadmin_getProperties() {
 				<td></td>
 				<td class="amcpbold" style="white-space: nowrap">[RESX:EditorType]:</td>
 				<td>
-					<asp:DropDownList ID="drpEditorTypes" runat="server" CssClass="amcptxtbx">
+					<asp:DropDownList ID="drpEditorTypes" runat="server" CssClass="amcptxtbx" >
 						<asp:ListItem Value="0">TextBox</asp:ListItem>
-						<asp:ListItem Value="2">Default DNN Editor</asp:ListItem>
+						<asp:ListItem Selected="True" Value="2">Default DNN Editor</asp:ListItem>
 					</asp:DropDownList>
 				</td>
 				<td></td>
@@ -1285,7 +1284,7 @@ function afadmin_getProperties() {
 				<td>
 					<asp:DropDownList ID="drpEditorMobile" runat="server" CssClass="amcptxtbx">
 						<asp:ListItem Value="0">TextBox</asp:ListItem>
-						<asp:ListItem Value="2">Default DNN Editor</asp:ListItem>
+						<asp:ListItem Value="2" Selected="True">Default DNN Editor</asp:ListItem>
 					</asp:DropDownList>
 				</td>
 				<td></td>

--- a/controls/admin_manageforums_forumeditor.ascx.cs
+++ b/controls/admin_manageforums_forumeditor.ascx.cs
@@ -97,8 +97,8 @@ namespace DotNetNuke.Modules.ActiveForums
             rdAttachOff.Attributes.Add("value", "0");
             cfgAttach.InnerHtml = propImage;
 
-            rdHTMLOn.Attributes.Add("onclick", "toggleEditor(this);");
-            rdHTMLOff.Attributes.Add("onclick", "toggleEditor(this);");
+            rdHTMLOn.Attributes.Add("onclick", "toggleEditor(this);document.getElementById('" + drpEditorTypes.ClientID + "').value = '2';document.getElementById('" + drpEditorMobile.ClientID + "').value ='2';");
+            rdHTMLOff.Attributes.Add("onclick", "toggleEditor(this); document.getElementById('" + drpEditorTypes.ClientID + "').value = '0'; document.getElementById('" + drpEditorMobile.ClientID + "').value = '0'; ");
             rdHTMLOn.Attributes.Add("value", "1");
             rdHTMLOff.Attributes.Add("value", "0");
             cfgHTML.Attributes.Add("style", "display:none;");
@@ -126,8 +126,8 @@ namespace DotNetNuke.Modules.ActiveForums
             else
                 lblMaintWarn.Text = string.Format(GetSharedResource("[RESX:MaintenanceWarning]"), GetSharedResource("[RESX:MaintenanceWarning:Remove]"), GetSharedResource("[RESX:MaintenanceWarning:Remove:Desc]"));
 
-            drpEditorTypes.Attributes.Add("onchange", "toggleEditorFields();");
-            
+            //drpEditorTypes.Attributes.Add("onchange", "toggleEditorFields();");
+
             if (cbEditorAction.IsCallback) 
                 return;
             
@@ -475,7 +475,7 @@ namespace DotNetNuke.Modules.ActiveForums
             Utilities.SelectListItemByValue(drpModNotifyTemplateId, fi.ModNotifyTemplateId);
             Utilities.SelectListItemByValue(drpDefaultTrust, (int)fi.DefaultTrustValue);
             Utilities.SelectListItemByValue(drpEditorTypes, (int)fi.EditorType);
-            Utilities.SelectListItemByValue(drpEditorMobile, fi.EditorMobile);
+            Utilities.SelectListItemByValue(drpEditorMobile, (int)fi.EditorMobile);
             Utilities.SelectListItemByValue(drpPermittedRoles, (int)fi.EditorPermittedUsers);
 
             txtAutoTrustLevel.Text = fi.AutoTrustLevel.ToString();
@@ -517,6 +517,18 @@ namespace DotNetNuke.Modules.ActiveForums
             txtMaxAttachHeight.Text = fi.MaxAttachHeight.ToString();
             ckAttachInsertAllowed.Checked = fi.AttachInsertAllowed;
             ckConvertingToJpegAllowed.Checked = fi.ConvertingToJpegAllowed;
+
+            // if switching from HTML off to HTML on, switch editor to HTML editor, or vice versa
+            if (rdHTMLOff.Checked && fi.AllowHTML)
+            {
+                Utilities.SelectListItemByValue(drpEditorTypes, (int)EditorTypes.HTMLEDITORPROVIDER);
+                Utilities.SelectListItemByValue(drpEditorMobile, (int)EditorTypes.HTMLEDITORPROVIDER);
+            }
+            if (rdHTMLOn.Checked && !fi.AllowHTML)
+            {
+                Utilities.SelectListItemByValue(drpEditorTypes, (int)EditorTypes.TEXTBOX);
+                Utilities.SelectListItemByValue(drpEditorMobile, (int)EditorTypes.TEXTBOX);
+            }
 
             rdHTMLOn.Checked = fi.AllowHTML;
             rdHTMLOff.Checked = !fi.AllowHTML;
@@ -638,7 +650,18 @@ namespace DotNetNuke.Modules.ActiveForums
             txtMaxAttachHeight.Text = gi.MaxAttachHeight.ToString();
             ckAttachInsertAllowed.Checked = gi.AttachInsertAllowed;
             ckConvertingToJpegAllowed.Checked = gi.ConvertingToJpegAllowed;
-
+            
+            // if switching from HTML off to HTML on, switch editor to HTML editor, or vice versa
+            if (rdHTMLOff.Checked && gi.AllowHTML)
+            {
+                Utilities.SelectListItemByValue(drpEditorTypes, (int)EditorTypes.HTMLEDITORPROVIDER);
+                Utilities.SelectListItemByValue(drpEditorMobile, (int)EditorTypes.HTMLEDITORPROVIDER);
+            }
+            if (rdHTMLOn.Checked && !gi.AllowHTML)
+            {
+                Utilities.SelectListItemByValue(drpEditorTypes, (int)EditorTypes.TEXTBOX);
+                Utilities.SelectListItemByValue(drpEditorMobile, (int)EditorTypes.TEXTBOX);
+            }
             rdHTMLOn.Checked = gi.AllowHTML;
             rdHTMLOff.Checked = !gi.AllowHTML;
 


### PR DESCRIPTION


### Enable HTML editor by default when enabling HTML; make HTML installation default

## Changes made
- Enable HTML editor as the default editor when enabling HTMLd
- make HTML default for a new installation


## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #108