### PR TITLE
SqlProvider files are getting installed to /sql/sql/ rather than /sql/

### DIFF
--- a/ActiveForums.dnn
+++ b/ActiveForums.dnn
@@ -102,7 +102,7 @@
 		
         <component type="Script">
            <scripts>
-            <basePath>DesktopModules\ActiveForums\sql</basePath>
+            <basePath>DesktopModules\ActiveForums</basePath>
             <script type="Install">
              <path>sql</path>
               <name>04.00.00.SqlDataProvider</name>


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
SqlProvider files are getting installed to /sql/sql/ rather than /sql/

## Changes made
- update manifest


## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #181