### PR TITLE
Remove duplicate templates tag in defaultsetup.config

### DIFF
--- a/Dnn.CommunityForums/config/defaultsetup.config
+++ b/Dnn.CommunityForums/config/defaultsetup.config
@@ -56,7 +56,6 @@
 		<template templateid="" templatetitle="PostDeleted" templatetype="10" templatesubject="[PORTALNAME] Forums - Deleted: [SUBJECT] " importfilehtml="~/DesktopModules/ActiveForums/config/templates/PostDeleted.txt" importfiletext="~/DesktopModules/ActiveForums/config/templates/PostDeleted_plaintext.txt" />
 		<template templateid="" templatetitle="PostMoved" templatetype="10" templatesubject="[PORTALNAME] Forums - Moved: [SUBJECT] " importfilehtml="~/DesktopModules/ActiveForums/config/templates/PostMoved.txt" importfiletext="~/DesktopModules/ActiveForums/config/templates/PostMoved_plaintext.txt" />
 
-		<templates> 
   </templates>
   <filters>
     <filter filterfile="~/DesktopModules/ActiveForums/config/templates/Filters.txt" />


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Merge of defaultsetup.config resulted in duplicated templates tag

## Changes made 
- remove duplicated tag
- 
## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #384 