### PR TITLE
Fix order of "What's new" module w/ topics only

### DIFF
--- a/ActiveForums.csproj
+++ b/ActiveForums.csproj
@@ -640,6 +640,7 @@
     <None Include="sql\06.03.03.SqlDataProvider" />
     <None Include="sql\06.04.01.SqlDataProvider" />
     <None Include="sql\07.00.00.SqlDataProvider" />
+    <None Include="sql\07.00.06.SqlProvider" />
     <None Include="sql\Enterprise.sql" />
     <Content Include="config\templates\ModAlert_text.txt" />
     <Content Include="config\templates\ModEmail_text.txt" />

--- a/ActiveForums.dnn
+++ b/ActiveForums.dnn
@@ -1,6 +1,6 @@
 ﻿<dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="Active Forums" type="Module" version="07.00.01">
+    <package name="Active Forums" type="Module" version="07.00.06">
       <friendlyName>Active Forums</friendlyName>
       <description>Community Forums: The official online forums module for the DNN Community.</description>
       <iconFile>DesktopModules/ActiveForums/images/af6_icon.jpg</iconFile>
@@ -83,7 +83,7 @@
             <assembly>
               <name>DotNetNuke.Modules.ActiveForums.dll</name>
               <sourceFileName>bin\DotNetNuke.Modules.ActiveForums.dll</sourceFileName>
-              <version>07.00.01</version>
+              <version>07.00.06</version>
             </assembly>
           </assemblies>
         </component>
@@ -333,10 +333,15 @@
                <name>07.00.00.SqlDataProvider</name>
                <version>07.00.00</version>
              </script>
-            <script type="UnInstall">
+			<script type="Install">
+				<path>sql</path>
+				<name>07.00.06.SqlDataProvider</name>
+				<version>07.00.06</version>
+			</script>
+			   <script type="UnInstall">
               <path>sql</path>
               <name>Uninstall.SqlDataProvider</name>
-              <version>07.00.01</version>
+              <version>07.00.06</version>
             </script>
           </scripts>
         </component>
@@ -371,7 +376,7 @@
       </components>
     </package>
 	
-    <package name="Active Forums What's New" type="Module" version="07.00.01">
+    <package name="Active Forums What's New" type="Module" version="07.00.06">
       <friendlyName>Active Forums What's New</friendlyName>
       <foldername>ActiveForumsWhatsNew</foldername>
       <description>Community Forums: Display the most recent topics or replies from selected forums on any page within your site.</description>

--- a/ActiveForums_Symbols.dnn
+++ b/ActiveForums_Symbols.dnn
@@ -1,6 +1,6 @@
 ﻿<dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="Active Forums_Symbols" type="Library" version="07.00.01">
+    <package name="Active Forums_Symbols" type="Library" version="07.00.06">
       <friendlyName>Active Forums Symbols</friendlyName>
       <description>Community Forums: The official online forums module for the DNN Community.</description>
       <iconFile>DesktopModules/ActiveForums/images/af6_icon.jpg</iconFile>
@@ -14,7 +14,7 @@
       <releaseNotes src="ReleaseNotes.txt" />
       <azureCompatible>True</azureCompatible>
       <dependencies>
-        <dependency type="managedPackage" version="7.0.1">Active Forums</dependency>
+        <dependency type="managedPackage" version="7.0.6">Active Forums</dependency>
       </dependencies>
       <components>
         <component type="ResourceFile">

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -52,9 +52,9 @@ using System.Security;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 
-[assembly: AssemblyVersion("07.00.01")]
+[assembly: AssemblyVersion("07.00.06")]
 
-[assembly: AssemblyFileVersion("07.00.01")]
+[assembly: AssemblyFileVersion("07.00.06")]
 [assembly: WebResource("DotNetNuke.Modules.ActiveForums.CustomControls.Resources.cb.js", "text/javascript")]
 [assembly: WebResource("DotNetNuke.Modules.ActiveForums.scripts.afadmin.properties.js", "text/javascript")]
 

--- a/sql/07.00.06.SqlProvider
+++ b/sql/07.00.06.SqlProvider
@@ -1,0 +1,114 @@
+﻿/* issue 205 - begin - what's new view with non-random option and topics only should be sorted to show most recent based on create/reply date rather than just original create date */
+IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_TP_GetPosts]') AND type in (N'P', N'PC'))
+DROP PROCEDURE {databaseOwner}[{objectQualifier}activeforums_TP_GetPosts]
+GO
+
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}activeforums_TP_GetPosts]
+@PortalId int,
+@Forums nvarchar(1000),
+@TopicsOnly bit,
+@RandomOrder bit,
+@Rows int,
+@IgnoreSecurity bit = 0,
+@Tags nvarchar(400),
+@FilterByUserId int = -1
+AS
+--SET ROWCOUNT @Rows
+IF @RandomOrder = 1 AND @TopicsOnly = 1
+	BEGIN
+		SELECT * FROM (
+		SELECT	g.GroupName, g.ForumGroupId, M.TabId, M.ModuleId, T.ForumName, T.ForumId, T.[Subject],
+				T.AuthorId, T.AuthorUserName, T.AuthorFirstName, T.AuthorLastName, T.AuthorDisplayName, T.DateCreated,
+				T.Body, T.ReplyCount, T.TopicId, "ReplyId" = 0,ROW_NUMBER() OVER (ORDER BY NewID()) as RowRank,
+				ISNULL(URL,'') as  TopicURL,
+				ISNULL(af.PrefixURL,'') as PrefixURL,
+				ISNULL(g.PrefixURL,'') as GroupPrefixURL
+		FROM {databaseOwner}{objectQualifier}vw_activeforums_TopicsView as T 
+			INNER JOIN {databaseOwner}{objectQualifier}activeforums_Functions_Split(@Forums,':') as F on t.ForumId = F.ID 			
+			INNER JOIN {databaseOwner}{objectQualifier}TabModules as M ON T.ModuleId = M.ModuleId
+			INNER JOIN {databaseOwner}{objectQualifier}activeforums_Forums as af ON T.ForumId = af.ForumId
+			INNER JOIN {databaseOwner}{objectQualifier}activeforums_Groups as g on af.ForumGroupId = g.ForumGroupId
+		WHERE @Tags = '' OR (@Tags <> '' AND T.TopicId IN (
+													SELECT tt.TopicId FROM {databaseOwner}{objectQualifier}activeforums_Tags as tag
+													 INNER JOIN {databaseOwner}{objectQualifier}activeforums_Topics_Tags as TT ON tag.TagId = tt.TagId 
+													WHERE     tag.TagName = @Tags AND tag.Moduleid = t.ModuleId))
+		) as posts WHERE RowRank <=@Rows
+	END
+IF @RandomOrder = 0 AND @TopicsOnly = 1
+	BEGIN
+		SELECT * FROM (
+		SELECT	g.GroupName, g.ForumGroupId, M.TabId, M.ModuleId, T.ForumName, T.ForumId, T.[Subject],
+				T.AuthorId, T.AuthorUserName, T.AuthorFirstName, T.AuthorLastName, T.AuthorDisplayName, T.DateCreated,
+				T.Body, T.ReplyCount, T.TopicId, "ReplyId" = 0,ROW_NUMBER() OVER (ORDER BY T.LastReplyDate DESC) as RowRank,
+				ISNULL(URL,'') as  TopicURL,
+				ISNULL(af.PrefixURL,'') as PrefixURL,
+				ISNULL(g.PrefixURL,'') as GroupPrefixURL
+				
+		FROM {databaseOwner}{objectQualifier}vw_activeforums_TopicsView as T 
+			INNER JOIN {databaseOwner}{objectQualifier}activeforums_Functions_Split(@Forums,':') as F on t.ForumId = F.ID 			
+			INNER JOIN {databaseOwner}{objectQualifier}TabModules as M ON T.ModuleId = M.ModuleId
+			INNER JOIN {databaseOwner}{objectQualifier}activeforums_Forums as af ON f.ID = af.ForumId
+			INNER JOIN {databaseOwner}{objectQualifier}activeforums_Groups as g on af.ForumGroupId = g.ForumGroupId
+		WHERE (@FilterByUserId = -1 OR T.AuthorId = @FilterByUserId)
+		AND (@Tags = '' OR (@Tags <> '' AND T.TopicId IN (
+													SELECT tt.TopicId FROM {databaseOwner}{objectQualifier}activeforums_Tags as tag
+													 INNER JOIN {databaseOwner}{objectQualifier}activeforums_Topics_Tags as TT ON tag.TagId = tt.TagId 
+													WHERE     tag.TagName = @Tags AND tag.Moduleid = t.ModuleId))
+			)
+		) as posts WHERE RowRank <=@Rows
+	END
+IF @RandomOrder = 0 AND @TopicsOnly = 0 
+	BEGIN
+		SELECT * FROM (
+		SELECT g.GroupName, g.ForumGroupId, M.TabId, M.ModuleId, AF.ForumName, T.ForumId,
+				T.Subject as [Subject], T.AuthorId as AuthorId,
+				T.Username AS AuthorUserName, T.FirstName as AuthorFirstName,
+				T.LastName AS AuthorLastName, T.DisplayName AS AuthorDisplayName,
+				T.DateUpdated AS DateCreated,
+				"ReplyCount" = 0, T.TopicId, T.ReplyId,
+				c.Body,ROW_NUMBER() OVER (ORDER BY T.DateUpdated DESC) as RowRank,
+				ISNULL(URL,'') as  TopicURL,
+				ISNULL(af.PrefixURL,'') as PrefixURL,
+				ISNULL(g.PrefixURL,'') as GroupPrefixURL
+		FROM {databaseOwner}{objectQualifier}vw_activeforums_TopicView as T
+			INNER JOIN {databaseOwner}{objectQualifier}activeforums_Functions_Split(@Forums,':') as F on t.ForumId = F.ID 			
+			INNER JOIN {databaseOwner}{objectQualifier}TabModules as M ON T.ModuleId = M.ModuleId
+			INNER JOIN {databaseOwner}{objectQualifier}activeforums_Forums as af ON T.ForumId = af.ForumId
+			INNER JOIN {databaseOwner}{objectQualifier}activeforums_Groups as g on af.ForumGroupId = g.ForumGroupId
+			INNER JOIN {databaseOwner}{objectQualifier}activeforums_Content as c on c.ContentId = T.ContentId
+		WHERE (@Tags = '' OR (@Tags <> '' AND T.TopicId IN (
+													SELECT tt.TopicId FROM {databaseOwner}{objectQualifier}activeforums_Tags as tag
+													 INNER JOIN {databaseOwner}{objectQualifier}activeforums_Topics_Tags as TT ON tag.TagId = tt.TagId 
+													WHERE     tag.TagName = @Tags AND tag.Moduleid = AF.ModuleId))
+			)
+		) as Posts WHERE RowRank <= @Rows
+	END
+IF @RandomOrder = 1 AND @TopicsOnly = 0 
+	BEGIN
+		SELECT * FROM (
+		SELECT g.GroupName, g.ForumGroupId, M.TabId, M.ModuleId, AF.ForumName, T.ForumId,
+				T.Subject as [Subject], T.AuthorId as AuthorId,
+				T.Username AS AuthorUserName, T.FirstName as AuthorFirstName,
+				T.LastName AS AuthorLastName, T.DisplayName AS AuthorDisplayName,
+				T.DateUpdated AS DateCreated,
+				"ReplyCount" = 0, T.TopicId, T.ReplyId,
+				c.Body,ROW_NUMBER() OVER (ORDER BY NEWID() DESC) as RowRank,
+				ISNULL(URL,'') as  TopicURL,
+				ISNULL(af.PrefixURL,'') as PrefixURL,
+				ISNULL(g.PrefixURL,'') as GroupPrefixURL
+		FROM {databaseOwner}{objectQualifier}vw_activeforums_TopicView as T
+				INNER JOIN {databaseOwner}{objectQualifier}activeforums_Functions_Split(@Forums,':') as F on t.ForumId = F.ID 			
+			INNER JOIN {databaseOwner}{objectQualifier}TabModules as M ON T.ModuleId = M.ModuleId
+			INNER JOIN {databaseOwner}{objectQualifier}activeforums_Forums as af ON T.ForumId = af.ForumId
+			INNER JOIN {databaseOwner}{objectQualifier}activeforums_Groups as g on af.ForumGroupId = g.ForumGroupId
+			INNER JOIN {databaseOwner}{objectQualifier}activeforums_Content as c on c.ContentId = T.ContentId
+		WHERE (@Tags = '' OR (@Tags <> '' AND T.TopicId IN (
+													SELECT tt.TopicId FROM {databaseOwner}{objectQualifier}activeforums_Tags as tag
+													 INNER JOIN {databaseOwner}{objectQualifier}activeforums_Topics_Tags as TT ON tag.TagId = tt.TagId 
+													WHERE     tag.TagName = @Tags AND tag.Moduleid = AF.ModuleId))
+			)
+		) as Posts WHERE RowRank <=@Rows
+		
+	END
+GO
+/* issue 205 - end - what's new view with non-random option and topics only should be sorted to show most recent based on create/reply date rather than just original create date */


### PR DESCRIPTION

<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
What's new module view with non-random option and topics only show most recent activity based on create/reply date rather than just original create date of an initial post. In other words, "popular" posts with more replies should bubble to the top.
## Changes made
- Changes to stored procedure to rank based on date created/last reply date rather than just original post date


## PR Template Checklist

- [] Fixes Bug
- [X] Feature solution
- [ ] Other


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #205