### PR TITLE
BUG: Bad redirect when replying and using friendly URL rewriter

### DIFF
--- a/controls/af_post.ascx.cs
+++ b/controls/af_post.ascx.cs
@@ -1152,8 +1152,8 @@ namespace DotNetNuke.Modules.ActiveForums
                     if (fullURL.Contains("~/"))
                         fullURL = Utilities.NavigateUrl(ForumTabId, "", new[] { ParamKeys.TopicId + "=" + TopicId, ParamKeys.ContentJumpId + "=" + tmpReplyId });
                     
-                    if (fullURL.EndsWith("/"))
-                        fullURL += "?" + ParamKeys.ContentJumpId + "=" + tmpReplyId;
+                    if (fullURL.EndsWith("/")) 
+                        fullURL += Utilities.UseFriendlyURLs(ModuleId) ? String.Concat("#", tmpReplyId) : String.Concat("?", ParamKeys.ContentJumpId, "=", tmpReplyId);
 
                     if (!_isEdit)
                     {


### PR DESCRIPTION
### Description of PR...
FIX: Bad redirect when replying and using friendly URL rewriter
(CONTINUATION of #325)

## Changes made
- In reply posting, check if friendly URLs are used, and redirect to reply using #xxxx rather than &afc=xxxx


## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #324 
