### PR TITLE
07.00.10 Upgrade fails when executing SQL for 07.00.05

### DIFF
--- a/sql/07.00.05.SqlDataProvider
+++ b/sql/07.00.05.SqlDataProvider
@@ -1,5 +1,4 @@
-
-﻿/* begin - issue #169 - More specific email notifications -- need to retrieve topic-or-forum-level subscriber */
+/* begin - issue #169 - More specific email notifications -- need to retrieve topic-or-forum-level subscriber */
 
 IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_Subscriptions_Subscribers]') AND type in (N'P', N'PC'))
 DROP PROCEDURE {databaseOwner}[{objectQualifier}activeforums_Subscriptions_Subscribers]

--- a/sql/07.00.06.SqlDataProvider
+++ b/sql/07.00.06.SqlDataProvider
@@ -1,4 +1,3 @@
-
 ﻿/* issue 205 - begin - what's new view with non-random option and topics only should be sorted to show most recent based on create/reply date rather than just original create date */
 IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_TP_GetPosts]') AND type in (N'P', N'PC'))
 DROP PROCEDURE {databaseOwner}[{objectQualifier}activeforums_TP_GetPosts]

--- a/sql/07.00.07.SqlDataProvider
+++ b/sql/07.00.07.SqlDataProvider
@@ -1,4 +1,3 @@
-
 ﻿/* issue 97 - begin - delete module instance not removing data from database */
 
 SET NOCOUNT ON


### PR DESCRIPTION
BUG: SqlDataProviders for 07.00.05/07.00.06/07.00.07 (re-)saved as UTF-8 BOM (rather than UTF-8) causing SQL errors during 07.00.10 upgrade.
 
## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other


