### PR TITLE
Replace flood/edit interval module settings dropdowns with textboxes

### DIFF
--- a/ForumSettings.ascx
+++ b/ForumSettings.ascx
@@ -66,20 +66,11 @@
 	<fieldset>
 		<div class="dnnFormItem">
 			<dnn:label ID="lblFloodInterval" runat="server" resourcekey="FloodInterval" Suffix=":" />
-            <asp:DropDownList ID="drpFloodInterval" runat="server">
-                <asp:ListItem>0</asp:ListItem>
-                <asp:ListItem>100</asp:ListItem>
-                <asp:ListItem>200</asp:ListItem>
-                <asp:ListItem>300</asp:ListItem>
-            </asp:DropDownList>
+            <asp:TextBox ID="txtFloodInterval" runat="server" MaxLength="5" Width="35" Text="0" />
 	    </div>
-		<div class="dnnFormItem">
+		<div class="dnnFormItem"> 
 			<dnn:label ID="lblEditInterval" runat="server" resourcekey="EditInterval" Suffix=":" />
-            <asp:DropDownList ID="drpEditInterval" runat="server">
-                <asp:ListItem>0</asp:ListItem>
-                <asp:ListItem>30</asp:ListItem>
-                <asp:ListItem>60</asp:ListItem>
-            </asp:DropDownList>
+            <asp:TextBox ID="txtEditInterval" runat="server" MaxLength="3" Width="25" Text="0" />
 		</div>
 		<div class="dnnFormItem">
 			<dnn:label ID="lblAutoLinks" runat="server" resourcekey="AutoLink" Suffix=":" />

--- a/ForumSettings.ascx.cs
+++ b/ForumSettings.ascx.cs
@@ -62,11 +62,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
 			drpPageSize.Style.Add("float", "none");
 
-            drpFloodInterval.Style.Add("float", "none");
-
-            drpEditInterval.Style.Add("float", "none");
-
-            if (!(Utilities.IsRewriteLoaded()) || PortalSettings.PortalAlias.HTTPAlias.Contains("/"))
+			if (!(Utilities.IsRewriteLoaded()) || PortalSettings.PortalAlias.HTTPAlias.Contains("/"))
 			{
 				rdEnableURLRewriter.SelectedIndex = 1;
 				rdEnableURLRewriter.Enabled = false;
@@ -131,9 +127,9 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 					BindForumSecurity();
 
                     Utilities.SelectListItemByValue(drpPageSize, PageSize);
-                    Utilities.SelectListItemByValue(drpFloodInterval, FloodInterval);
-                    Utilities.SelectListItemByValue(drpEditInterval, EditInterval);
-
+	                
+					txtFloodInterval.Text = FloodInterval.ToString(); ;
+					txtEditInterval.Text = EditInterval.ToString();
 
                     Utilities.SelectListItemByValue(drpMode, Mode);
                     Utilities.SelectListItemByValue(drpThemes, Theme);
@@ -200,8 +196,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 				Mode = drpMode.SelectedValue;
 				TemplateId = Utilities.SafeConvertInt(drpTemplates.SelectedValue);
 				PageSize = Utilities.SafeConvertInt(drpPageSize.SelectedValue, 10);
-                FloodInterval = Utilities.SafeConvertInt(drpFloodInterval.SelectedValue,0);
-                EditInterval = Utilities.SafeConvertInt(drpEditInterval.SelectedValue,0);
+                FloodInterval = Math.Max(0,Utilities.SafeConvertInt(txtFloodInterval.Text,0));
+                EditInterval = Math.Max(0,Utilities.SafeConvertInt(txtEditInterval.Text,0));
                 AutoLink = Utilities.SafeConvertBool(rdAutoLinks.SelectedValue);
                 DeleteBehavior = Utilities.SafeConvertInt(drpDeleteBehavior.SelectedValue);
 				ProfileVisibility = Utilities.SafeConvertInt(drpProfileVisibility.SelectedValue);

--- a/ForumSettings.ascx.designer.cs
+++ b/ForumSettings.ascx.designer.cs
@@ -168,13 +168,13 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
         protected global::System.Web.UI.UserControl lblFloodInterval;
 
         /// <summary>
-        /// drpFloodInterval control.
+        /// txtFloodInterval control.
         /// </summary>
         /// <remarks>
         /// Auto-generated field.
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
-        protected global::System.Web.UI.WebControls.DropDownList drpFloodInterval;
+        protected global::System.Web.UI.WebControls.TextBox txtFloodInterval;
 
         /// <summary>
         /// lblEditInterval control.
@@ -186,13 +186,13 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
         protected global::System.Web.UI.UserControl lblEditInterval;
 
         /// <summary>
-        /// drpEditInterval control.
+        /// txtEditInterval control.
         /// </summary>
         /// <remarks>
         /// Auto-generated field.
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
-        protected global::System.Web.UI.WebControls.DropDownList drpEditInterval;
+        protected global::System.Web.UI.WebControls.TextBox txtEditInterval;
 
         /// <summary>
         /// lblAutoLinks control.


### PR DESCRIPTION

<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Replace flood/edit interval module settings dropdowns with textboxes, removing limitation imposed by using hard-coded dropdown lists.

![image](https://user-images.githubusercontent.com/9553126/218854951-c5aa9f3d-caaa-4730-a0f0-7f7280656aef.png)


## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #234 