### PR TITLE
Fix displayed name for "anonymous" users 

### DIFF
--- a/CustomControls/UserControls/TopicsView.cs
+++ b/CustomControls/UserControls/TopicsView.cs
@@ -974,9 +974,9 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     sTopicsTemplate = sTopicsTemplate.Replace("[SUBJECTLINK]", GetTopic(ModuleId, TabId, ForumId, TopicId, Subject, sBodyTitle, UserId, AuthorId, ReplyCount, -1, sTopicURL) + sPollImage);
 
                     var displayName = UserProfiles.GetDisplayName(ModuleId, true, bModApprove, ForumUser.IsAdmin || ForumUser.IsSuperUser, AuthorId, AuthorUserName, AuthorFirstName, AuthorLastName, AuthorDisplayName).ToString().Replace("&amp;#", "&#");
-                    if (displayName == "Anonymous")
+                    if (Utilities.StripHTMLTag(displayName) == "Anonymous")
                     {
-                        displayName = AuthorDisplayName;
+                        displayName = displayName.Replace("Anonymous", AuthorName);
                     }
                     sTopicsTemplate = sTopicsTemplate.Replace("[STARTEDBY]", displayName);
                     sTopicsTemplate = sTopicsTemplate.Replace("[DATECREATED]", Utilities.GetUserFormattedDateTime(DateCreated,PortalId,UserId));


### PR DESCRIPTION

<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
When using Forums module setting "Member name display format" = "Display name", and topic or reply is from an "anonymous" poster, topics view is displaying 'Anonymous' rather than the displayname entered by the anonymous poster.

## Changes made
-  An HTML tag was wrapped around the "Anonymous" string, causing the IF statement to ignore "Anonymous" users
- ,Source of variable substitution was from the Users table, rather than from the "Anonymous" user's entered name, which is stamped into the activeforums_Content table.

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #204