### PR TITLE
FIX: Uninstall fails when dropping table activeforums_Tags

### DIFF
--- a/Dnn.CommunityForums/sql/Uninstall.SqlDataProvider
+++ b/Dnn.CommunityForums/sql/Uninstall.SqlDataProvider
@@ -667,6 +667,10 @@ IF EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databas
 ALTER TABLE {databaseOwner}[{objectQualifier}activeforums_Topics_Tags]
 	DROP CONSTRAINT [FK_{objectQualifier}activeforums_Topics_Tags_Topics]
 GO
+IF EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}[FK_{objectQualifier}activeforums_Topics_Tags_Tags]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_Topics_Tags]'))
+ALTER TABLE {databaseOwner}[{objectQualifier}activeforums_Topics_Tags] 
+	DROP CONSTRAINT [FK_{objectQualifier}activeforums_Topics_Tags_Tags]
+GO
 IF EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}[FK_{objectQualifier}activeforums_URL_Topics]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_URL]'))
 ALTER TABLE {databaseOwner}[{objectQualifier}activeforums_URL]
 	DROP CONSTRAINT [FK_{objectQualifier}activeforums_URL_Topics]


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Uninstall fails when dropping table activeforums_Tags

## Changes made
- add missing DROP CONSTRAINT to uninstaller for activeforums_Tags

## How did you test these updates?  
Installed previous version and uninstalled it to verify table was not removed.
From event log:
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/01fe6d4b-7fac-4653-b09f-66d7ae8f421c)


Manually removed table.
Installed new version and uninstalled it to verify that table was properly removed.
From event log:
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/7c82122f-d67e-4b8c-a5ce-1cb4b2491d19)


## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #392 