### PR TITLE
FIX: Incorrect links in pager when forum does not inherit group settings

### DIFF
--- a/Dnn.CommunityForums/CustomControls/ServerControls/PagerNav.cs
+++ b/Dnn.CommunityForums/CustomControls/ServerControls/PagerNav.cs
@@ -109,10 +109,6 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 {
                     BaseURL += "/";
                 }
-                if (!(BaseURL.StartsWith("/")))
-                {
-                    BaseURL = "/" + BaseURL;
-                }
             }
 
             var qs = string.Empty;

--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
@@ -1672,9 +1672,6 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
             var intPages = Convert.ToInt32(Math.Ceiling(_rowCount / (double)_pageSize));
 
-            if (!(_topicURL.Contains(ForumInfo.PrefixURL)))
-                _topicURL = "/" + ForumInfo.PrefixURL + "/" + _topicURL;
-
             var @params = new List<string>();
             if (!string.IsNullOrWhiteSpace(Request.Params[ParamKeys.Sort]))
                 @params.Add(ParamKeys.Sort + "=" + Request.Params[ParamKeys.Sort]);
@@ -1691,19 +1688,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 pager1.View = Views.Topic;
                 pager1.TopicId = TopicId;
                 pager1.PageMode = PagerNav.Mode.Links;
-                if (MainSettings.URLRewriteEnabled && !string.IsNullOrWhiteSpace(_topicURL))
-                {
-                    if (!(string.IsNullOrEmpty(MainSettings.PrefixURLBase)))
-                    {
-                        pager1.BaseURL = "/" + MainSettings.PrefixURLBase;
-                    }
-                    if (!(string.IsNullOrEmpty(ForumInfo.ForumGroup.PrefixURL)))
-                    {
-                        pager1.BaseURL += "/" + ForumInfo.ForumGroup.PrefixURL;
-                    }
-                    pager1.BaseURL += _topicURL;
-                }
-
+                pager1.BaseURL = URL.ForumLink(TabId, ForumInfo) + _topicURL;
                 pager1.Params = @params.ToArray();
             }
 
@@ -1719,19 +1704,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 pager2.View = Views.Topic;
                 pager2.TopicId = TopicId;
                 pager2.PageMode = PagerNav.Mode.Links;
-                if (MainSettings.URLRewriteEnabled && !string.IsNullOrWhiteSpace(_topicURL))
-                {
-                    if (!(string.IsNullOrEmpty(MainSettings.PrefixURLBase)))
-                    {
-                        pager2.BaseURL = "/" + MainSettings.PrefixURLBase;
-                    }
-                    if (!(string.IsNullOrEmpty(ForumInfo.ForumGroup.PrefixURL)))
-                    {
-                        pager2.BaseURL += "/" + ForumInfo.ForumGroup.PrefixURL;
-                    }
-                    pager2.BaseURL += _topicURL;
-                }
-
+                pager2.BaseURL = URL.ForumLink(TabId, ForumInfo) + _topicURL;
                 pager2.Params = @params.ToArray();
             }
 

--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicsView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicsView.cs
@@ -1079,15 +1079,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     intPages = Convert.ToInt32(System.Math.Ceiling(TopicRowCount / (double)PageSize));
                     Pager1.PageCount = intPages;
                     Pager1.PageMode = PagerNav.Mode.Links;
-                    if (!(string.IsNullOrEmpty(ForumInfo.PrefixURL)) && MainSettings.URLRewriteEnabled)
-                    {
-                        if (!(string.IsNullOrEmpty(MainSettings.PrefixURLBase)))
-                        {
-                            Pager1.BaseURL = "/" + MainSettings.PrefixURLBase;
-                        }
-                        Pager1.BaseURL += "/" + ForumInfo.ForumGroup.PrefixURL + "/" + ForumInfo.PrefixURL + "/";
-                        Pager1.PageMode = PagerNav.Mode.Links;
-                    }
+                    Pager1.BaseURL = URL.ForumLink(TabId, ForumInfo);
                     Pager1.CurrentPage = PageId;
                     Pager1.TabID = Convert.ToInt32(Request.Params["TabId"]);
                     Pager1.ForumID = ForumId;
@@ -1110,16 +1102,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
                 if (Pager2 != null)
                 {
-                    Pager2.PageMode = Modules.ActiveForums.Controls.PagerNav.Mode.Links; // DotNetNuke.Modules.ActiveForums.Controls.Pager.Mode.CallBack
-                    if (!(string.IsNullOrEmpty(ForumInfo.PrefixURL)) && MainSettings.URLRewriteEnabled)
-                    {
-                        if (!(string.IsNullOrEmpty(MainSettings.PrefixURLBase)))
-                        {
-                            Pager2.BaseURL = "/" + MainSettings.PrefixURLBase;
-                        }
-                        Pager2.BaseURL += "/" + ForumInfo.ForumGroup.PrefixURL + "/" + ForumInfo.PrefixURL + "/";
-                        Pager2.PageMode = PagerNav.Mode.Links;
-                    }
+                    Pager2.PageMode = Modules.ActiveForums.Controls.PagerNav.Mode.Links;
+                    Pager2.BaseURL = URL.ForumLink(TabId, ForumInfo);
                     Pager2.UseShortUrls = MainSettings.UseShortUrls;
                     Pager2.PageCount = intPages;
                     Pager2.CurrentPage = PageId;


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Incorrect links in pager when forum overrides (does not inherit) settings from forum group.

## Changes made
- changed to use common URL logic

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Tested multiple forums and pages in test copy of dnncommunity.org

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #425