### PR TITLE
Fix for iPad issue, img overlapping forum index links #134

### DIFF
--- a/module.css
+++ b/module.css
@@ -377,7 +377,7 @@ color: #333;
 word-break: break-word;}
 td.af-title{width:100%;padding-left:25px;}
 td.af-groupname{padding-left:10px;width:100%;}
-td.af-groupcollapse{text-align:right;padding-right:10px;}
+td.af-groupcollapse{text-align:right; padding-right:10px; position:relative;}
 td.af-right{text-align:right;}
 td.af-posticon{
     width:30px;


### PR DESCRIPTION


Made sure the parent of the collapse image with position absolute gets position:relative, to avoid the image from growing too large


## PR Template Checklist

- [x] Fixes Bug
- [ ] Feature solution
- [ ] Other


## Please mark which issue is solved
Fixes #134 
Close #134