### PR TITLE
Task/build error issues

### DIFF
--- a/ActiveForums.csproj
+++ b/ActiveForums.csproj
@@ -729,6 +729,8 @@
     <Compile Include="class\ParamBuilder.cs" />
     <Compile Include="class\StringExtensions.cs" />
     <Compile Include="class\WhatsNewModuleSettings.cs" />
+    <Compile Include="components\Topics\TopicInfo.cs" />
+    <Compile Include="components\Topics\TopicsController.cs" />
     <Compile Include="Constants\SEOConstants.cs" />
     <Compile Include="controls\af_topicscripts.ascx.cs">
       <DependentUpon>af_topicscripts.ascx</DependentUpon>

--- a/ActiveForums.csproj
+++ b/ActiveForums.csproj
@@ -822,7 +822,6 @@
     <Compile Include="components\Social\ActiveSocial.cs" />
     <Compile Include="components\Tokens\Token.cs" />
     <Compile Include="components\Tokens\TokensController.cs" />
-    <Compile Include="components\Topics\Topics.cs" />
     <Compile Include="components\Users\User.cs" />
     <Compile Include="components\Users\UserController.cs" />
     <Compile Include="controls\admin_properties.ascx.designer.cs">


### PR DESCRIPTION
This PR resolves a build issue that doesn't allow Visual Studio to build.  

### Description of PR...

## Changes made
- Removes a reference to the since-deleted `Topics.cs` class file.  
- Adds missing references to the newer topic classes, `TopicInfo.cs` and `TopicsController.cs`.  

CC:  @johnhenley @Timo-Breumelhof 