### PR TITLE
FIX: Bad redirect when replying and using friendly URL rewriter

### DIFF
--- a/components/Replies/Replies.cs
+++ b/components/Replies/Replies.cs
@@ -281,7 +281,7 @@ namespace DotNetNuke.Modules.ActiveForums
 				}
 				if (fullURL.EndsWith("/"))
 				{
-					fullURL += "?" + ParamKeys.ContentJumpId + "=" + ReplyId;
+					fullURL += Utilities.IsRewriteLoaded() ? String.Concat("#", ReplyId) : String.Concat("?", ParamKeys.ContentJumpId, "=", ReplyId);
 				}
 				Social amas = new Social();
 				amas.AddReplyToJournal(PortalId, ModuleId, ForumId, TopicId, ReplyId, reply.Author.AuthorId, fullURL, reply.Content.Subject, string.Empty, reply.Content.Body,fi.Security.Read, fi.SocialGroupId);

--- a/controls/af_quickreply.ascx.cs
+++ b/controls/af_quickreply.ascx.cs
@@ -431,7 +431,7 @@ namespace DotNetNuke.Modules.ActiveForums
             }
             if (fullURL.EndsWith("/"))
             {
-                fullURL += "?" + ParamKeys.ContentJumpId + "=" + ReplyId;
+                fullURL += Utilities.IsRewriteLoaded() ? String.Concat("#", ReplyId) : String.Concat("?", ParamKeys.ContentJumpId, "=", ReplyId);
             }
             if (isApproved)
             {


### PR DESCRIPTION
### Description of PR...
FIX: Bad redirect when replying and using friendly URL rewriter

## Changes made
- In reply and quick reply, check if friendly URLs are used, and redirect to reply using #xxxx rather than &afc=xxxx


## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #324 
