### PR TITLE
BUG: Incorrect friendly URL when including 'jumpto' topic id

### DIFF
--- a/CustomControls/UserControls/ForumView.cs
+++ b/CustomControls/UserControls/ForumView.cs
@@ -767,7 +767,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 {
                     if (sTopicURL.EndsWith("/"))
                     {
-                        sURL = sTopicURL + "?" + ParamKeys.ContentJumpId + "=" + PostId;
+                        sURL = sTopicURL + "?" + (Utilities.UseFriendlyURLs(ForumModuleId) ? String.Concat("#", PostId) : String.Concat("?", ParamKeys.ContentJumpId, "=", PostId));
                     }
                     else
                     {

--- a/CustomControls/UserControls/TopicsView.cs
+++ b/CustomControls/UserControls/TopicsView.cs
@@ -892,7 +892,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     {
                         if (sTopicURL.EndsWith("/"))
                         {
-                            sLastReplyURL = sTopicURL + "?" + ParamKeys.ContentJumpId + "=" + LastReplyId;
+                            sLastReplyURL = sTopicURL + (Utilities.UseFriendlyURLs(ForumModuleId) ? String.Concat("#", LastReplyId) : String.Concat("?", ParamKeys.ContentJumpId, "=", LastReplyId));
                         }
                     }
                     string sLastReadURL = string.Empty;
@@ -916,7 +916,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                         }
                         if (sTopicURL.EndsWith("/"))
                         {
-                            sLastReadURL = sTopicURL + "?" + ParamKeys.FirstNewPost + "=" + UserLastReplyRead;
+                            sLastReadURL = sTopicURL + (Utilities.UseFriendlyURLs(ForumModuleId) ? String.Concat("#", UserLastReplyRead) : String.Concat("?", ParamKeys.FirstNewPost, "=", UserLastReplyRead));
                         }
                     }
 


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
BUG: Incorrect friendly URL when including 'jumpto' topic id

## Changes made
- check if friendly URLs are used, and redirect to reply using #xxxx rather than &afc=xxxx 


## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #346 
