### PR TITLE
Replace deprecated DNN platform method GetModuleSettings() with .ModuleSettings property references

### DIFF
--- a/ActiveForums.csproj
+++ b/ActiveForums.csproj
@@ -47,7 +47,7 @@
     <DebugSymbols>true</DebugSymbols>
     <Optimize>false</Optimize>
     <WarningLevel>1</WarningLevel>
-    <WarningLevel>1</WarningLevel>
+    <WarningLevel>3</WarningLevel>
     <DebugType>full</DebugType>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <UseVSHostingProcess>true</UseVSHostingProcess>
@@ -59,7 +59,7 @@
     <DefineConstants>TRACE;</DefineConstants>
     <DebugSymbols>false</DebugSymbols>
     <Optimize>true</Optimize>
-    <WarningLevel>1</WarningLevel>
+    <WarningLevel>4</WarningLevel>
     <DebugType>none</DebugType>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>

--- a/Classic.ascx.cs
+++ b/Classic.ascx.cs
@@ -243,8 +243,7 @@ namespace DotNetNuke.Modules.ActiveForums
                         {
                             isPrivate = true;
                         }
-                        Entities.Modules.ModuleController objModules = new Entities.Modules.ModuleController();
-                        Hashtable htSettings = objModules.GetTabModuleSettings(TabModuleId);
+                        Hashtable htSettings = new Entities.Modules.ModuleController().GetModule(TabModuleId).TabModuleSettings;
 
                         fc.CreateGroupForum(PortalId, ModuleId, SocialGroupId, Convert.ToInt32(htSettings["ForumGroupTemplate"].ToString()), role.RoleName + " Discussions", role.Description, isPrivate, htSettings["ForumConfig"].ToString());
                         ForumIds = fc.GetForumIdsBySocialGroup(PortalId, SocialGroupId);

--- a/ControlPanel.ascx.cs
+++ b/ControlPanel.ascx.cs
@@ -24,6 +24,7 @@ using System.Web;
 using DotNetNuke.Web.Client.ClientResourceManagement;
 using System.Text;
 using DotNetNuke.Framework;
+using System.Runtime.InteropServices;
 
 namespace DotNetNuke.Modules.ActiveForums
 {
@@ -49,9 +50,8 @@ namespace DotNetNuke.Modules.ActiveForums
             IsCallBack = cbShell.IsCallback;
 
             btnReturn.ClientSideScript = "window.location.href = '" + Common.Globals.NavigateURL(TabId) + "';";
-            var objModules = new Entities.Modules.ModuleController();
             cbModal.LoadingTemplate = GetLoadingTemplateSmall();
-            Hashtable Settings = objModules.GetModuleSettings(ModuleId);
+            Hashtable Settings = new DotNetNuke.Entities.Modules.ModuleController().GetModule(ModuleId).ModuleSettings;
             string upFilePath = Server.MapPath("~/desktopmodules/activeforums/upgrade4x.txt");
             if (Convert.ToBoolean(Settings["AFINSTALLED"]) == false)
             {
@@ -59,7 +59,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 {
                     var fc = new ForumsConfig();
                     bool configComplete = fc.ForumsInit(PortalId, ModuleId);
-                    objModules.UpdateModuleSetting(ModuleId, "AFINSTALLED", configComplete.ToString());
+                    new DotNetNuke.Entities.Modules.ModuleController().UpdateModuleSetting(ModuleId, "AFINSTALLED", configComplete.ToString());
                     if (System.IO.File.Exists(upFilePath))
                     {
                         System.IO.File.Delete(upFilePath);

--- a/CustomControls/UserControls/WhatsNewRSS.cs
+++ b/CustomControls/UserControls/WhatsNewRSS.cs
@@ -115,7 +115,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     var moduleSettings = DataCache.CacheRetrieve(settingsCacheKey) as Hashtable;
                     if (moduleSettings == null)
                     {
-                        moduleSettings = new ModuleController().GetModuleSettings(RequestModuleID);
+                        moduleSettings =  new DotNetNuke.Entities.Modules.ModuleController().GetModule(moduleID: RequestModuleID).ModuleSettings;
+
                         DataCache.CacheStore(settingsCacheKey, moduleSettings);
                     }
 

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -10,6 +10,12 @@
 		<h3>07.00.04</h3>
 		<h4>Features, Enhancements, and Bug Fixes</h4>
 		<ul>
+			<li>NEW: Replace deprecated DNN platform method GetModuleSettings() with .ModuleSettings property references [huge perf improvement!] (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/252">Issue 252</a>, thanks <a href="https://github.com/johnhenley" target="_blank">@johnhenley</a>!)</li>
+		</ul>
+
+		<h3>07.00.04</h3>
+		<h4>Features, Enhancements, and Bug Fixes</h4>
+		<ul>
 			<li>NEW: Added IUpgradeable for Future Code-Based Upgrade Tasks (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/186">Issue 186</a>, thanks <a href="https://github.com/johnhenley" target="_blank">@johnhenley</a>!)</li>
 			<li>BUG: Restored Missing 'Anonymous' Username Logic (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/204">Issue 204</a>, thanks <a href="https://github.com/johnhenley" target="_blank">@johnhenley</a>!)</li>
 			<li>TASK: Remove obsolete Active Social integration (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/173">Issue 173</a>, thanks <a href="https://github.com/johnhenley" target="_blank">@johnhenley</a>!)</li>

--- a/Services/AdminServiceController.cs
+++ b/Services/AdminServiceController.cs
@@ -22,6 +22,7 @@ using System.Net.Http;
 using System.Text;
 using System.Web;
 using System.Web.Http;
+using DotNetNuke.Entities.Modules;
 using DotNetNuke.Security;
 using DotNetNuke.Web.Api;
 
@@ -41,8 +42,6 @@ namespace DotNetNuke.Modules.ActiveForums
 
         public HttpResponseMessage ToggleURLHandler(ToggleUrlHandlerDTO dto)
         {
-            var objModules = new Entities.Modules.ModuleController();
-            var objSettings = new SettingsInfo { MainSettings = objModules.GetModuleSettings(dto.ModuleId) };
             var cfg = new ConfigUtils();
             bool success;
             if (Utilities.IsRewriteLoaded())
@@ -69,9 +68,8 @@ namespace DotNetNuke.Modules.ActiveForums
 
         public HttpResponseMessage RunMaintenance(RunMaintenanceDTO dto)
         {
-            var objModules = new Entities.Modules.ModuleController();
-            var objSettings = new SettingsInfo {MainSettings = objModules.GetModuleSettings(dto.ModuleId)};
-            var rows = DataProvider.Instance().Forum_Maintenance(dto.ForumId, dto.OlderThan, dto.LastActive, dto.ByUserId, dto.WithNoReplies, dto.DryRun, objSettings.DeleteBehavior);
+            var moduleSettings = new SettingsInfo { MainSettings = new ModuleController().GetModule(moduleID: dto.ModuleId).ModuleSettings };
+            var rows = DataProvider.Instance().Forum_Maintenance(dto.ForumId, dto.OlderThan, dto.LastActive, dto.ByUserId, dto.WithNoReplies, dto.DryRun, moduleSettings.DeleteBehavior);
             if (dto.DryRun)
                 return Request.CreateResponse(HttpStatusCode.OK, new { Result = string.Format(Utilities.GetSharedResource("[RESX:Maint:DryRunResults]", true), rows.ToString()) });
 

--- a/WhatsNew.ascx.cs
+++ b/WhatsNew.ascx.cs
@@ -50,7 +50,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     var moduleSettings = DataCache.CacheRetrieve(settingsCacheKey) as Hashtable;
                     if (moduleSettings == null)
                     {
-                        moduleSettings = new ModuleController().GetModuleSettings(ModuleId);
+                        moduleSettings = new ModuleController().GetModule(moduleID:ModuleId).ModuleSettings;
                         DataCache.CacheStore(settingsCacheKey, moduleSettings);
                     }
 

--- a/WhatsNewOptions.ascx.cs
+++ b/WhatsNewOptions.ascx.cs
@@ -81,11 +81,10 @@ namespace DotNetNuke.Modules.ActiveForums
                         }
                     }
                 }
-
-                var mc = new ModuleController();
+                var moduleController = new ModuleController();
 
                 // Load the current settings
-                var settings = WhatsNewModuleSettings.CreateFromModuleSettings(mc.GetModuleSettings(ModuleId));
+                var settings = WhatsNewModuleSettings.CreateFromModuleSettings(moduleController.GetModule(ModuleId).ModuleSettings);
 
                 // Update Settings Values
                 settings.Forums = forums;
@@ -113,7 +112,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 }
 
                 // Save Settings
-                settings.Save(mc, ModuleId);
+                settings.Save(moduleController, ModuleId);
 
                 // Redirect back to the portal home page
                 Response.Redirect(Common.Globals.NavigateURL(), true);
@@ -166,7 +165,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
         private void LoadForm()
         {
-            var moduleSettings = new ModuleController().GetModuleSettings(ModuleId) ;
+            var moduleSettings = new ModuleController().GetModule(ModuleId).ModuleSettings;
             var settings = WhatsNewModuleSettings.CreateFromModuleSettings(moduleSettings);
 
             txtNumItems.Text = settings.Rows.ToString();

--- a/class/ActiveAdminBase.cs
+++ b/class/ActiveAdminBase.cs
@@ -94,10 +94,7 @@ namespace DotNetNuke.Modules.ActiveForums
         {
             get
             {
-                var _portalSettings = (Entities.Portals.PortalSettings)(HttpContext.Current.Items["PortalSettings"]);
-                var objModules = new Entities.Modules.ModuleController();
-                var objSettings = new SettingsInfo {MainSettings = objModules.GetModuleSettings(ModuleId)};
-                return objSettings;
+                return new SettingsInfo { MainSettings = new DotNetNuke.Entities.Modules.ModuleController().GetModule(ModuleId).ModuleSettings };
             }
         }
         public DateTime CacheUpdatedTime

--- a/class/SettingsBase.cs
+++ b/class/SettingsBase.cs
@@ -350,12 +350,7 @@ namespace DotNetNuke.Modules.ActiveForums
             get
             {
                 ForumModuleId = _forumModuleId <= 0 ? ForumModuleId : _forumModuleId;
-
-                var _portalSettings = (PortalSettings)(HttpContext.Current.Items["PortalSettings"]);
-                var objModules = new Entities.Modules.ModuleController();
-                var objSettings = new SettingsInfo {MainSettings = objModules.GetModuleSettings(ForumModuleId)};
-
-                return objSettings;
+                return new SettingsInfo { MainSettings = new Entities.Modules.ModuleController().GetModule(ForumModuleId).ModuleSettings };
             }
         }
         public string ImagePath

--- a/components/Extensions/ReWriter.cs
+++ b/components/Extensions/ReWriter.cs
@@ -258,11 +258,8 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			if (_moduleId > 0)
 			{
-				Entities.Modules.ModuleController objModules = new Entities.Modules.ModuleController();
-				SettingsInfo objSettings = new SettingsInfo();
-				objSettings.MainSettings = objModules.GetModuleSettings(_moduleId);
-				_mainSettings = objSettings; // DataCache.MainSettings(_moduleId)
-			}
+				_mainSettings = new SettingsInfo { MainSettings = new Entities.Modules.ModuleController().GetModule(moduleID: _moduleId).ModuleSettings };
+            }
 			if (_mainSettings == null)
 			{
 				return;

--- a/components/Topics/TopicsController.cs
+++ b/components/Topics/TopicsController.cs
@@ -392,12 +392,12 @@ namespace DotNetNuke.Modules.ActiveForums
 			 * A possible future enhancement might be to write this entry or to perhaps change the module definition ...
 			 * 
 			 */
-			var ms = new SettingsInfo { MainSettings = new Entities.Modules.ModuleController().GetModuleSettings(moduleInfo.ModuleID) };
-			/* if not using soft deletes, remove and rebuild entire index; 
+			var ms = new SettingsInfo { MainSettings = moduleInfo.ModuleSettings };
+            /* if not using soft deletes, remove and rebuild entire index; 
 			   note that this "internals" method is suggested by blog post (https://www.dnnsoftware.com/community-blog/cid/154913/integrating-with-search-introducing-modulesearchbase#Comment106)
 			   and also is used by the Community Links module (https://github.com/DNNCommunity/DNN.Links/blob/development/Components/FeatureController.cs)
 			*/
-			if (ms.DeleteBehavior != 1)
+            if (ms.DeleteBehavior != 1)
 			{
 				DotNetNuke.Services.Search.Internals.InternalSearchController.Instance.DeleteSearchDocumentsByModule(moduleInfo.PortalID, moduleInfo.ModuleID, moduleInfo.ModuleDefID);
 				beginDateUtc = SqlDateTime.MinValue.Value.AddDays(1);


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
DNN Platform DotNetNuke.Entities.Modules.ModuleController .GetModuleSettings() and .GetTabModuleSettings() methods are being deprecated. In addition, they don't cache the settings, resulting in repeated database roundtrips to retrieve settings:
![image](https://user-images.githubusercontent.com/9553126/221308680-bc4d412c-56e5-4f5e-9d40-119f046160e4.png)

## Changes made
- Changed module settings retrieval logic in all affected classes

Database calls greatly reduced:
![image](https://user-images.githubusercontent.com/9553126/221309646-ad1788f9-4db5-48ec-8568-fdd1a97a62cb.png)


## PR Template Checklist

- [ ] Fixes Bug
- [ ] Feature solution
- [X] Other


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #252