### PR TITLE
07.00.11 Upgrade fails when executing SQL for 07.00.10

### DIFF
--- a/sql/07.00.10.SqlDataProvider
+++ b/sql/07.00.10.SqlDataProvider
@@ -1,5 +1,4 @@
-
-﻿/* issue 185 - begin - show subscriber count on topic  */
+/* issue 185 - begin - show subscriber count on topic  */
 
 /*activeforums_UI_TopicView*/
 IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_UI_TopicView]') AND type in (N'P', N'PC'))


### PR DESCRIPTION
BUG: 07.00.10.SqlDataProvider formatted as UTF-8 BOM (rather than UTF-8) causing SQL errors during 07.00.11 upgrade.
 
## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
