### PR TITLE
FIX: Forum settings in Control Panel

### DIFF
--- a/Dnn.CommunityForums/CustomControls/ServerControls/ForumLoader.cs
+++ b/Dnn.CommunityForums/CustomControls/ServerControls/ForumLoader.cs
@@ -18,10 +18,9 @@
 // DEALINGS IN THE SOFTWARE.
 //
 using System;
+using System.IO;
 using System.Web.UI;
 using System.Web.UI.WebControls;
-using System.IO;
-using DotNetNuke.Modules.ActiveForums.Constants;
 using DotNetNuke.Common.Utilities;
 
 namespace DotNetNuke.Modules.ActiveForums.Controls
@@ -31,8 +30,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
     {
         private Forum fi;
         protected override void OnLoad(EventArgs e)
-		{
-			base.OnLoad(e);
+        {
+            base.OnLoad(e);
 
             try
             {
@@ -58,7 +57,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 if (ForumId > 0 && ForumModuleId == -1)
                 {
                     ForumController fc = new ForumController();
-                    fi = fc.Forums_Get(ForumId, UserId, true, true);
+                    fi = fc.Forums_Get(PortalId, ForumModuleId, ForumId, true);
                     ForumModuleId = fi.ModuleId;
                 }
                 if (ForumModuleId > 0)
@@ -69,7 +68,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     modInfo.PortalID = PortalId;
                     modInfo.DesktopModule.Permissions = this.ModuleConfiguration.DesktopModule.Permissions;
 
-                   ForumBase objModule = (ForumBase)(LoadControl("~/desktopmodules/ActiveForums/classic.ascx"));
+                    ForumBase objModule = (ForumBase)(LoadControl("~/desktopmodules/ActiveForums/classic.ascx"));
                     if (objModule != null)
                     {
                         objModule.ModuleConfiguration = modInfo;
@@ -77,7 +76,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                         objModule.ForumModuleId = ForumModuleId;
                         objModule.ForumTabId = ForumTabId;
                         objModule.ForumInfo = fi;
-                        objModule.ForumId = ForumId; 
+                        objModule.ForumId = ForumId;
                         objModule.ForumGroupId = ForumGroupId;
                         objModule.DefaultForumViewTemplateId = DefaultForumViewTemplateId;
                         objModule.DefaultTopicsViewTemplateId = DefaultTopicsViewTemplateId;

--- a/Dnn.CommunityForums/CustomControls/ServerControls/QuickReply.cs
+++ b/Dnn.CommunityForums/CustomControls/ServerControls/QuickReply.cs
@@ -69,7 +69,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             ForumController fc = new ForumController();
             if (ForumInfo == null)
             {
-                ForumInfo = fc.Forums_Get(PortalId, ModuleId, ForumId, this.UserId, true, false, TopicId);
+                ForumInfo = fc.Forums_Get(PortalId, ModuleId, ForumId, false, TopicId);
             }
 
             string sTemp = string.Empty;
@@ -177,7 +177,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
         private void SaveQuickReply()
         {
             ForumController fc = new ForumController();
-            Forum forumInfo = fc.Forums_Get(PortalId, ModuleId, ForumId, this.UserId, true, false, TopicId);
+            Forum forumInfo = fc.Forums_Get(PortalId, ModuleId, ForumId, false, TopicId);
             if (!Utilities.HasFloodIntervalPassed(floodInterval: MainSettings.FloodInterval, user: ForumUser, forumInfo: forumInfo))
             {
                 UserProfileController upc = new UserProfileController();

--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
@@ -183,7 +183,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             base.OnInit(e);
 
             if (ForumInfo == null)
-                ForumInfo = new ForumController().Forums_Get(PortalId, ForumModuleId, ForumId, UserId, true, false, TopicId);
+                ForumInfo = new ForumController().Forums_Get(PortalId, ForumModuleId, ForumId, false, TopicId);
         }
 
         protected override void OnLoad(EventArgs e)

--- a/Dnn.CommunityForums/Services/ForumServiceController.cs
+++ b/Dnn.CommunityForums/Services/ForumServiceController.cs
@@ -141,7 +141,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
                 // Make sure that we can find the forum and that attachments are allowed
                 var fc = new ForumController();
-                var forum = fc.Forums_Get(ActiveModule.PortalID, ActiveModule.ModuleID, forumId, userInfo.UserID, true, true, -1);
+                var forum = fc.Forums_Get(ActiveModule.PortalID, ActiveModule.ModuleID, forumId, true, -1);
 
                 if (forum == null || !forum.AllowAttach)
                 {
@@ -414,7 +414,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
             var fc = new ForumController();
 
-            var forum_out = fc.Forums_Get(portalSettings.PortalId, ActiveModule.ModuleID, 0, forumUser.UserId, false, true, dto.OldTopicId);
+            var forum_out = fc.Forums_Get(portalSettings.PortalId, ActiveModule.ModuleID, 0, true, dto.OldTopicId);
             var forum_in = fc.GetForum(portalSettings.PortalId, ActiveModule.ModuleID, dto.NewForumId);
             if (forum_out != null && forum_in != null)
             {

--- a/Dnn.CommunityForums/Services/ModerationService.cs
+++ b/Dnn.CommunityForums/Services/ModerationService.cs
@@ -43,18 +43,18 @@ namespace DotNetNuke.Modules.ActiveForums
         public HttpResponseMessage ApprovePost(ModerationDTO dto)
         {
             var notify = NotificationsController.Instance.GetNotification(dto.NotificationId);
-            
+
             ParseNotificationContext(notify.Context);
-            
+
             var fc = new ForumController();
-            
-            var fi = fc.Forums_Get(_forumId, -1, false, true);
+
+            var fi = fc.Forums_Get(ActiveModule.PortalID, ActiveModule.ModuleID, _forumId, true);
             if (fi == null)
                 return Request.CreateResponse(HttpStatusCode.OK, new { Message = "Forum Not Found" });
 
 
             if (!(IsMod(_forumId)))
-                return Request.CreateResponse(HttpStatusCode.Forbidden, new { Message = "User is not a moderator for this forum"});
+                return Request.CreateResponse(HttpStatusCode.Forbidden, new { Message = "User is not a moderator for this forum" });
 
 
             if (_replyId > 0)
@@ -73,7 +73,7 @@ namespace DotNetNuke.Modules.ActiveForums
             }
 
             NotificationsController.Instance.DeleteNotification(dto.NotificationId);
-            
+
             return Request.CreateResponse(HttpStatusCode.OK, new { Result = "success" });
         }
 
@@ -81,11 +81,11 @@ namespace DotNetNuke.Modules.ActiveForums
         public HttpResponseMessage RejectPost(ModerationDTO dto)
         {
             var notify = NotificationsController.Instance.GetNotification(dto.NotificationId);
-            
+
             ParseNotificationContext(notify.Context);
-            
+
             var fc = new ForumController();
-            var fi = fc.Forums_Get(_forumId, -1, false, true);
+            var fi = fc.Forums_Get(ActiveModule.PortalID, ActiveModule.ModuleID, _forumId, true);
             if (fi == null)
                 return Request.CreateResponse(HttpStatusCode.OK, new { Message = "Forum Not Found" });
 
@@ -95,9 +95,9 @@ namespace DotNetNuke.Modules.ActiveForums
 
             var mc = new ModController();
             mc.Mod_Reject(PortalSettings.PortalId, _moduleId, UserInfo.UserID, _forumId, _topicId, _replyId);
-            
+
             int authorId;
-            
+
             if (_replyId > 0)
             {
                 var rc = new ReplyController();
@@ -125,14 +125,14 @@ namespace DotNetNuke.Modules.ActiveForums
                 if (ui != null)
                 {
                     var au = new Author
-                                 {
-                                     AuthorId = authorId,
-                                     DisplayName = ui.DisplayName,
-                                     Email = ui.Email,
-                                     FirstName = ui.FirstName,
-                                     LastName = ui.LastName,
-                                     Username = ui.Username
-                                 };
+                    {
+                        AuthorId = authorId,
+                        DisplayName = ui.DisplayName,
+                        Email = ui.Email,
+                        FirstName = ui.FirstName,
+                        LastName = ui.LastName,
+                        Username = ui.Username
+                    };
                     Email.SendEmail(fi.ModRejectTemplateId, PortalSettings.PortalId, _moduleId, _tabId, _forumId, _topicId, _replyId, string.Empty, au);
                 }
 
@@ -147,10 +147,10 @@ namespace DotNetNuke.Modules.ActiveForums
         {
             var notify = NotificationsController.Instance.GetNotification(dto.NotificationId);
             ParseNotificationContext(notify.Context);
-           
+
             var fc = new ForumController();
-            var fi = fc.Forums_Get(_forumId, -1, false, true);
-            
+            var fi = fc.Forums_Get(ActiveModule.PortalID, ActiveModule.ModuleID, _forumId, true);
+
             if (fi == null)
                 return Request.CreateResponse(HttpStatusCode.OK, new { Message = "Forum Not Found" });
 
@@ -185,7 +185,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 tc.Topics_Delete(PortalSettings.PortalId, _moduleId, _forumId, _topicId, ms.DeleteBehavior);
                 tc.UpdateModuleLastContentModifiedOnDate(_moduleId);
             }
-           
+
             if (fi.ModDeleteTemplateId > 0 && authorId > 0)
             {
                 var uc = new DotNetNuke.Entities.Users.UserController();
@@ -216,9 +216,9 @@ namespace DotNetNuke.Modules.ActiveForums
         {
             var notify = NotificationsController.Instance.GetNotification(dto.NotificationId);
             ParseNotificationContext(notify.Context);
-           
+
             var fc = new ForumController();
-            var fi = fc.Forums_Get(_forumId, -1, false, true);
+            var fi = fc.Forums_Get(ActiveModule.PortalID, ActiveModule.ModuleID, _forumId, true);
             if (fi == null)
                 return Request.CreateResponse(HttpStatusCode.OK, new { Message = "Forum Not Found" });
 
@@ -230,10 +230,10 @@ namespace DotNetNuke.Modules.ActiveForums
         }
 
         #region Private Methods
-        
+
         private bool IsMod(int forumId)
         {
-            var mods = Utilities.GetListOfModerators(PortalSettings.PortalId, forumId);
+            var mods = Utilities.GetListOfModerators(ActiveModule.PortalID, ActiveModule.ModuleID, forumId);
 
             return mods.Any(i => i.UserID == UserInfo.UserID);
         }

--- a/Dnn.CommunityForums/class/Email.cs
+++ b/Dnn.CommunityForums/class/Email.cs
@@ -22,7 +22,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Net.Mail;
 using System.Threading;
 using System.Web;
 using DotNetNuke.Common.Utilities;
@@ -34,69 +33,69 @@ using DotNetNuke.Security.Roles;
 
 namespace DotNetNuke.Modules.ActiveForums
 {
-	public class Email
-	{
-		public int PortalId;
-		public string Subject;
-		public string From;
-		public string BodyText;
-		public string BodyHTML;
+    public class Email
+    {
+        public int PortalId;
+        public string Subject;
+        public string From;
+        public string BodyText;
+        public string BodyHTML;
 
-		public List<SubscriptionInfo> Recipients;
-	
+        public List<SubscriptionInfo> Recipients;
+
         public bool UseQueue = false;
 
-		public static void SendEmail(int templateId, int portalId, int moduleId, int tabId, int forumId, int topicId, int replyId, string comments, Author author)
-		{
-			var portalSettings = (DotNetNuke.Entities.Portals.PortalSettings)(HttpContext.Current.Items["PortalSettings"]);
-			var mainSettings = SettingsBase.GetModuleSettings(moduleId);
-		    var sTemplate = string.Empty;
-			var tc = new TemplateController();
-			var ti = tc.Template_Get(templateId, portalId, moduleId);
-			var subject = TemplateUtils.ParseEmailTemplate(ti.Subject, string.Empty, portalId, moduleId, tabId, forumId, topicId, replyId, string.Empty, author.AuthorId, Utilities.GetCultureInfoForUser(portalId, author.AuthorId), Utilities.GetTimeZoneOffsetForUser(portalId, author.AuthorId));
-			var bodyText = TemplateUtils.ParseEmailTemplate(ti.TemplateText, string.Empty, portalId, moduleId, tabId, forumId, topicId, replyId, string.Empty, author.AuthorId, Utilities.GetCultureInfoForUser(portalId, author.AuthorId), Utilities.GetTimeZoneOffsetForUser(portalId, author.AuthorId));
-			var bodyHTML = TemplateUtils.ParseEmailTemplate(ti.TemplateHTML, string.Empty, portalId, moduleId, tabId, forumId, topicId, replyId, string.Empty, author.AuthorId, Utilities.GetCultureInfoForUser(portalId, author.AuthorId), Utilities.GetTimeZoneOffsetForUser(portalId, author.AuthorId));
-			bodyText = bodyText.Replace("[REASON]", comments);
-			bodyHTML = bodyHTML.Replace("[REASON]", comments);
-		    var fc = new ForumController();
-			var fi = fc.Forums_Get(forumId, -1, false, true);
-			var sFrom = fi.EmailAddress != string.Empty ? fi.EmailAddress : portalSettings.Email;
-			
+        public static void SendEmail(int templateId, int portalId, int moduleId, int tabId, int forumId, int topicId, int replyId, string comments, Author author)
+        {
+            var portalSettings = (DotNetNuke.Entities.Portals.PortalSettings)(HttpContext.Current.Items["PortalSettings"]);
+            var mainSettings = SettingsBase.GetModuleSettings(moduleId);
+            var sTemplate = string.Empty;
+            var tc = new TemplateController();
+            var ti = tc.Template_Get(templateId, portalId, moduleId);
+            var subject = TemplateUtils.ParseEmailTemplate(ti.Subject, string.Empty, portalId, moduleId, tabId, forumId, topicId, replyId, string.Empty, author.AuthorId, Utilities.GetCultureInfoForUser(portalId, author.AuthorId), Utilities.GetTimeZoneOffsetForUser(portalId, author.AuthorId));
+            var bodyText = TemplateUtils.ParseEmailTemplate(ti.TemplateText, string.Empty, portalId, moduleId, tabId, forumId, topicId, replyId, string.Empty, author.AuthorId, Utilities.GetCultureInfoForUser(portalId, author.AuthorId), Utilities.GetTimeZoneOffsetForUser(portalId, author.AuthorId));
+            var bodyHTML = TemplateUtils.ParseEmailTemplate(ti.TemplateHTML, string.Empty, portalId, moduleId, tabId, forumId, topicId, replyId, string.Empty, author.AuthorId, Utilities.GetCultureInfoForUser(portalId, author.AuthorId), Utilities.GetTimeZoneOffsetForUser(portalId, author.AuthorId));
+            bodyText = bodyText.Replace("[REASON]", comments);
+            bodyHTML = bodyHTML.Replace("[REASON]", comments);
+            var fc = new ForumController();
+            var fi = fc.Forums_Get(portalId: portalId, moduleId: moduleId, forumId: forumId, useCache: true);
+            var sFrom = fi.EmailAddress != string.Empty ? fi.EmailAddress : portalSettings.Email;
+
             //Send now
-			
+
             var oEmail = new Email();
-			var subs = new List<SubscriptionInfo>();
-			var si = new SubscriptionInfo
-			             {
-			                 DisplayName = author.DisplayName,
-			                 Email = author.Email,
-			                 FirstName = author.FirstName,
-			                 LastName = author.LastName,
-			                 UserId = author.AuthorId,
-			                 Username = author.Username
-			             };
+            var subs = new List<SubscriptionInfo>();
+            var si = new SubscriptionInfo
+            {
+                DisplayName = author.DisplayName,
+                Email = author.Email,
+                FirstName = author.FirstName,
+                LastName = author.LastName,
+                UserId = author.AuthorId,
+                Username = author.Username
+            };
 
-		    subs.Add(si);
-			oEmail.PortalId = portalId;
-			oEmail.UseQueue = mainSettings.MailQueue;
-			oEmail.Recipients = subs;
-			oEmail.Subject = subject;
-			oEmail.From = sFrom;
-			oEmail.BodyText = bodyText;
-			oEmail.BodyHTML = bodyHTML;
+            subs.Add(si);
+            oEmail.PortalId = portalId;
+            oEmail.UseQueue = mainSettings.MailQueue;
+            oEmail.Recipients = subs;
+            oEmail.Subject = subject;
+            oEmail.From = sFrom;
+            oEmail.BodyText = bodyText;
+            oEmail.BodyHTML = bodyHTML;
 
-			new Thread(oEmail.Send).Start();
-		}
+            new Thread(oEmail.Send).Start();
+        }
 
-		public static void SendEmailToModerators(int templateId, int portalId, int forumId, int topicId, int replyId, int moduleID, int tabID, string comments)
-		{
-			SendEmailToModerators(templateId, portalId, forumId, topicId, replyId, moduleID, tabID, comments, null);
-		}
+        public static void SendEmailToModerators(int templateId, int portalId, int forumId, int topicId, int replyId, int moduleID, int tabID, string comments)
+        {
+            SendEmailToModerators(templateId, portalId, forumId, topicId, replyId, moduleID, tabID, comments, null);
+        }
 
-		public static void SendEmailToModerators(int templateId, int portalId, int forumId, int topicId, int replyId, int moduleID, int tabID, string comments, UserInfo user)
+        public static void SendEmailToModerators(int templateId, int portalId, int forumId, int topicId, int replyId, int moduleID, int tabID, string comments, UserInfo user)
         {
             var fc = new ForumController();
-            var fi = fc.Forums_Get(forumId, -1, false, true);
+            var fi = fc.Forums_Get(portalId: portalId, moduleId: moduleID, forumId: forumId, useCache: true);
             if (fi == null)
                 return;
 
@@ -114,17 +113,17 @@ namespace DotNetNuke.Modules.ActiveForums
                 foreach (UserRoleInfo usr in rp.GetUserRoles(portalId, null, rName))
                 {
                     var ui = uc.GetUser(portalId, usr.UserID);
-					var si = new SubscriptionInfo
-					{
-						UserId = ui.UserID,
-						DisplayName = ui.DisplayName,
-						Email = ui.Email,
-						FirstName = ui.FirstName,
-						LastName = ui.LastName,
-						TimeZoneOffSet = Utilities.GetTimeZoneOffsetForUser(portalId, ui.UserID),
-						UserCulture = Utilities.GetCultureInfoForUser(portalId, ui.UserID),
-						TopicSubscriber = false
-					};
+                    var si = new SubscriptionInfo
+                    {
+                        UserId = ui.UserID,
+                        DisplayName = ui.DisplayName,
+                        Email = ui.Email,
+                        FirstName = ui.FirstName,
+                        LastName = ui.LastName,
+                        TimeZoneOffSet = Utilities.GetTimeZoneOffsetForUser(portalId, ui.UserID),
+                        UserCulture = Utilities.GetCultureInfoForUser(portalId, ui.UserID),
+                        TopicSubscriber = false
+                    };
                     if (!(subs.Contains(si)))
                     {
                         subs.Add(si);
@@ -133,25 +132,25 @@ namespace DotNetNuke.Modules.ActiveForums
             }
             if (subs.Count > 0)
             {
-				SendTemplatedEmail(templateId, portalId, topicId, replyId, moduleID, tabID, comments, user.UserID, fi, subs);
-			}
+                SendTemplatedEmail(templateId, portalId, topicId, replyId, moduleID, tabID, comments, user.UserID, fi, subs);
+            }
         }
-		public static void SendTemplatedEmail(int templateId, int portalId, int topicId, int replyId, int moduleID, int tabID, string comments, int userId, Forum fi, List<SubscriptionInfo> subs)
-		{
-			PortalSettings portalSettings = (DotNetNuke.Entities.Portals.PortalSettings)(HttpContext.Current.Items["PortalSettings"]);
-			SettingsInfo mainSettings = SettingsBase.GetModuleSettings(moduleID);
+        public static void SendTemplatedEmail(int templateId, int portalId, int topicId, int replyId, int moduleID, int tabID, string comments, int userId, Forum fi, List<SubscriptionInfo> subs)
+        {
+            PortalSettings portalSettings = (DotNetNuke.Entities.Portals.PortalSettings)(HttpContext.Current.Items["PortalSettings"]);
+            SettingsInfo mainSettings = SettingsBase.GetModuleSettings(moduleID);
 
-			TemplateController tc = new TemplateController();
-			TemplateUtils.lstSubscriptionInfo = subs;
-			TemplateInfo ti = templateId > 0 ? tc.Template_Get(templateId) : tc.Template_Get("SubscribedEmail", portalId, moduleID);
-			IEnumerable<CultureInfo> userCultures = subs.Select(s => s.UserCulture).Distinct();
-			foreach (CultureInfo userCulture in userCultures)
-			{
-				IEnumerable<TimeSpan> timeZoneOffsets = subs.Where(s=>s.UserCulture == userCulture).Select(s => s.TimeZoneOffSet).Distinct();
-				foreach (TimeSpan timeZoneOffset in timeZoneOffsets)
-				{
-					string sTemplate = string.Empty;
-					string sFrom = fi.EmailAddress != string.Empty ? fi.EmailAddress : portalSettings.Email;
+            TemplateController tc = new TemplateController();
+            TemplateUtils.lstSubscriptionInfo = subs;
+            TemplateInfo ti = templateId > 0 ? tc.Template_Get(templateId) : tc.Template_Get("SubscribedEmail", portalId, moduleID);
+            IEnumerable<CultureInfo> userCultures = subs.Select(s => s.UserCulture).Distinct();
+            foreach (CultureInfo userCulture in userCultures)
+            {
+                IEnumerable<TimeSpan> timeZoneOffsets = subs.Where(s => s.UserCulture == userCulture).Select(s => s.TimeZoneOffSet).Distinct();
+                foreach (TimeSpan timeZoneOffset in timeZoneOffsets)
+                {
+                    string sTemplate = string.Empty;
+                    string sFrom = fi.EmailAddress != string.Empty ? fi.EmailAddress : portalSettings.Email;
                     /* subject/text/body, etc. can now be different based on topic subscriber vs forum subscriber so process first for topic subscribers and then for forum subscribers */
                     Email oEmail = new Email /* subject can be different based on topic subscriber vs forum subscriber so process first for topic subscribers and then for forum subscribers */
                     {
@@ -163,10 +162,10 @@ namespace DotNetNuke.Modules.ActiveForums
                         From = sFrom,
                         UseQueue = mainSettings.MailQueue
                     };
-					if (oEmail.Recipients.Count > 0)
-					{
-						new System.Threading.Thread(oEmail.Send).Start();
-					}
+                    if (oEmail.Recipients.Count > 0)
+                    {
+                        new System.Threading.Thread(oEmail.Send).Start();
+                    }
                     oEmail = new Email /* subject can be different based on topic subscriber vs forum subscriber so process first for topic subscribers and then for forum subscribers */
                     {
                         PortalId = portalId,
@@ -183,143 +182,143 @@ namespace DotNetNuke.Modules.ActiveForums
                     }
 
                 }
-            } 
-       
-		}
+            }
 
-		/* 
+        }
+
+        /* 
          * Note: This is the method that actual sends the email.  The mail queue  
          */
-		public static void SendNotification(string fromEmail, string toEmail, string subject, string bodyText, string bodyHTML)
-		{
-			SendNotification(-1, fromEmail, toEmail, subject, bodyText, bodyHTML);
-		}
+        public static void SendNotification(string fromEmail, string toEmail, string subject, string bodyText, string bodyHTML)
+        {
+            SendNotification(-1, fromEmail, toEmail, subject, bodyText, bodyHTML);
+        }
 
-		public static void SendNotification(int portalId, string fromEmail, string toEmail, string subject, string bodyText, string bodyHTML)
-		{
+        public static void SendNotification(int portalId, string fromEmail, string toEmail, string subject, string bodyText, string bodyHTML)
+        {
             //USE DNN API for this to ensure proper delivery & adherence to portal settings
             //Services.Mail.Mail.SendEmail(fromEmail, fromEmail, toEmail, subject, bodyHTML);
 
             //Since this code is triggered from the DNN scheduler, the default/simple API (now commented out above) uses Host rather than Portal-specific SMTP configuration
             //updated here to retrieve portal-specific SMTP configuration and use more elaborate DNN API that allows passing of the SMTP information rather than rely on DNN API DotNetNuke.Host.SMTP property accessors to determine portal vs. host SMTP values 
             DotNetNuke.Services.Mail.Mail.SendMail(mailFrom: fromEmail,
-										mailSender: (SMTPPortalEnabled(portalId) ? PortalController.Instance.GetPortal(portalId).Email : Host.HostEmail),
-										mailTo: toEmail,
-										cc: string.Empty,
-										bcc: string.Empty,
-										replyTo: string.Empty,
-										priority: DotNetNuke.Services.Mail.MailPriority.Normal,
-										subject: subject,
-										bodyFormat: DotNetNuke.Services.Mail.MailFormat.Html,
-										bodyEncoding: System.Text.Encoding.Default,
-										body: bodyHTML,
-										attachments: new List<System.Net.Mail.Attachment>(),
-										smtpServer: SMTPServer(portalId),
-										smtpAuthentication: SMTPAuthentication(portalId),
-										smtpUsername: SMTPUsername(portalId),
-										smtpPassword: SMTPPassword(portalId),
-										smtpEnableSSL: EnableSMTPSSL(portalId));
-		}
+                                        mailSender: (SMTPPortalEnabled(portalId) ? PortalController.Instance.GetPortal(portalId).Email : Host.HostEmail),
+                                        mailTo: toEmail,
+                                        cc: string.Empty,
+                                        bcc: string.Empty,
+                                        replyTo: string.Empty,
+                                        priority: DotNetNuke.Services.Mail.MailPriority.Normal,
+                                        subject: subject,
+                                        bodyFormat: DotNetNuke.Services.Mail.MailFormat.Html,
+                                        bodyEncoding: System.Text.Encoding.Default,
+                                        body: bodyHTML,
+                                        attachments: new List<System.Net.Mail.Attachment>(),
+                                        smtpServer: SMTPServer(portalId),
+                                        smtpAuthentication: SMTPAuthentication(portalId),
+                                        smtpUsername: SMTPUsername(portalId),
+                                        smtpPassword: SMTPPassword(portalId),
+                                        smtpEnableSSL: EnableSMTPSSL(portalId));
+        }
 
-		public void Send()
-		{
-			try
-			{
-				Subject = Subject.Replace("&#91;", "[");
-				Subject = Subject.Replace("&#93;", "]");
+        public void Send()
+        {
+            try
+            {
+                Subject = Subject.Replace("&#91;", "[");
+                Subject = Subject.Replace("&#93;", "]");
 
                 foreach (var si in Recipients.Where(si => si.Email != string.Empty))
-				{
-					if(UseQueue)
-					    Queue.Controller.Add(PortalId, From, si.Email, Subject, BodyHTML, BodyText, string.Empty, string.Empty);
+                {
+                    if (UseQueue)
+                        Queue.Controller.Add(PortalId, From, si.Email, Subject, BodyHTML, BodyText, string.Empty, string.Empty);
                     else
-                        SendNotification(PortalId, From, si.Email, Subject, BodyText, BodyHTML); 
-				}
+                        SendNotification(PortalId, From, si.Email, Subject, BodyText, BodyHTML);
+                }
             }
-			catch (Exception ex)
-			{
+            catch (Exception ex)
+            {
                 DotNetNuke.Services.Exceptions.Exceptions.LogException(ex);
-			}
-		}
+            }
+        }
 
-		#region "code modeled on DotNetNuke.Services.Mail/DotNetNuke.Entities.Host APIs to support portal-specific SMTP configuration"
-		internal static string SMTPServer(int portalId)
-		{
-			return GetSmtpSetting(portalId, "SMTPServer");
-		}
-		internal static string SMTPAuthentication(int portalId)
-		{
-			return GetSmtpSetting(portalId, "SMTPAuthentication");
-		}
-		internal static bool EnableSMTPSSL(int portalId)
-		{
-			if (SMTPPortalEnabled(portalId))
-			{
-				return PortalController.GetPortalSettingAsBoolean("SMTPEnableSSL", portalId, false);
-			}
-			else
-			{
-				return HostController.Instance.GetBoolean("SMTPEnableSSL", false);
-			}
-		}
-		internal static string SMTPUsername(int portalId)
-		{
-			return GetSmtpSetting(portalId, "SMTPUsername");
-		}
-		internal static string SMTPPassword(int portalId)
-		{
-			if (SMTPPortalEnabled(portalId))
-			{
-				return PortalController.GetEncryptedString("SMTPPassword", portalId, Config.GetDecryptionkey());
-			}
-			else
-			{
-				string decryptedText;
-				try
-				{
-					decryptedText = HostController.Instance.GetEncryptedString("SMTPPassword", Config.GetDecryptionkey());
-				}
-				catch (Exception)
-				{
-					//fixes case where smtppassword failed to encrypt due to failing upgrade
-					var current = HostController.Instance.GetString("SMTPPassword");
-					if (!string.IsNullOrEmpty(current))
-					{
-						HostController.Instance.UpdateEncryptedString("SMTPPassword", current, Config.GetDecryptionkey());
-						decryptedText = current;
-					}
-					else
-					{
-						decryptedText = string.Empty;
-					}
-				}
-				return decryptedText;
-			}
-		}
-
-		internal static bool SMTPPortalEnabled(int portalId)
-		{
-			if (portalId != null && portalId != -1)
-			{
-				return PortalController.GetPortalSetting("SMTPmode", portalId, Null.NullString).Equals("P", StringComparison.OrdinalIgnoreCase);
-			}
-			else 
-			{ 
-				return false; 
-			}
-		}
-
-		internal static string GetSmtpSetting(int portalId, string settingName)
-		{
-			if (SMTPPortalEnabled(portalId))
-			{
-				return PortalController.GetPortalSetting(settingName, portalId, Null.NullString);
-			}
+        #region "code modeled on DotNetNuke.Services.Mail/DotNetNuke.Entities.Host APIs to support portal-specific SMTP configuration"
+        internal static string SMTPServer(int portalId)
+        {
+            return GetSmtpSetting(portalId, "SMTPServer");
+        }
+        internal static string SMTPAuthentication(int portalId)
+        {
+            return GetSmtpSetting(portalId, "SMTPAuthentication");
+        }
+        internal static bool EnableSMTPSSL(int portalId)
+        {
+            if (SMTPPortalEnabled(portalId))
+            {
+                return PortalController.GetPortalSettingAsBoolean("SMTPEnableSSL", portalId, false);
+            }
             else
             {
-				return HostController.Instance.GetString(settingName);
-			}
-		}
+                return HostController.Instance.GetBoolean("SMTPEnableSSL", false);
+            }
+        }
+        internal static string SMTPUsername(int portalId)
+        {
+            return GetSmtpSetting(portalId, "SMTPUsername");
+        }
+        internal static string SMTPPassword(int portalId)
+        {
+            if (SMTPPortalEnabled(portalId))
+            {
+                return PortalController.GetEncryptedString("SMTPPassword", portalId, Config.GetDecryptionkey());
+            }
+            else
+            {
+                string decryptedText;
+                try
+                {
+                    decryptedText = HostController.Instance.GetEncryptedString("SMTPPassword", Config.GetDecryptionkey());
+                }
+                catch (Exception)
+                {
+                    //fixes case where smtppassword failed to encrypt due to failing upgrade
+                    var current = HostController.Instance.GetString("SMTPPassword");
+                    if (!string.IsNullOrEmpty(current))
+                    {
+                        HostController.Instance.UpdateEncryptedString("SMTPPassword", current, Config.GetDecryptionkey());
+                        decryptedText = current;
+                    }
+                    else
+                    {
+                        decryptedText = string.Empty;
+                    }
+                }
+                return decryptedText;
+            }
+        }
+
+        internal static bool SMTPPortalEnabled(int portalId)
+        {
+            if (portalId != null && portalId != -1)
+            {
+                return PortalController.GetPortalSetting("SMTPmode", portalId, Null.NullString).Equals("P", StringComparison.OrdinalIgnoreCase);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        internal static string GetSmtpSetting(int portalId, string settingName)
+        {
+            if (SMTPPortalEnabled(portalId))
+            {
+                return PortalController.GetPortalSetting(settingName, portalId, Null.NullString);
+            }
+            else
+            {
+                return HostController.Instance.GetString(settingName);
+            }
+        }
         #endregion
     }
 }

--- a/Dnn.CommunityForums/class/ForumBase.cs
+++ b/Dnn.CommunityForums/class/ForumBase.cs
@@ -425,7 +425,7 @@ namespace DotNetNuke.Modules.ActiveForums
         {
             get 
             {
-                return _foruminfo ?? (_foruminfo = ForumController.Forums_Get(PortalId, ForumModuleId, ForumId, UserId, true, true, TopicId));
+                return _foruminfo ?? (_foruminfo = ForumController.Forums_Get(PortalId, ForumModuleId, ForumId, true, TopicId));
             }
             set
             {

--- a/Dnn.CommunityForums/class/ForumController.cs
+++ b/Dnn.CommunityForums/class/ForumController.cs
@@ -20,496 +20,473 @@
 
 using System;
 using System.Data;
-using System.Text;
 using System.IO;
+using System.Text;
 using System.Xml;
 using DotNetNuke.Modules.ActiveForums.Data;
 using DotNetNuke.Security.Roles;
-using System.Text.RegularExpressions;
-using System.Reflection;
 
 namespace DotNetNuke.Modules.ActiveForums
 {
 
-	public class ForumController
-	{
-		private ForumsDB _forumDB;
-		internal ForumsDB ForumsDB
-		{
-			get { return _forumDB ?? (_forumDB = new ForumsDB()); }
-		}
+    public class ForumController
+    {
+        private ForumsDB _forumDB;
+        internal ForumsDB ForumsDB
+        {
+            get { return _forumDB ?? (_forumDB = new ForumsDB()); }
+        }
 
-		public string GetForumsForUser(string userRoles, int portalId, int moduleId, string permissionType = "CanView", bool strict = false)
-		{
-			// Setting strict to true enforces the actual permission
-			// If strict is false, forums will show up in the list if they are not hidden for users
-			// that don't otherwise have access
+        public string GetForumsForUser(string userRoles, int portalId, int moduleId, string permissionType = "CanView", bool strict = false)
+        {
+            // Setting strict to true enforces the actual permission
+            // If strict is false, forums will show up in the list if they are not hidden for users
+            // that don't otherwise have access
 
-			var forumIds = string.Empty;
-			var fc = ForumsDB.Forums_List(portalId, moduleId);
-			foreach (Forum f in fc)
-			{
-				string roles;
-				switch (permissionType)
-				{
-					case "CanView":
-						roles = f.Security.View;
-						break;
-					case "CanRead":
-						roles = f.Security.Read;
-						break;
-					case "CanApprove":
-						roles = f.Security.ModApprove;
-						break;
-					case "CanEdit":
-						roles = f.Security.ModEdit;
-						break;
-					default:
-						roles = f.Security.View;
-						break;
-				}
+            var forumIds = string.Empty;
+            var fc = ForumsDB.Forums_List(portalId, moduleId);
+            foreach (Forum f in fc)
+            {
+                string roles;
+                switch (permissionType)
+                {
+                    case "CanView":
+                        roles = f.Security.View;
+                        break;
+                    case "CanRead":
+                        roles = f.Security.Read;
+                        break;
+                    case "CanApprove":
+                        roles = f.Security.ModApprove;
+                        break;
+                    case "CanEdit":
+                        roles = f.Security.ModEdit;
+                        break;
+                    default:
+                        roles = f.Security.View;
+                        break;
+                }
 
-				var hasPermissions = Permissions.HasPerm(roles, userRoles);
+                var hasPermissions = Permissions.HasPerm(roles, userRoles);
 
-				if ((hasPermissions || (!strict && !f.Hidden && (permissionType == "CanView" || permissionType == "CanRead"))) && f.Active)
-				{
-					forumIds += string.Concat(f.ForumID, ";");
-				}
-			}
+                if ((hasPermissions || (!strict && !f.Hidden && (permissionType == "CanView" || permissionType == "CanRead"))) && f.Active)
+                {
+                    forumIds += string.Concat(f.ForumID, ";");
+                }
+            }
 
-			return forumIds;
-		}
+            return forumIds;
+        }
 
-		public Forum GetForum(int portalId, int moduleId, int forumId)
-		{
-			return GetForum(portalId, moduleId, forumId, false);
-		}
+        public Forum GetForum(int portalId, int moduleId, int forumId)
+        {
+            return GetForum(portalId, moduleId, forumId, false);
+        }
 
-		public Forum GetForum(int portalId, int moduleId, int forumId, bool ignoreCache)
-		{
+        public Forum GetForum(int portalId, int moduleId, int forumId, bool ignoreCache)
+        {
 
-			var cachekey = string.Format(CacheKeys.ForumInfo, moduleId, forumId);
-			var forum = DataCache.SettingsCacheRetrieve(moduleId, cachekey) as Forum;
-			if (forum == null || ignoreCache)
-			{
-				using (var dr = ForumsDB.Forums_Get(portalId, moduleId, forumId))
-				{
-					while (dr.Read())
-					{
-						forum = FillForum(dr);
-					}
-					dr.Close();
-				}
-				if (forum != null)
-				{
-					if (forum.HasProperties)
-					{
-						var propC = new PropertiesController();
-						forum.Properties = propC.ListProperties(portalId, 1, forumId);
-					}
+            var cachekey = string.Format(CacheKeys.ForumInfo, moduleId, forumId);
+            var forum = DataCache.SettingsCacheRetrieve(moduleId, cachekey) as Forum;
+            if (forum == null || ignoreCache)
+            {
+                using (var dr = ForumsDB.Forums_Get(portalId, moduleId, forumId))
+                {
+                    while (dr.Read())
+                    {
+                        forum = FillForum(dr);
+                    }
+                    dr.Close();
+                }
+                if (forum != null)
+                {
+                    if (forum.HasProperties)
+                    {
+                        var propC = new PropertiesController();
+                        forum.Properties = propC.ListProperties(portalId, 1, forumId);
+                    }
 
-				}
+                }
                 forum.ForumSettings = DataCache.GetSettings(moduleId, forum.ForumSettingsKey, string.Format(CacheKeys.ForumSettingsByKey, moduleId, forum.ForumSettingsKey), !ignoreCache);
                 DataCache.SettingsCacheStore(moduleId, cachekey, forum);
-			}
-			return forum;
-		}
+            }
+            return forum;
+        }
 
-		private static Forum FillForum(IDataRecord dr)
-		{
-			var fi = new Forum
-			{
-				ForumGroup = new ForumGroupInfo(),
-				ForumID = Convert.ToInt32(dr["ForumId"].ToString()),
-				Active = Convert.ToBoolean(dr["Active"]),
-				ModuleId = Convert.ToInt32(dr["ModuleId"].ToString()),
-				ForumGroupId = Convert.ToInt32(dr["ForumGroupId"].ToString()),
-				ParentForumId = Convert.ToInt32(dr["ParentForumId"].ToString()),
-				ForumName = dr["ForumName"].ToString(),
-				ForumDesc = dr["ForumDesc"].ToString(),
-				SortOrder = Convert.ToInt32(dr["SortOrder"].ToString()),
-				Hidden = Convert.ToBoolean(dr["Hidden"]),
-				TotalTopics = Convert.ToInt32(dr["TotalTopics"].ToString()),
-				TotalReplies = Convert.ToInt32(dr["TotalReplies"].ToString()),
-				LastTopicId = Convert.ToInt32(dr["LastTopicId"].ToString()),
-				LastReplyId = Convert.ToInt32(dr["LastReplyId"].ToString()),
-				GroupName = dr["GroupName"].ToString(),
-				PermissionsId = Convert.ToInt32(dr["PermissionsId"].ToString()),
-				ForumSettingsKey = dr["ForumSettingsKey"].ToString(),
-				InheritSecurity = Convert.ToBoolean(dr["InheritSecurity"]),
-				PrefixURL = dr["PrefixURL"].ToString(),
-				SocialGroupId = Convert.ToInt32(dr["SocialGroupId"].ToString()),
-				HasProperties = Convert.ToBoolean(dr["HasProperties"])
-			};
+        private static Forum FillForum(IDataRecord dr)
+        {
+            var fi = new Forum
+            {
+                ForumGroup = new ForumGroupInfo(),
+                ForumID = Convert.ToInt32(dr["ForumId"].ToString()),
+                Active = Convert.ToBoolean(dr["Active"]),
+                ModuleId = Convert.ToInt32(dr["ModuleId"].ToString()),
+                ForumGroupId = Convert.ToInt32(dr["ForumGroupId"].ToString()),
+                ParentForumId = Convert.ToInt32(dr["ParentForumId"].ToString()),
+                ForumName = dr["ForumName"].ToString(),
+                ForumDesc = dr["ForumDesc"].ToString(),
+                SortOrder = Convert.ToInt32(dr["SortOrder"].ToString()),
+                Hidden = Convert.ToBoolean(dr["Hidden"]),
+                TotalTopics = Convert.ToInt32(dr["TotalTopics"].ToString()),
+                TotalReplies = Convert.ToInt32(dr["TotalReplies"].ToString()),
+                LastTopicId = Convert.ToInt32(dr["LastTopicId"].ToString()),
+                LastReplyId = Convert.ToInt32(dr["LastReplyId"].ToString()),
+                GroupName = dr["GroupName"].ToString(),
+                PermissionsId = Convert.ToInt32(dr["PermissionsId"].ToString()),
+                ForumSettingsKey = dr["ForumSettingsKey"].ToString(),
+                InheritSecurity = Convert.ToBoolean(dr["InheritSecurity"]),
+                PrefixURL = dr["PrefixURL"].ToString(),
+                SocialGroupId = Convert.ToInt32(dr["SocialGroupId"].ToString()),
+                HasProperties = Convert.ToBoolean(dr["HasProperties"])
+            };
 
-			fi.ForumGroup.ForumGroupId = fi.ForumGroupId;
-			fi.ForumGroup.GroupName = fi.GroupName;
-			fi.ForumGroup.PrefixURL = dr["GroupPrefixURL"].ToString();
-			fi.Security.Announce = dr["CanAnnounce"].ToString();
-			fi.Security.Attach = dr["CanAttach"].ToString();
-			fi.Security.Create = dr["CanCreate"].ToString();
-			fi.Security.Delete = dr["CanDelete"].ToString();
-			fi.Security.Edit = dr["CanEdit"].ToString();
-			fi.Security.Lock = dr["CanLock"].ToString();
-			fi.Security.ModApprove = dr["CanModApprove"].ToString();
-			fi.Security.ModDelete = dr["CanModDelete"].ToString();
-			fi.Security.ModEdit = dr["CanModEdit"].ToString();
-			fi.Security.ModLock = dr["CanModLock"].ToString();
-			fi.Security.ModMove = dr["CanModMove"].ToString();
-			fi.Security.ModPin = dr["CanModPin"].ToString();
-			fi.Security.ModSplit = dr["CanModSplit"].ToString();
-			fi.Security.ModUser = dr["CanModUser"].ToString();
-			fi.Security.Pin = dr["CanPin"].ToString();
-			fi.Security.Poll = dr["CanPoll"].ToString();
-			fi.Security.Block = dr["CanBlock"].ToString();
-			fi.Security.Read = dr["CanRead"].ToString();
-			fi.Security.Reply = dr["CanReply"].ToString();
-			fi.Security.Subscribe = dr["CanSubscribe"].ToString();
-			fi.Security.Trust = dr["CanTrust"].ToString();
-			fi.Security.View = dr["CanView"].ToString();
-			fi.Security.Tag = dr["CanTag"].ToString();
-			fi.Security.Prioritize = dr["CanPrioritize"].ToString();
-			fi.Security.Categorize = dr["CanCategorize"].ToString();
+            fi.ForumGroup.ForumGroupId = fi.ForumGroupId;
+            fi.ForumGroup.GroupName = fi.GroupName;
+            fi.ForumGroup.PrefixURL = dr["GroupPrefixURL"].ToString();
+            fi.Security.Announce = dr["CanAnnounce"].ToString();
+            fi.Security.Attach = dr["CanAttach"].ToString();
+            fi.Security.Create = dr["CanCreate"].ToString();
+            fi.Security.Delete = dr["CanDelete"].ToString();
+            fi.Security.Edit = dr["CanEdit"].ToString();
+            fi.Security.Lock = dr["CanLock"].ToString();
+            fi.Security.ModApprove = dr["CanModApprove"].ToString();
+            fi.Security.ModDelete = dr["CanModDelete"].ToString();
+            fi.Security.ModEdit = dr["CanModEdit"].ToString();
+            fi.Security.ModLock = dr["CanModLock"].ToString();
+            fi.Security.ModMove = dr["CanModMove"].ToString();
+            fi.Security.ModPin = dr["CanModPin"].ToString();
+            fi.Security.ModSplit = dr["CanModSplit"].ToString();
+            fi.Security.ModUser = dr["CanModUser"].ToString();
+            fi.Security.Pin = dr["CanPin"].ToString();
+            fi.Security.Poll = dr["CanPoll"].ToString();
+            fi.Security.Block = dr["CanBlock"].ToString();
+            fi.Security.Read = dr["CanRead"].ToString();
+            fi.Security.Reply = dr["CanReply"].ToString();
+            fi.Security.Subscribe = dr["CanSubscribe"].ToString();
+            fi.Security.Trust = dr["CanTrust"].ToString();
+            fi.Security.View = dr["CanView"].ToString();
+            fi.Security.Tag = dr["CanTag"].ToString();
+            fi.Security.Prioritize = dr["CanPrioritize"].ToString();
+            fi.Security.Categorize = dr["CanCategorize"].ToString();
 
-			return fi;
-		}
+            return fi;
+        }
 
-		public string GetForumIdsBySocialGroup(int portalId, int socialGroupId)
-		{
-			var forumIds = string.Empty;
-			using (var dr = ForumsDB.Forums_GetForSocialGroup(portalId, socialGroupId))
-			{
-				while (dr.Read())
-				{
-					forumIds += string.Concat(dr["ForumId"], ";");
-				}
-				dr.Close();
-			}
-			return forumIds;
-		}
+        public string GetForumIdsBySocialGroup(int portalId, int socialGroupId)
+        {
+            var forumIds = string.Empty;
+            using (var dr = ForumsDB.Forums_GetForSocialGroup(portalId, socialGroupId))
+            {
+                while (dr.Read())
+                {
+                    forumIds += string.Concat(dr["ForumId"], ";");
+                }
+                dr.Close();
+            }
+            return forumIds;
+        }
+        internal Forum Forums_Get(int portalId, int moduleId, int forumId, bool useCache)
+        {
+            return Forums_Get(portalId, moduleId, forumId, useCache, -1);
+        }
+        internal Forum Forums_Get(int portalId, int moduleId, int forumId, bool useCache, int topicId)
+        {
+            if (forumId <= 0 && topicId <= 0)
+            {
+                return null;
+            }
 
-		internal int Forums_GetGroupId(int forumId)
-		{
-			var fi = Forums_Get(forumId, -1, false);
-			return fi.ForumGroupId;
-		}
+            // Get the forum by topic id
+            if (topicId > 0 & forumId <= 0)
+            {
+                forumId = ForumsDB.Forum_GetByTopicId(topicId);
+            }
 
-		internal Forum Forums_Get(int forumId, int userId, bool withSecurity, bool useCache)
-		{
-			return Forums_Get(-1, -1, forumId, userId, withSecurity, useCache, -1);
-		}
+            return forumId <= 0 ? null : GetForum(portalId, moduleId, forumId, !useCache);
+        }
+        public int Forums_Save(int portalId, Forum fi, bool isNew, bool useGroup)
+        {
+            var rc = new RoleController();
+            var db = new Data.Common();
+            var permissionsId = -1;
+            if (useGroup && (string.IsNullOrEmpty(fi.ForumSettingsKey) || fi.PermissionsId == -1))
+            {
+                var fc = new ForumGroupController();
+                var fg = fc.Groups_Get(fi.ModuleId, fi.ForumGroupId);
+                if (fg != null)
+                {
+                    fi.ForumSettingsKey = fg.GroupSettingsKey;
+                    //fi.ModuleId = fg.ModuleId
+                    fi.PermissionsId = fg.PermissionsId;
+                }
+            }
+            else if (fi.PermissionsId <= 0 && useGroup == false)
+            {
+                var ri = rc.GetRoleByName(portalId, "Administrators");
+                if (ri != null)
+                {
+                    fi.PermissionsId = db.CreatePermSet(ri.RoleID.ToString());
+                    permissionsId = fi.PermissionsId;
+                    isNew = true;
+                }
+                if (fi.ForumID > 0 & !(string.IsNullOrEmpty(fi.ForumSettingsKey)))
+                {
+                    if (fi.ForumSettingsKey.Contains("G:"))
+                        fi.ForumSettingsKey = string.Empty;
+                }
+                if (fi.ForumSettingsKey == "" && fi.ForumID > 0)
+                {
+                    fi.ForumSettingsKey = string.Concat("F:", fi.ForumID);
+                }
+            }
+            else if (useGroup == false && string.IsNullOrEmpty(fi.ForumSettingsKey) && fi.ForumID > 0)
+            {
+                fi.ForumSettingsKey = string.Concat("F:", fi.ForumID);
+            }
 
-		internal Forum Forums_Get(int forumId, int userId, bool withSecurity)
-		{
-			return Forums_Get(-1, -1, forumId, userId, withSecurity, false, -1);
-		}
+            var forumId = Convert.ToInt32(DataProvider.Instance().Forum_Save(portalId, fi.ForumID, fi.ModuleId, fi.ForumGroupId, fi.ParentForumId, fi.ForumName, fi.ForumDesc, fi.SortOrder, fi.Active, fi.Hidden, fi.ForumSettingsKey, fi.PermissionsId, fi.PrefixURL, fi.SocialGroupId, fi.HasProperties));
+            if (String.IsNullOrEmpty(fi.ForumSettingsKey))
+                fi.ForumSettingsKey = string.Concat("F:", forumId);
 
-		internal Forum Forums_Get(int portalId, int moduleId, int forumId, int userId, bool withSecurity, bool useCache, int topicId)
-		{
-			Forum fi = null;
+            if (fi.ForumSettingsKey.Contains("G:"))
+                DataProvider.Instance().Forum_ConfigCleanUp(fi.ModuleId, string.Concat("F:", fi.ForumID), string.Concat("F:", fi.ForumID));
 
-			if (forumId <= 0 && topicId <= 0)
-				return null;
+            if (isNew && useGroup == false)
+            {
+                Permissions.CreateDefaultSets(portalId, permissionsId);
 
-			// Get the forum by topic id
-			if (topicId > 0 & forumId <= 0)
-				forumId = ForumsDB.Forum_GetByTopicId(topicId);
+                var sKey = "F:" + forumId.ToString();
+                Settings.SaveSetting(fi.ModuleId, sKey, ForumSettingKeys.TopicsTemplateId, "0");
+                Settings.SaveSetting(fi.ModuleId, sKey, ForumSettingKeys.TopicTemplateId, "0");
+                Settings.SaveSetting(fi.ModuleId, sKey, ForumSettingKeys.TopicFormId, "0");
+                Settings.SaveSetting(fi.ModuleId, sKey, ForumSettingKeys.ReplyFormId, "0");
+                Settings.SaveSetting(fi.ModuleId, sKey, ForumSettingKeys.AllowRSS, "false");
+            }
 
-			if (forumId <= 0)
-				return null;
-
-			fi = (Forum)DataCache.SettingsCacheRetrieve(moduleId, string.Format(CacheKeys.ForumInfo, moduleId, forumId));
-			if (fi == null)
-			{ 
-				fi = GetForum(portalId, moduleId, forumId, !useCache);
-				
-                DataCache.SettingsCacheStore(moduleId, string.Format(CacheKeys.ForumInfo, moduleId, forumId), fi);
-            }	
-			return fi;
-		}
-		public int Forums_Save(int portalId, Forum fi, bool isNew, bool useGroup)
-		{
-			var rc = new RoleController();
-		    var db = new Data.Common();
-			var permissionsId = -1;
-			if (useGroup && (string.IsNullOrEmpty(fi.ForumSettingsKey) || fi.PermissionsId == -1))
-			{
-				var fc = new ForumGroupController();
-				var fg = fc.Groups_Get(fi.ModuleId, fi.ForumGroupId);
-				if (fg != null)
-				{
-					fi.ForumSettingsKey = fg.GroupSettingsKey;
-					//fi.ModuleId = fg.ModuleId
-					fi.PermissionsId = fg.PermissionsId;
-				}
-			}
-			else if (fi.PermissionsId <= 0 && useGroup == false)
-			{
-				var ri = rc.GetRoleByName(portalId,"Administrators");
-				if (ri != null)
-				{
-					fi.PermissionsId = db.CreatePermSet(ri.RoleID.ToString());
-					permissionsId = fi.PermissionsId;
-					isNew = true;
-				}
-				if (fi.ForumID > 0 & ! (string.IsNullOrEmpty(fi.ForumSettingsKey)))
-				{
-					if (fi.ForumSettingsKey.Contains("G:"))
-						fi.ForumSettingsKey = string.Empty;
-				}
-				if (fi.ForumSettingsKey == "" && fi.ForumID > 0)
-				{
-					fi.ForumSettingsKey = string.Concat("F:", fi.ForumID);
-				}
-			}
-			else if (useGroup == false && string.IsNullOrEmpty(fi.ForumSettingsKey) && fi.ForumID > 0)
-			{
-				fi.ForumSettingsKey = string.Concat("F:", fi.ForumID);
-			}
-
-			var forumId = Convert.ToInt32(DataProvider.Instance().Forum_Save(portalId, fi.ForumID, fi.ModuleId, fi.ForumGroupId, fi.ParentForumId, fi.ForumName, fi.ForumDesc, fi.SortOrder, fi.Active, fi.Hidden, fi.ForumSettingsKey, fi.PermissionsId, fi.PrefixURL, fi.SocialGroupId, fi.HasProperties));
-			if (String.IsNullOrEmpty(fi.ForumSettingsKey))
-				fi.ForumSettingsKey = string.Concat("F:", forumId);
-
-			if (fi.ForumSettingsKey.Contains("G:"))
-			    DataProvider.Instance().Forum_ConfigCleanUp(fi.ModuleId, string.Concat("F:", fi.ForumID), string.Concat("F:", fi.ForumID));
-
-			if (isNew && useGroup == false)
-			{
-				Permissions.CreateDefaultSets(portalId, permissionsId);
-
-				var sKey = "F:" + forumId.ToString();
-				Settings.SaveSetting(fi.ModuleId, sKey, ForumSettingKeys.TopicsTemplateId, "0");
-				Settings.SaveSetting(fi.ModuleId, sKey, ForumSettingKeys.TopicTemplateId, "0");
-				Settings.SaveSetting(fi.ModuleId, sKey, ForumSettingKeys.TopicFormId, "0");
-				Settings.SaveSetting(fi.ModuleId, sKey, ForumSettingKeys.ReplyFormId, "0");
-				Settings.SaveSetting(fi.ModuleId, sKey, ForumSettingKeys.AllowRSS, "false");
-			}
-            
             // Clear the caches
-			DataCache.SettingsCacheClear(fi.ModuleId, string.Format(CacheKeys.ForumList, fi.ModuleId));
-			DataCache.SettingsCacheClear(fi.ModuleId,string.Format(CacheKeys.ForumInfo, fi.ModuleId, forumId));
+            DataCache.SettingsCacheClear(fi.ModuleId, string.Format(CacheKeys.ForumList, fi.ModuleId));
+            DataCache.SettingsCacheClear(fi.ModuleId, string.Format(CacheKeys.ForumInfo, fi.ModuleId, forumId));
 
-			return forumId;
-		}
+            return forumId;
+        }
 
-		public string GetForumsHtmlOption(int portalId, int moduleId, User currentUser)
-		{
-			var userForums = GetForumsForUser(currentUser.UserRoles, portalId, moduleId, "CanView");
-			var dt = DataProvider.Instance().UI_ForumView(portalId, moduleId, currentUser.UserId, currentUser.IsSuperUser, userForums).Tables[0];
-			var i = 0;
-			var n = 1;
-			var tmpGroupCount = 0;
-			var tmpForumCount = 0;
-			var tmpGroupKey = string.Empty;
-			var tmpForumKey = string.Empty;
-			var sb = new StringBuilder();
-			foreach (DataRow dr in dt.Rows)
-			{
-				var bView = Permissions.HasPerm(dr["CanView"].ToString(), currentUser.UserRoles);
-				var groupName = Convert.ToString(dr["GroupName"]);
-				var groupId = Convert.ToInt32(dr["ForumGroupId"]);
-				var groupKey = groupName + groupId.ToString();
-				var forumName = Convert.ToString(dr["ForumName"]);
-				var forumId = Convert.ToInt32(dr["ForumId"]);
-				var forumKey = forumName + forumId.ToString();
-				var parentForumId = Convert.ToInt32(dr["ParentForumId"]);
+        public string GetForumsHtmlOption(int portalId, int moduleId, User currentUser)
+        {
+            var userForums = GetForumsForUser(currentUser.UserRoles, portalId, moduleId, "CanView");
+            var dt = DataProvider.Instance().UI_ForumView(portalId, moduleId, currentUser.UserId, currentUser.IsSuperUser, userForums).Tables[0];
+            var i = 0;
+            var n = 1;
+            var tmpGroupCount = 0;
+            var tmpForumCount = 0;
+            var tmpGroupKey = string.Empty;
+            var tmpForumKey = string.Empty;
+            var sb = new StringBuilder();
+            foreach (DataRow dr in dt.Rows)
+            {
+                var bView = Permissions.HasPerm(dr["CanView"].ToString(), currentUser.UserRoles);
+                var groupName = Convert.ToString(dr["GroupName"]);
+                var groupId = Convert.ToInt32(dr["ForumGroupId"]);
+                var groupKey = groupName + groupId.ToString();
+                var forumName = Convert.ToString(dr["ForumName"]);
+                var forumId = Convert.ToInt32(dr["ForumId"]);
+                var forumKey = forumName + forumId.ToString();
+                var parentForumId = Convert.ToInt32(dr["ParentForumId"]);
 
-				//TODO - Need to add support for Group Permissions and GroupHidden
+                //TODO - Need to add support for Group Permissions and GroupHidden
 
-				if (tmpGroupKey != groupKey)
-				{
-					sb.AppendFormat("<option value=\"{0}\">{1}</option>", "-1", groupName);
-					n += 1;
-					tmpGroupKey = groupKey;
-				}
+                if (tmpGroupKey != groupKey)
+                {
+                    sb.AppendFormat("<option value=\"{0}\">{1}</option>", "-1", groupName);
+                    n += 1;
+                    tmpGroupKey = groupKey;
+                }
 
-				if (bView)
-				{
-					if (parentForumId == 0)
-					{
-						sb.AppendFormat("<option value=\"{0}\">{1}</option>", dr["ForumID"], "--" + dr["ForumName"]);
-						n += 1;
-						sb.Append(GetSubForums(n, Convert.ToInt32(dr["ForumId"]), dt, ref n));
-					}
+                if (bView)
+                {
+                    if (parentForumId == 0)
+                    {
+                        sb.AppendFormat("<option value=\"{0}\">{1}</option>", dr["ForumID"], "--" + dr["ForumName"]);
+                        n += 1;
+                        sb.Append(GetSubForums(n, Convert.ToInt32(dr["ForumId"]), dt, ref n));
+                    }
 
-				}
-			}
+                }
+            }
 
-			return sb.ToString();
-		}
-		private static string GetSubForums(int itemCount, int parentForumId, DataTable dtForums, ref int n)
-		{
-			var sb = new StringBuilder();
-			dtForums.DefaultView.RowFilter = string.Concat("ParentForumId = ", parentForumId);
-			if (dtForums.DefaultView.Count > 0)
-			{
-				foreach (DataRow dr in dtForums.DefaultView.ToTable().Rows)
-				{
-					sb.AppendFormat("<option value=\"{0}\">----{1}</option>", dr["ForumID"], dr["ForumName"]);
-					itemCount += 1;
-				}
-			}
-			n = itemCount;
-			return sb.ToString();
-		}
+            return sb.ToString();
+        }
+        private static string GetSubForums(int itemCount, int parentForumId, DataTable dtForums, ref int n)
+        {
+            var sb = new StringBuilder();
+            dtForums.DefaultView.RowFilter = string.Concat("ParentForumId = ", parentForumId);
+            if (dtForums.DefaultView.Count > 0)
+            {
+                foreach (DataRow dr in dtForums.DefaultView.ToTable().Rows)
+                {
+                    sb.AppendFormat("<option value=\"{0}\">----{1}</option>", dr["ForumID"], dr["ForumName"]);
+                    itemCount += 1;
+                }
+            }
+            n = itemCount;
+            return sb.ToString();
+        }
 
-		public DataTable GetForumView(int portalId, int moduleId, int currentUserId, bool isSuperUser, string forumIds)
-		{
-		    DataSet ds;
-			DataTable dt;
-			var cachekey = string.Format(CacheKeys.ForumViewForUser, moduleId, currentUserId, forumIds);
+        public DataTable GetForumView(int portalId, int moduleId, int currentUserId, bool isSuperUser, string forumIds)
+        {
+            DataSet ds;
+            DataTable dt;
+            var cachekey = string.Format(CacheKeys.ForumViewForUser, moduleId, currentUserId, forumIds);
 
-			var dataSetXML = DataCache.ContentCacheRetrieve(moduleId,cachekey) as string;
+            var dataSetXML = DataCache.ContentCacheRetrieve(moduleId, cachekey) as string;
 
-			// cached datatable is held as an XML string (because data vanishes if just caching the DT in this instance)
+            // cached datatable is held as an XML string (because data vanishes if just caching the DT in this instance)
             if (dataSetXML != null)
-			{
+            {
                 var sr = new StringReader(dataSetXML);
-				ds = new DataSet();
-				ds.ReadXml(sr);
-				dt = ds.Tables[0];
-			}
-			else
-			{
-				ds = DataProvider.Instance().UI_ForumView(portalId, moduleId, currentUserId, isSuperUser, forumIds);
-				dt = ds.Tables[0];
+                ds = new DataSet();
+                ds.ReadXml(sr);
+                dt = ds.Tables[0];
+            }
+            else
+            {
+                ds = DataProvider.Instance().UI_ForumView(portalId, moduleId, currentUserId, isSuperUser, forumIds);
+                dt = ds.Tables[0];
 
-			    var sw = new StringWriter();
+                var sw = new StringWriter();
 
-				dt.WriteXml(sw);
-				var result = sw.ToString();
+                dt.WriteXml(sw);
+                var result = sw.ToString();
 
-				sw.Close();
-				sw.Dispose();
+                sw.Close();
+                sw.Dispose();
 
-				DataCache.ContentCacheStore(moduleId,cachekey, result);
-			}
+                DataCache.ContentCacheStore(moduleId, cachekey, result);
+            }
 
-			return dt;
-		}
-		public int CreateGroupForum(int portalId, int moduleId, int socialGroupId, int forumGroupId, string forumName, string forumDescription, bool isPrivate, string forumConfig)
-		{
-			var forumId = -1;
+            return dt;
+        }
+        public int CreateGroupForum(int portalId, int moduleId, int socialGroupId, int forumGroupId, string forumName, string forumDescription, bool isPrivate, string forumConfig)
+        {
+            var forumId = -1;
 
-			try
-			{
-				var forumsDb = new Data.Common();
-			    var fgc = new ForumGroupController();
-				var gi = fgc.Groups_Get(moduleId, forumGroupId);
-				var socialGroup = DotNetNuke.Security.Roles.RoleController.Instance.GetRoleById(portalId: portalId, roleId: socialGroupId);
-				var groupAdmin = string.Concat(socialGroupId.ToString(), ":0");
-				var groupMember = socialGroupId.ToString();
+            try
+            {
+                var forumsDb = new Data.Common();
+                var fgc = new ForumGroupController();
+                var gi = fgc.Groups_Get(moduleId, forumGroupId);
+                var socialGroup = DotNetNuke.Security.Roles.RoleController.Instance.GetRoleById(portalId: portalId, roleId: socialGroupId);
+                var groupAdmin = string.Concat(socialGroupId.ToString(), ":0");
+                var groupMember = socialGroupId.ToString();
 
-			    var ri = DotNetNuke.Security.Roles.RoleController.Instance.GetRoleByName(portalId: portalId, roleName: "Administrators");
-				var permissionsId = forumsDb.CreatePermSet(ri.RoleID.ToString());
+                var ri = DotNetNuke.Security.Roles.RoleController.Instance.GetRoleByName(portalId: portalId, roleName: "Administrators");
+                var permissionsId = forumsDb.CreatePermSet(ri.RoleID.ToString());
 
-				moduleId = gi.ModuleId;
+                moduleId = gi.ModuleId;
 
-				var fi = new Forum
-				{
-				    ForumDesc = forumDescription,
-				    Active = true,
-				    ForumGroupId = forumGroupId,
-				    ForumID = -1,
-				    ForumName = forumName,
-				    Hidden = isPrivate,
-				    ModuleId = gi.ModuleId,
-				    ParentForumId = 0,
-				    PortalId = portalId,
-				    PermissionsId = gi.PermissionsId,
-				    SortOrder = 0,
-				    SocialGroupId = socialGroupId
-				};
+                var fi = new Forum
+                {
+                    ForumDesc = forumDescription,
+                    Active = true,
+                    ForumGroupId = forumGroupId,
+                    ForumID = -1,
+                    ForumName = forumName,
+                    Hidden = isPrivate,
+                    ModuleId = gi.ModuleId,
+                    ParentForumId = 0,
+                    PortalId = portalId,
+                    PermissionsId = gi.PermissionsId,
+                    SortOrder = 0,
+                    SocialGroupId = socialGroupId
+                };
 
-			    forumId = Forums_Save(portalId, fi, true, true);
-				fi = GetForum(portalId, moduleId, forumId);
-				fi.PermissionsId = permissionsId;
-				Forums_Save(portalId, fi, false, false);
+                forumId = Forums_Save(portalId, fi, true, true);
+                fi = GetForum(portalId, moduleId, forumId);
+                fi.PermissionsId = permissionsId;
+                Forums_Save(portalId, fi, false, false);
 
-			    var xDoc = new XmlDocument();
-				xDoc.LoadXml(forumConfig);
+                var xDoc = new XmlDocument();
+                xDoc.LoadXml(forumConfig);
 
-				var xRoot = xDoc.DocumentElement;
-			    if (xRoot != null)
-			    {
-			        var xSecList = xRoot.SelectSingleNode("//security[@type='groupadmin']");
-			        string permSet;
-			        string secKey;
-			        if (xSecList != null)
-			        {
-			            foreach (XmlNode n in xSecList.ChildNodes)
-			            {
-			                secKey = n.Name;
-			                if (n.Attributes == null || n.Attributes["value"].Value != "true") 
-			                    continue;
-			                permSet = forumsDb.GetPermSet(permissionsId, secKey);
-			                permSet = Permissions.AddPermToSet(groupAdmin, 2, permSet);
-			                forumsDb.SavePermSet(permissionsId, secKey, permSet);
-			            }
-			        }
+                var xRoot = xDoc.DocumentElement;
+                if (xRoot != null)
+                {
+                    var xSecList = xRoot.SelectSingleNode("//security[@type='groupadmin']");
+                    string permSet;
+                    string secKey;
+                    if (xSecList != null)
+                    {
+                        foreach (XmlNode n in xSecList.ChildNodes)
+                        {
+                            secKey = n.Name;
+                            if (n.Attributes == null || n.Attributes["value"].Value != "true")
+                                continue;
+                            permSet = forumsDb.GetPermSet(permissionsId, secKey);
+                            permSet = Permissions.AddPermToSet(groupAdmin, 2, permSet);
+                            forumsDb.SavePermSet(permissionsId, secKey, permSet);
+                        }
+                    }
 
-			        xSecList = xRoot.SelectSingleNode("//security[@type='groupmember']");
-			        if (xSecList != null)
-			        {
-			            foreach (XmlNode n in xSecList.ChildNodes)
-			            {
-			                secKey = n.Name;
-						    
-			                if (n.Attributes == null || n.Attributes["value"].Value != "true") 
-			                    continue;
-						    
-			                permSet = forumsDb.GetPermSet(permissionsId, secKey);
-			                permSet = Permissions.AddPermToSet(groupMember, 0, permSet);
-			                forumsDb.SavePermSet(permissionsId, secKey, permSet);
-			            }
-			        }
+                    xSecList = xRoot.SelectSingleNode("//security[@type='groupmember']");
+                    if (xSecList != null)
+                    {
+                        foreach (XmlNode n in xSecList.ChildNodes)
+                        {
+                            secKey = n.Name;
 
-			        if (socialGroup.IsPublic)
-			        {
-			            xSecList = xRoot.SelectSingleNode("//security[@type='registereduser']");
-			            ri = DotNetNuke.Security.Roles.RoleController.Instance.GetRoleByName(portalId: portalId, roleName: "Registered Users");
-			            if (xSecList != null)
-			            {
-			                foreach (XmlNode n in xSecList.ChildNodes)
-			                {
-			                    secKey = n.Name;
-							    
-			                    if (n.Attributes == null || n.Attributes["value"].Value != "true") 
-			                        continue;
-							    
-			                    permSet = forumsDb.GetPermSet(permissionsId, secKey);
-			                    permSet = Permissions.AddPermToSet(ri.RoleID.ToString(), 0, permSet);
-			                    forumsDb.SavePermSet(permissionsId, secKey, permSet);
-			                }
-			            }
+                            if (n.Attributes == null || n.Attributes["value"].Value != "true")
+                                continue;
 
-			            xSecList = xRoot.SelectSingleNode("//security[@type='anon']");
-			            if (xSecList != null)
-			            {
-			                foreach (XmlNode n in xSecList.ChildNodes)
-			                {
-			                    secKey = n.Name;
+                            permSet = forumsDb.GetPermSet(permissionsId, secKey);
+                            permSet = Permissions.AddPermToSet(groupMember, 0, permSet);
+                            forumsDb.SavePermSet(permissionsId, secKey, permSet);
+                        }
+                    }
 
-			                    if (n.Attributes == null || n.Attributes["value"].Value != "true") 
-			                        continue;
+                    if (socialGroup.IsPublic)
+                    {
+                        xSecList = xRoot.SelectSingleNode("//security[@type='registereduser']");
+                        ri = DotNetNuke.Security.Roles.RoleController.Instance.GetRoleByName(portalId: portalId, roleName: "Registered Users");
+                        if (xSecList != null)
+                        {
+                            foreach (XmlNode n in xSecList.ChildNodes)
+                            {
+                                secKey = n.Name;
 
-			                    permSet = forumsDb.GetPermSet(permissionsId, secKey);
-			                    permSet = Permissions.AddPermToSet("-1", 0, permSet);
-			                    forumsDb.SavePermSet(permissionsId, secKey, permSet);
-			                }
-			            }
-			        }
-			    }
-			}
-			catch
-			{
-				// do nothing?? 
-			}
+                                if (n.Attributes == null || n.Attributes["value"].Value != "true")
+                                    continue;
 
-			DataCache.SettingsCacheClear(moduleId,string.Format(CacheKeys.ForumListXml, moduleId));
+                                permSet = forumsDb.GetPermSet(permissionsId, secKey);
+                                permSet = Permissions.AddPermToSet(ri.RoleID.ToString(), 0, permSet);
+                                forumsDb.SavePermSet(permissionsId, secKey, permSet);
+                            }
+                        }
 
-			return forumId;
-		}
+                        xSecList = xRoot.SelectSingleNode("//security[@type='anon']");
+                        if (xSecList != null)
+                        {
+                            foreach (XmlNode n in xSecList.ChildNodes)
+                            {
+                                secKey = n.Name;
+
+                                if (n.Attributes == null || n.Attributes["value"].Value != "true")
+                                    continue;
+
+                                permSet = forumsDb.GetPermSet(permissionsId, secKey);
+                                permSet = Permissions.AddPermToSet("-1", 0, permSet);
+                                forumsDb.SavePermSet(permissionsId, secKey, permSet);
+                            }
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // do nothing?? 
+            }
+
+            DataCache.SettingsCacheClear(moduleId, string.Format(CacheKeys.ForumListXml, moduleId));
+
+            return forumId;
+        }
     }
 }

--- a/Dnn.CommunityForums/class/TemplateUtils.cs
+++ b/Dnn.CommunityForums/class/TemplateUtils.cs
@@ -20,18 +20,17 @@
 
 
 using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Data;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Web;
 using System.Text.RegularExpressions;
-using System.Configuration;
-using Microsoft.ApplicationBlocks.Data;
-using System.Data;
-using System.Collections.Generic;
-using System.Globalization;
+using System.Web;
 using DotNetNuke.Entities.Portals;
-using DotNetNuke.Framework;
+using Microsoft.ApplicationBlocks.Data;
 
 namespace DotNetNuke.Modules.ActiveForums
 {
@@ -91,13 +90,13 @@ namespace DotNetNuke.Modules.ActiveForums
         }
 
         public static string ParseEmailTemplate(string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, int timeZoneOffset)
-        { 
+        {
             return ParseEmailTemplate(string.Empty, templateName, portalID, moduleID, tabID, forumID, topicId, replyId, string.Empty, null, -1, Utilities.GetCultureInfoForUser(portalID, -1), new TimeSpan(hours: 0, minutes: timeZoneOffset, seconds: 0), false);
         }
 
         public static string ParseEmailTemplate(string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, string comments, int timeZoneOffset)
         {
-            return ParseEmailTemplate(string.Empty, templateName, portalID, moduleID, tabID, forumID, topicId, replyId, comments, null,-1, Utilities.GetCultureInfoForUser(portalID, -1), new TimeSpan(hours: 0, minutes: timeZoneOffset, seconds: 0), false);
+            return ParseEmailTemplate(string.Empty, templateName, portalID, moduleID, tabID, forumID, topicId, replyId, comments, null, -1, Utilities.GetCultureInfoForUser(portalID, -1), new TimeSpan(hours: 0, minutes: timeZoneOffset, seconds: 0), false);
         }
 
         public static string ParseEmailTemplate(string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, DotNetNuke.Entities.Users.UserInfo user, int timeZoneOffset)
@@ -108,7 +107,7 @@ namespace DotNetNuke.Modules.ActiveForums
         {
             var uc = new DotNetNuke.Entities.Users.UserController();
             var usr = uc.GetUser(portalID, userId);
-            return ParseEmailTemplate(template, templateName, portalID, moduleID, tabID, forumID, topicId, replyId, comments, usr, userId, Utilities.GetCultureInfoForUser(portalID, userId),new TimeSpan(hours: 0, minutes: timeZoneOffset, seconds: 0), false);
+            return ParseEmailTemplate(template, templateName, portalID, moduleID, tabID, forumID, topicId, replyId, comments, usr, userId, Utilities.GetCultureInfoForUser(portalID, userId), new TimeSpan(hours: 0, minutes: timeZoneOffset, seconds: 0), false);
         }
         public static string ParseEmailTemplate(string template, string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, string comments, DotNetNuke.Entities.Users.UserInfo user, int userId, int timeZoneOffset)
         {
@@ -202,7 +201,7 @@ namespace DotNetNuke.Modules.ActiveForums
             body = Utilities.ManageImagePath(body, Common.Globals.AddHTTP(Common.Globals.GetDomainName(HttpContext.Current.Request)));
 
             // load the forum information
-            var fi = new ForumController().Forums_Get(forumID, -1, false);
+            var fi = new ForumController().Forums_Get(portalId: portalID, moduleId: moduleID, forumId: forumID, useCache: true);
 
             // Load the user if needed
             if (user == null)
@@ -232,7 +231,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 sDisplayName = string.Empty;
                 sUsername = string.Empty;
             }
-            
+
             // Build the link
             string link;
             if (string.IsNullOrEmpty(fi.PrefixURL) || !Utilities.UseFriendlyURLs(moduleID))
@@ -279,8 +278,8 @@ namespace DotNetNuke.Modules.ActiveForums
             result.Replace("[FIRSTNAME]", sFirstName);
             result.Replace("[LASTNAME]", sLastName);
             result.Replace("[FULLNAME]", string.Concat(sFirstName, " ", sLastName));
-            result.Replace("[GROUPNAME]", fi.GroupName); 
-            result.Replace("[POSTDATE]", Utilities.GetUserFormattedDateTime(dateCreated,userCultureInfo,timeZoneOffset));
+            result.Replace("[GROUPNAME]", fi.GroupName);
+            result.Replace("[POSTDATE]", Utilities.GetUserFormattedDateTime(dateCreated, userCultureInfo, timeZoneOffset));
             result.Replace("[COMMENTS]", comments);
             result.Replace("[PORTALNAME]", portalSettings.PortalName);
             result.Replace("[MODLINK]", string.Concat("<a href=\"", modLink, "\">", modLink, "</a>"));
@@ -294,12 +293,12 @@ namespace DotNetNuke.Modules.ActiveForums
             result.Replace("[POSTEDTO]", (replyId <= 0 ? Utilities.GetSharedResource("[RESX:postedto]") : string.Empty));
             result.Replace("[REPLIEDTO]", (replyId > 0 ? Utilities.GetSharedResource("[RESX:repliedto]") : string.Empty));
             result.Replace("[NEWPOST]", (replyId <= 0 ? Utilities.GetSharedResource("[RESX:NewPost]") : string.Empty));
-            result.Replace("[NEWREPLY]", (replyId > 0 ? Utilities.GetSharedResource("[RESX:NewReply]") : string.Empty ));
+            result.Replace("[NEWREPLY]", (replyId > 0 ? Utilities.GetSharedResource("[RESX:NewReply]") : string.Empty));
             result.Replace("[SUBSCRIBEDTOPIC]", (topicSubscriber ? Utilities.GetSharedResource("[RESX:SubscribedTopic]") : string.Empty));
             result.Replace("[SUBSCRIBEDTOPICSUBJECT]", (topicSubscriber ? string.Format(Utilities.GetSharedResource("[RESX:SubscribedTopicSubject]"), subject) : string.Empty));
             result.Replace("[SUBSCRIBEDTOPICFORUMNAME]", (topicSubscriber ? string.Format(Utilities.GetSharedResource("[RESX:SubscribedTopicForumName]"), subject, fi.ForumName) : string.Empty));
             result.Replace("[SUBSCRIBEDFORUM]", (topicSubscriber ? string.Empty : "[RESX:SubscribedForum]"));
-            result.Replace("[SUBSCRIBEDFORUMNAME]", (topicSubscriber ? string.Empty : string.Format(Utilities.GetSharedResource("[RESX:SubscribedForumName]"),fi.ForumName)));
+            result.Replace("[SUBSCRIBEDFORUMNAME]", (topicSubscriber ? string.Empty : string.Format(Utilities.GetSharedResource("[RESX:SubscribedForumName]"), fi.ForumName)));
             result.Replace("[SUBSCRIBEDFORUMORTOPICSUBJECTFORUMNAME]", (topicSubscriber ? string.Format(Utilities.GetSharedResource("[RESX:SubscribedTopicForumName]"), subject, fi.ForumName) : string.Format(Utilities.GetSharedResource("[RESX:SubscribedForumTopicForumName]"), subject, fi.ForumName)));
 
             // Introduced for Active Forum Email Connector plug-in Starts
@@ -427,25 +426,25 @@ namespace DotNetNuke.Modules.ActiveForums
             var mainSettings = SettingsBase.GetModuleSettings(moduleId);
 
             var cacheKey = string.Format(CacheKeys.ProfileInfo, moduleId);
-            var myTemplate = Convert.ToString(DataCache.SettingsCacheRetrieve(moduleId,cacheKey));
+            var myTemplate = Convert.ToString(DataCache.SettingsCacheRetrieve(moduleId, cacheKey));
             if (string.IsNullOrEmpty(myTemplate))
             {
                 var objTemplateInfo = GetTemplateByName("ProfileInfo", moduleId, portalId);
                 myTemplate = objTemplateInfo.TemplateHTML;
                 if (cacheKey != string.Empty)
-                    DataCache.SettingsCacheStore(moduleId,cacheKey, myTemplate);
+                    DataCache.SettingsCacheStore(moduleId, cacheKey, myTemplate);
             }
 
             myTemplate = ParseProfileTemplate(myTemplate, up, portalId, moduleId, imagePath, currentUserType, true, userPrefHideAvatar, false, ipAddress, currentUserId, timeZoneOffset);
 
             return myTemplate;
         }
-        
+
         public static string ParseProfileTemplate(string profileTemplate, int userId, int portalId, int moduleId, int currentUserId, int timeZoneOffset)
         {
             return ParseProfileTemplate(profileTemplate, userId, portalId, moduleId, currentUserId, new TimeSpan(hours: 0, minutes: timeZoneOffset, seconds: 0));
         }
-        
+
         public static string ParseProfileTemplate(string profileTemplate, int userId, int portalId, int moduleId, int currentUserId, TimeSpan timeZoneOffset)
         {
             var uc = new UserController();
@@ -453,47 +452,47 @@ namespace DotNetNuke.Modules.ActiveForums
 
             return ParseProfileTemplate(profileTemplate, up, portalId, moduleId, string.Empty, CurrentUserTypes.Anon, false, false, false, string.Empty, currentUserId, timeZoneOffset);
         }
-        
+
         public static string ParseProfileTemplate(string profileTemplate, User up, int portalId, int moduleId, string imagePath, CurrentUserTypes currentUserType, int timeZoneOffset)
-        { 
+        {
             return ParseProfileTemplate(profileTemplate, up, portalId, moduleId, imagePath, currentUserType, new TimeSpan(hours: 0, minutes: timeZoneOffset, seconds: 0));
         }
-        
+
         public static string ParseProfileTemplate(string profileTemplate, User up, int portalId, int moduleId, string imagePath, CurrentUserTypes currentUserType, TimeSpan timeZoneOffset)
         {
             return ParseProfileTemplate(profileTemplate, up, portalId, moduleId, imagePath, currentUserType, false, false, false, string.Empty, -1, timeZoneOffset);
         }
-        
+
         public static string ParseProfileTemplate(string profileTemplate, User up, int portalId, int moduleId, string imagePath, CurrentUserTypes currentUserType, bool legacyTemplate, int timeZoneOffset)
         {
             return ParseProfileTemplate(profileTemplate, up, portalId, moduleId, imagePath, currentUserType, false, false, false, string.Empty, -1, new TimeSpan(hours: 0, minutes: timeZoneOffset, seconds: 0));
         }
-        
+
         public static string ParseProfileTemplate(string profileTemplate, User up, int portalId, int moduleId, string imagePath, CurrentUserTypes currentUserType, bool legacyTemplate, TimeSpan timeZoneOffset)
         {
             return ParseProfileTemplate(profileTemplate, up, portalId, moduleId, imagePath, currentUserType, false, false, false, string.Empty, -1, timeZoneOffset);
         }
-        
+
         public static string ParseProfileTemplate(string profileTemplate, User up, int portalId, int moduleId, string imagePath, CurrentUserTypes currentUserType, bool legacyTemplate, bool userPrefHideAvatar, bool userPrefHideSignature, string ipAddress, int timeZoneOffset)
         {
             return ParseProfileTemplate(profileTemplate, up, portalId, moduleId, imagePath, currentUserType, legacyTemplate, userPrefHideAvatar, userPrefHideSignature, ipAddress, -1, new TimeSpan(hours: 0, minutes: timeZoneOffset, seconds: 0));
         }
-        
+
         public static string ParseProfileTemplate(string profileTemplate, User up, int portalId, int moduleId, string imagePath, CurrentUserTypes currentUserType, bool legacyTemplate, bool userPrefHideAvatar, bool userPrefHideSignature, string ipAddress, TimeSpan timeZoneOffset)
         {
             return ParseProfileTemplate(profileTemplate, up, portalId, moduleId, imagePath, currentUserType, legacyTemplate, userPrefHideAvatar, userPrefHideSignature, ipAddress, -1, timeZoneOffset);
         }
-        
+
         public static string ParseProfileTemplate(string profileTemplate, User up, int portalId, int moduleId, string imagePath, CurrentUserTypes currentUserType, int currentUserId, TimeSpan timeZoneOffset)
         {
             return ParseProfileTemplate(profileTemplate, up, portalId, moduleId, imagePath, currentUserType, false, false, false, string.Empty, currentUserId, timeZoneOffset);
         }
-        
+
         public static string ParseProfileTemplate(string profileTemplate, User up, int portalId, int moduleId, string imagePath, CurrentUserTypes currentUserType, bool legacyTemplate, bool userPrefHideAvatar, bool userPrefHideSignature, string ipAddress, int currentUserId, int timeZoneOffset)
         {
             return ParseProfileTemplate(profileTemplate, up, portalId, moduleId, imagePath, currentUserType, legacyTemplate, userPrefHideAvatar, userPrefHideSignature, ipAddress, currentUserId, new TimeSpan(hours: 0, minutes: timeZoneOffset, seconds: 0));
         }
-        
+
         public static string ParseProfileTemplate(string profileTemplate, User up, int portalId, int moduleId, string imagePath, CurrentUserTypes currentUserType, bool legacyTemplate, bool userPrefHideAvatar, bool userPrefHideSignature, string ipAddress, int currentUserId, TimeSpan timeZoneOffset)
         {
             try
@@ -535,7 +534,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
                 // IP Address
                 result.Replace("[MODIPADDRESS]", isMod ? ipAddress : string.Empty);
-                
+
                 // User Edit
                 result.Replace("[AF:BUTTON:EDITUSER]", isAdmin && up.UserId > 0 ? string.Format("<button class='af-button af-button-edituser' data-id='{0}' data-name='{1}'>[RESX:Edit]</button>", up.UserId, Utilities.JSON.EscapeJsonString(up.DisplayName)) : string.Empty);
 
@@ -642,7 +641,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 // Date Created
                 var sDateCreated = string.Empty;
                 var sDateCreatedReplacement = "[AF:PROFILE:DATECREATED]";
-                
+
                 if (up.UserId > 0 && up.Profile != null && up.Profile.DateCreated != null)
                 {
                     if (pt.Contains("[AF:PROFILE:DATECREATED:"))
@@ -667,7 +666,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     if (pt.Contains("[AF:PROFILE:DATELASTACTIVITY:"))
                     {
                         string sFormat = pt.Substring(pt.IndexOf("[AF:PROFILE:DATELASTACTIVITY:", StringComparison.Ordinal) + (sDateLastActivityReplacement.Length), 1);
-                        sDateLastActivity = Utilities.GetUserFormattedDateTime(up.Profile.DateLastActivity, portalId, currentUserId, sFormat); 
+                        sDateLastActivity = Utilities.GetUserFormattedDateTime(up.Profile.DateLastActivity, portalId, currentUserId, sFormat);
                         sDateLastActivityReplacement = string.Concat("[AF:PROFILE:DATELASTACTIVITY:", sFormat, "]");
                     }
                     else
@@ -684,7 +683,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 result.Replace("[AF:PROFILE:USERNAME]", Utilities.HTMLEncode(up.UserName).Replace("&amp;#", "&#"));
                 result.Replace("[AF:PROFILE:FIRSTNAME]", Utilities.HTMLEncode(up.FirstName).Replace("&amp;#", "&#"));
                 result.Replace("[AF:PROFILE:LASTNAME]", Utilities.HTMLEncode(up.LastName).Replace("&amp;#", "&#"));
-                result.Replace("[AF:PROFILE:DATELASTPOST]", (up.Profile.DateLastPost == DateTime.MinValue) ? string.Empty : Utilities.GetUserFormattedDateTime(up.Profile.DateLastPost, portalId, currentUserId)); 
+                result.Replace("[AF:PROFILE:DATELASTPOST]", (up.Profile.DateLastPost == DateTime.MinValue) ? string.Empty : Utilities.GetUserFormattedDateTime(up.Profile.DateLastPost, portalId, currentUserId));
                 result.Replace("[AF:PROFILE:TOPICCOUNT]", up.Profile.TopicCount.ToString());
                 result.Replace("[AF:PROFILE:REPLYCOUNT]", up.Profile.ReplyCount.ToString());
                 result.Replace("[AF:PROFILE:ANSWERCOUNT]", up.Profile.AnswerCount.ToString());
@@ -709,7 +708,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
             const string pattern = @"\[ROLES:(.+?)\]";
 
-            template = Regex.Replace(template, pattern, delegate(Match match)
+            template = Regex.Replace(template, pattern, delegate (Match match)
             {
                 if (userRoleArray == null || userRoleArray.Count == 0)
                     return string.Empty;

--- a/Dnn.CommunityForums/class/Utilities.cs
+++ b/Dnn.CommunityForums/class/Utilities.cs
@@ -22,19 +22,18 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.IO;
 using System.Web;
-using System.Reflection;
 using System.Web.UI.WebControls;
-using DotNetNuke.Common.Utilities;
+using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Tabs;
 using DotNetNuke.Entities.Users;
-using DotNetNuke.Entities.Portals;
-using DotNetNuke.Security.Roles;
 using DotNetNuke.Framework;
+using DotNetNuke.Security.Roles;
 
 namespace DotNetNuke.Modules.ActiveForums
 {
@@ -98,7 +97,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
             template = ParseSpacer(template);
 
-            var li = DotNetNuke.Modules.ActiveForums.Controllers.TokenController.TokensList(moduleId,group);
+            var li = DotNetNuke.Modules.ActiveForums.Controllers.TokenController.TokensList(moduleId, group);
             if (li != null)
                 template = li.Aggregate(template, (current, tk) => current.Replace(tk.TokenTag, tk.TokenReplace));
 
@@ -313,8 +312,8 @@ namespace DotNetNuke.Modules.ActiveForums
             }
             catch (Exception ex)
             {
-                Exceptions.LogException(ex); 
-                return null; 
+                Exceptions.LogException(ex);
+                return null;
             }
         }
         public static DotNetNuke.Entities.Portals.PortalSettings GetPortalSettings(int portalId)
@@ -344,7 +343,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 return null;
             }
         }
-       public static string GetHost()
+        public static string GetHost()
         {
             string strHost;
             if (HttpContext.Current.Request.IsSecureConnection)
@@ -384,7 +383,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
         public static string NavigateUrl(int tabId, string controlKey, string pageName, int portalId, params string[] additionalParameters)
         {
-            var currParams = additionalParameters.ToList(); 
+            var currParams = additionalParameters.ToList();
             string s = Common.Globals.NavigateURL(tabId, controlKey, currParams.ToArray());
             if (portalId == -1 || string.IsNullOrWhiteSpace(pageName))
                 return s;
@@ -1057,7 +1056,7 @@ namespace DotNetNuke.Modules.ActiveForums
         {
             return ManageImagePath(sHTML, new Uri(hostWithScheme));
         }
-        
+
         public static string ManageImagePath(string sHTML, Uri hostUri)
         {
             string hostWithScheme = hostUri.AbsoluteUri.Replace(hostUri.PathAndQuery, string.Empty).ToLowerInvariant();
@@ -1078,7 +1077,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
             return sHTML;
         }
-		internal static string GetFileContent(string filePath)
+        internal static string GetFileContent(string filePath)
         {
             var sPath = filePath;
             if (!(sPath.Contains(@":\")) && !(sPath.Contains(@"\\")))
@@ -1143,12 +1142,12 @@ namespace DotNetNuke.Modules.ActiveForums
 
             return newDate.AddMinutes(offset);
         }
-        
+
         public string GetUserFormattedDate(DateTime date, PortalInfo portalInfo, UserInfo userInfo)
         {
             return GetUserFormattedDateTime(date, portalInfo.PortalID, userInfo.UserID);
         }
-        
+
         public static string GetUserFormattedDateTime(DateTime dateTime, int portalId, int userId, string format)
         {
             CultureInfo userCultureInfo = GetCultureInfoForUser(portalId, userId);
@@ -1184,7 +1183,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 return dateTime.ToString(format, CultureInfo.CurrentCulture);
             }
         }
-        
+
         public static CultureInfo GetCultureInfoForUser(int portalId, int userId)
         {
             return GetCultureInfoForUser(DotNetNuke.Entities.Users.UserController.Instance.GetUser(portalId, userId));
@@ -1237,13 +1236,13 @@ namespace DotNetNuke.Modules.ActiveForums
         }
         public static TimeSpan GetTimeZoneOffsetForUser(int PortalId, int UserId)
         {
-            return GetTimeZoneOffsetForUser( new DotNetNuke.Entities.Users.UserController().GetUser(PortalId,UserId));
+            return GetTimeZoneOffsetForUser(new DotNetNuke.Entities.Users.UserController().GetUser(PortalId, UserId));
         }
         public static DateTime GetUserFormattedDate(DateTime displayDate, int mid, TimeSpan offset)
         {
             return displayDate.AddMinutes(offset.TotalMinutes);
         }
-        
+
         public static string GetLastPostSubject(int lastPostID, int parentPostID, int forumID, int tabID, string subject, int length, int pageSize, int replyCount, bool canRead)
         {
             var sb = new StringBuilder();
@@ -1489,13 +1488,17 @@ namespace DotNetNuke.Modules.ActiveForums
             }
             return contents;
         }
-
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Use GetListOfModerators(int portalId, int ModuleId, int forumId).")]
         public static List<DotNetNuke.Entities.Users.UserInfo> GetListOfModerators(int portalId, int forumId)
+        {
+            return GetListOfModerators(portalId, -1, forumId);
+        }
+        public static List<DotNetNuke.Entities.Users.UserInfo> GetListOfModerators(int portalId, int moduleId, int forumId)
         {
             var rp = RoleProvider.Instance();
             var uc = new DotNetNuke.Entities.Users.UserController();
             var fc = new ForumController();
-            var fi = fc.Forums_Get(forumId, -1, false, true);
+            var fi = fc.Forums_Get(portalId: portalId, moduleId: moduleId, forumId: forumId, useCache: true);
             if (fi == null)
                 return null;
 

--- a/Dnn.CommunityForums/components/Replies/Replies.cs
+++ b/Dnn.CommunityForums/components/Replies/Replies.cs
@@ -18,288 +18,280 @@
 // DEALINGS IN THE SOFTWARE.
 //
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Data;
-using System.IO;
-using System.Reflection;
-using DotNetNuke.Common.Utilities;
-using DotNetNuke.Entities.Content;
-using DotNetNuke.Modules.ActiveForums.Entities;
 using DotNetNuke.Services.FileSystem;
 using DotNetNuke.Services.Journal;
-using TopicInfo = DotNetNuke.Modules.ActiveForums.Entities.TopicInfo;
 
 namespace DotNetNuke.Modules.ActiveForums
 {
     #region ReplyInfo
     public class ReplyInfo
-	{
-#region Private Members
-		private int _ReplyId;
-		private int _TopicId;
-		private int _ReplyToId;
-		private int _ContentId;
-		private int _StatusId;
-		private bool _IsApproved;
-		private bool _IsDeleted;
-		private Content _Content;
-		private Author _Author;
-#endregion
-#region Public Properties
-		public int ReplyId
-		{
-			get
-			{
-				return _ReplyId;
-			}
-			set
-			{
-				_ReplyId = value;
-			}
-		}
-		public int ReplyToId
-		{
-			get
-			{
-				return _ReplyToId;
-			}
-			set
-			{
-				_ReplyToId = value;
-			}
-		}
-		public int TopicId
-		{
-			get
-			{
-				return _TopicId;
-			}
-			set
-			{
-				_TopicId = value;
-			}
-		}
-		public int ContentId
-		{
-			get
-			{
-				return _ContentId;
-			}
-			set
-			{
-				_ContentId = value;
-			}
-		}
-		public int StatusId
-		{
-			get
-			{
-				return _StatusId;
-			}
-			set
-			{
-				_StatusId = value;
-			}
-		}
-		public bool IsApproved
-		{
-			get
-			{
-				return _IsApproved;
-			}
-			set
-			{
-				_IsApproved = value;
-			}
-		}
-		public bool IsDeleted
-		{
-			get
-			{
-				return _IsDeleted;
-			}
-			set
-			{
-				_IsDeleted = value;
-			}
-		}
-		public Content Content
-		{
-			get
-			{
-				return _Content;
-			}
-			set
-			{
-				_Content = value;
-			}
-		}
-		public Author Author
-		{
-			get
-			{
-				return _Author;
-			}
-			set
-			{
-				_Author = value;
-			}
-		}
-#endregion
-		public ReplyInfo()
-		{
-			Content = new Content();
-			Author = new Author();
-		}
-	}
-#endregion
-#region Reply Controller
-	public class ReplyController
-	{
-#region Public Methods
-		public void Reply_Delete(int PortalId, int ForumId, int TopicId, int ReplyId, int DelBehavior)
-		{
+    {
+        #region Private Members
+        private int _ReplyId;
+        private int _TopicId;
+        private int _ReplyToId;
+        private int _ContentId;
+        private int _StatusId;
+        private bool _IsApproved;
+        private bool _IsDeleted;
+        private Content _Content;
+        private Author _Author;
+        #endregion
+        #region Public Properties
+        public int ReplyId
+        {
+            get
+            {
+                return _ReplyId;
+            }
+            set
+            {
+                _ReplyId = value;
+            }
+        }
+        public int ReplyToId
+        {
+            get
+            {
+                return _ReplyToId;
+            }
+            set
+            {
+                _ReplyToId = value;
+            }
+        }
+        public int TopicId
+        {
+            get
+            {
+                return _TopicId;
+            }
+            set
+            {
+                _TopicId = value;
+            }
+        }
+        public int ContentId
+        {
+            get
+            {
+                return _ContentId;
+            }
+            set
+            {
+                _ContentId = value;
+            }
+        }
+        public int StatusId
+        {
+            get
+            {
+                return _StatusId;
+            }
+            set
+            {
+                _StatusId = value;
+            }
+        }
+        public bool IsApproved
+        {
+            get
+            {
+                return _IsApproved;
+            }
+            set
+            {
+                _IsApproved = value;
+            }
+        }
+        public bool IsDeleted
+        {
+            get
+            {
+                return _IsDeleted;
+            }
+            set
+            {
+                _IsDeleted = value;
+            }
+        }
+        public Content Content
+        {
+            get
+            {
+                return _Content;
+            }
+            set
+            {
+                _Content = value;
+            }
+        }
+        public Author Author
+        {
+            get
+            {
+                return _Author;
+            }
+            set
+            {
+                _Author = value;
+            }
+        }
+        #endregion
+        public ReplyInfo()
+        {
+            Content = new Content();
+            Author = new Author();
+        }
+    }
+    #endregion
+    #region Reply Controller
+    public class ReplyController
+    {
+        #region Public Methods
+        public void Reply_Delete(int PortalId, int ForumId, int TopicId, int ReplyId, int DelBehavior)
+        {
             DataProvider.Instance().Reply_Delete(ForumId, TopicId, ReplyId, DelBehavior);
             var objectKey = string.Format("{0}:{1}:{2}", ForumId, TopicId, ReplyId);
-			JournalController.Instance.DeleteJournalItemByKey(PortalId, objectKey);
+            JournalController.Instance.DeleteJournalItemByKey(PortalId, objectKey);
 
-		    if (DelBehavior != 0) 
+            if (DelBehavior != 0)
                 return;
 
             // If it's a hard delete, delete associated attachments
-		    var attachmentController = new Data.AttachController();
-		    var fileManager = FileManager.Instance;
+            var attachmentController = new Data.AttachController();
+            var fileManager = FileManager.Instance;
             var folderManager = FolderManager.Instance;
-		    var attachmentFolder = folderManager.GetFolder(PortalId, "activeforums_Attach");
+            var attachmentFolder = folderManager.GetFolder(PortalId, "activeforums_Attach");
 
-		    foreach(var attachment in attachmentController.ListForPost(TopicId, ReplyId))
-		    {
+            foreach (var attachment in attachmentController.ListForPost(TopicId, ReplyId))
+            {
                 attachmentController.Delete(attachment.AttachmentId);
 
                 var file = attachment.FileId.HasValue ? fileManager.GetFile(attachment.FileId.Value) : fileManager.GetFile(attachmentFolder, attachment.FileName);
 
                 // Only delete the file if it exists in the attachment folder
                 if (file != null && file.FolderId == attachmentFolder.FolderID)
-                    fileManager.DeleteFile(file); 
-		    }
-		}
-		public int Reply_QuickCreate(int PortalId, int ModuleId, int ForumId, int TopicId, int ReplyToId, string Subject, string Body, int UserId, string DisplayName, bool IsApproved, string IPAddress)
-		{
-			int replyId = -1;
-			DotNetNuke.Modules.ActiveForums.ReplyInfo ri = new DotNetNuke.Modules.ActiveForums.ReplyInfo();
-			DateTime dt = DateTime.UtcNow;
-			ri.Content.DateUpdated = dt;
-			ri.Content.DateCreated = dt;
-			ri.Content.AuthorId = UserId;
-			ri.Content.AuthorName = DisplayName;
-			ri.Content.Subject = Subject;
-			ri.Content.Body = Body;
-			ri.Content.IPAddress = IPAddress;
-			ri.Content.Summary = string.Empty;
-			ri.IsApproved = IsApproved;
-			ri.IsDeleted = false;
-			ri.ReplyToId = ReplyToId;
-			ri.StatusId = -1;
-			ri.TopicId = TopicId;
-			replyId = Reply_Save(PortalId, ModuleId, ri);
+                    fileManager.DeleteFile(file);
+            }
+        }
+        public int Reply_QuickCreate(int PortalId, int ModuleId, int ForumId, int TopicId, int ReplyToId, string Subject, string Body, int UserId, string DisplayName, bool IsApproved, string IPAddress)
+        {
+            int replyId = -1;
+            DotNetNuke.Modules.ActiveForums.ReplyInfo ri = new DotNetNuke.Modules.ActiveForums.ReplyInfo();
+            DateTime dt = DateTime.UtcNow;
+            ri.Content.DateUpdated = dt;
+            ri.Content.DateCreated = dt;
+            ri.Content.AuthorId = UserId;
+            ri.Content.AuthorName = DisplayName;
+            ri.Content.Subject = Subject;
+            ri.Content.Body = Body;
+            ri.Content.IPAddress = IPAddress;
+            ri.Content.Summary = string.Empty;
+            ri.IsApproved = IsApproved;
+            ri.IsDeleted = false;
+            ri.ReplyToId = ReplyToId;
+            ri.StatusId = -1;
+            ri.TopicId = TopicId;
+            replyId = Reply_Save(PortalId, ModuleId, ri);
             UpdateModuleLastContentModifiedOnDate(ModuleId);
             return replyId;
-		}
+        }
         [Obsolete("Deprecated in Community Forums. Scheduled removal in 09.00.00. Use ReplyController.Reply_Save(int PortalId, int ModuleId, ReplyInfo ri)")]
         public int Reply_Save(int PortalId, ReplyInfo ri)
         {
             return Reply_Save(PortalId, -1, ri);
-		}
-		public int Reply_Save(int PortalId, int ModuleId, DotNetNuke.Modules.ActiveForums.ReplyInfo ri)
+        }
+        public int Reply_Save(int PortalId, int ModuleId, DotNetNuke.Modules.ActiveForums.ReplyInfo ri)
         {
             // Clear profile Cache to make sure the LastPostDate is updated for Flood Control
-            UserProfileController.Profiles_ClearCache(ModuleId,ri.Content.AuthorId);
+            UserProfileController.Profiles_ClearCache(ModuleId, ri.Content.AuthorId);
 
             return Convert.ToInt32(DataProvider.Instance().Reply_Save(PortalId, ri.TopicId, ri.ReplyId, ri.ReplyToId, ri.StatusId, ri.IsApproved, ri.IsDeleted, ri.Content.Subject.Trim(), ri.Content.Body.Trim(), ri.Content.DateCreated, ri.Content.DateUpdated, ri.Content.AuthorId, ri.Content.AuthorName, ri.Content.IPAddress));
-		}
-		public DotNetNuke.Modules.ActiveForums.ReplyInfo Reply_Get(int PortalId, int ModuleId, int TopicId, int ReplyId)
-		{
-			IDataReader dr = DataProvider.Instance().Reply_Get(PortalId, ModuleId, TopicId, ReplyId);
-			DotNetNuke.Modules.ActiveForums.ReplyInfo ri = null;
-			while (dr.Read())
-			{
-				ri = new DotNetNuke.Modules.ActiveForums.ReplyInfo();
-				ri.ReplyId = Convert.ToInt32(dr["ReplyId"]);
-				ri.ReplyToId = Convert.ToInt32(dr["ReplyToId"]);
-				ri.Content.AuthorId = Convert.ToInt32(dr["AuthorId"]);
-				ri.Content.AuthorName = dr["AuthorName"].ToString();
-				ri.Content.Body = dr["Body"].ToString();
-				ri.Content.ContentId = Convert.ToInt32(dr["ContentId"]);
-				ri.Content.DateCreated = Convert.ToDateTime(dr["DateCreated"]);
-				ri.Content.DateUpdated = Convert.ToDateTime(dr["DateUpdated"]);
-				ri.Content.IsDeleted = Convert.ToBoolean(dr["IsDeleted"]);
-				ri.Content.Subject = dr["Subject"].ToString();
-				ri.Content.Summary = dr["Summary"].ToString();
-				ri.Content.IPAddress = dr["IPAddress"].ToString();
-				ri.Author.AuthorId = ri.Content.AuthorId;
-				ri.Author.DisplayName = dr["DisplayName"].ToString();
-				ri.Author.Email = dr["Email"].ToString();
-				ri.Author.FirstName = dr["FirstName"].ToString();
-				ri.Author.LastName = dr["LastName"].ToString();
-				ri.Author.Username = dr["Username"].ToString();
-				ri.ContentId = Convert.ToInt32(dr["ContentId"]);
-				ri.IsApproved = Convert.ToBoolean(dr["IsApproved"]);
-				ri.IsDeleted = Convert.ToBoolean(dr["IsDeleted"]);
-				ri.StatusId = Convert.ToInt32(dr["StatusId"]);
-				ri.TopicId = Convert.ToInt32(dr["TopicId"]);
-				//tl.Add(ti)
-			}
-			dr.Close();
-			return ri;
-		}
-		public DotNetNuke.Modules.ActiveForums.ReplyInfo ApproveReply(int PortalId, int TabId, int ModuleId, int ForumId, int TopicId, int ReplyId)
-		{
-			SettingsInfo ms = SettingsBase.GetModuleSettings(ModuleId);
-			ForumController fc = new ForumController();
-			Forum fi = fc.Forums_Get(ForumId, -1, false, true);
+        }
+        public DotNetNuke.Modules.ActiveForums.ReplyInfo Reply_Get(int PortalId, int ModuleId, int TopicId, int ReplyId)
+        {
+            IDataReader dr = DataProvider.Instance().Reply_Get(PortalId, ModuleId, TopicId, ReplyId);
+            DotNetNuke.Modules.ActiveForums.ReplyInfo ri = null;
+            while (dr.Read())
+            {
+                ri = new DotNetNuke.Modules.ActiveForums.ReplyInfo();
+                ri.ReplyId = Convert.ToInt32(dr["ReplyId"]);
+                ri.ReplyToId = Convert.ToInt32(dr["ReplyToId"]);
+                ri.Content.AuthorId = Convert.ToInt32(dr["AuthorId"]);
+                ri.Content.AuthorName = dr["AuthorName"].ToString();
+                ri.Content.Body = dr["Body"].ToString();
+                ri.Content.ContentId = Convert.ToInt32(dr["ContentId"]);
+                ri.Content.DateCreated = Convert.ToDateTime(dr["DateCreated"]);
+                ri.Content.DateUpdated = Convert.ToDateTime(dr["DateUpdated"]);
+                ri.Content.IsDeleted = Convert.ToBoolean(dr["IsDeleted"]);
+                ri.Content.Subject = dr["Subject"].ToString();
+                ri.Content.Summary = dr["Summary"].ToString();
+                ri.Content.IPAddress = dr["IPAddress"].ToString();
+                ri.Author.AuthorId = ri.Content.AuthorId;
+                ri.Author.DisplayName = dr["DisplayName"].ToString();
+                ri.Author.Email = dr["Email"].ToString();
+                ri.Author.FirstName = dr["FirstName"].ToString();
+                ri.Author.LastName = dr["LastName"].ToString();
+                ri.Author.Username = dr["Username"].ToString();
+                ri.ContentId = Convert.ToInt32(dr["ContentId"]);
+                ri.IsApproved = Convert.ToBoolean(dr["IsApproved"]);
+                ri.IsDeleted = Convert.ToBoolean(dr["IsDeleted"]);
+                ri.StatusId = Convert.ToInt32(dr["StatusId"]);
+                ri.TopicId = Convert.ToInt32(dr["TopicId"]);
+                //tl.Add(ti)
+            }
+            dr.Close();
+            return ri;
+        }
+        public DotNetNuke.Modules.ActiveForums.ReplyInfo ApproveReply(int PortalId, int TabId, int ModuleId, int ForumId, int TopicId, int ReplyId)
+        {
+            SettingsInfo ms = SettingsBase.GetModuleSettings(ModuleId);
+            ForumController fc = new ForumController();
+            Forum fi = fc.Forums_Get(portalId: PortalId, moduleId: ModuleId, forumId: ForumId, useCache: true);
 
-			ReplyController rc = new ReplyController();
-			DotNetNuke.Modules.ActiveForums.ReplyInfo reply = rc.Reply_Get(PortalId, ModuleId, TopicId, ReplyId);
-			if (reply == null)
-			{
-				return null;
-			}
-			reply.IsApproved = true;
-			rc.Reply_Save(PortalId, ModuleId, reply);
-			TopicsController tc = new TopicsController();
-			tc.Topics_SaveToForum(ForumId, TopicId, PortalId, ModuleId, ReplyId);
+            ReplyController rc = new ReplyController();
+            DotNetNuke.Modules.ActiveForums.ReplyInfo reply = rc.Reply_Get(PortalId, ModuleId, TopicId, ReplyId);
+            if (reply == null)
+            {
+                return null;
+            }
+            reply.IsApproved = true;
+            rc.Reply_Save(PortalId, ModuleId, reply);
+            TopicsController tc = new TopicsController();
+            tc.Topics_SaveToForum(ForumId, TopicId, PortalId, ModuleId, ReplyId);
             DotNetNuke.Modules.ActiveForums.Entities.TopicInfo topic = tc.Topics_Get(PortalId, ModuleId, TopicId, ForumId, -1, false);
 
-			if (fi.ModApproveTemplateId > 0 & reply.Author.AuthorId > 0)
-			{
-				Email.SendEmail(fi.ModApproveTemplateId, PortalId, ModuleId, TabId, ForumId, TopicId, ReplyId, string.Empty, reply.Author);
-			}
+            if (fi.ModApproveTemplateId > 0 & reply.Author.AuthorId > 0)
+            {
+                Email.SendEmail(fi.ModApproveTemplateId, PortalId, ModuleId, TabId, ForumId, TopicId, ReplyId, string.Empty, reply.Author);
+            }
 
-			Subscriptions.SendSubscriptions(PortalId, ModuleId, TabId, ForumId, TopicId, ReplyId, reply.Content.AuthorId);
+            Subscriptions.SendSubscriptions(PortalId, ModuleId, TabId, ForumId, TopicId, ReplyId, reply.Content.AuthorId);
 
-			try
-			{
-				ControlUtils ctlUtils = new ControlUtils();
+            try
+            {
+                ControlUtils ctlUtils = new ControlUtils();
                 string fullURL = ctlUtils.BuildUrl(TabId, ModuleId, fi.ForumGroup.PrefixURL, fi.PrefixURL, fi.ForumGroupId, ForumId, TopicId, topic.TopicUrl, -1, -1, string.Empty, 1, ReplyId, fi.SocialGroupId);
 
-				if (fullURL.Contains("~/"))
-				{
-					fullURL = Utilities.NavigateUrl(TabId, "", new string[] {ParamKeys.TopicId + "=" + TopicId, ParamKeys.ContentJumpId + "=" + ReplyId});
-				}
-				if (fullURL.EndsWith("/"))
-				{
+                if (fullURL.Contains("~/"))
+                {
+                    fullURL = Utilities.NavigateUrl(TabId, "", new string[] { ParamKeys.TopicId + "=" + TopicId, ParamKeys.ContentJumpId + "=" + ReplyId });
+                }
+                if (fullURL.EndsWith("/"))
+                {
                     fullURL += Utilities.UseFriendlyURLs(ModuleId) ? String.Concat("#", ReplyId) : String.Concat("?", ParamKeys.ContentJumpId, "=", ReplyId);
                 }
-				Social amas = new Social();
-				amas.AddReplyToJournal(PortalId, ModuleId,TabId, ForumId, TopicId, ReplyId, reply.Author.AuthorId, fullURL, reply.Content.Subject, string.Empty, reply.Content.Body,fi.Security.Read, fi.SocialGroupId);
-			}
-			catch (Exception ex)
-			{
-				DotNetNuke.Services.Exceptions.Exceptions.LogException(ex);
-			}
-			return reply;
-		}
+                Social amas = new Social();
+                amas.AddReplyToJournal(PortalId, ModuleId, TabId, ForumId, TopicId, ReplyId, reply.Author.AuthorId, fullURL, reply.Content.Subject, string.Empty, reply.Content.Body, fi.Security.Read, fi.SocialGroupId);
+            }
+            catch (Exception ex)
+            {
+                DotNetNuke.Services.Exceptions.Exceptions.LogException(ex);
+            }
+            return reply;
+        }
         public void UpdateModuleLastContentModifiedOnDate(int ModuleId)
         {
             // signal to platform that module has updated content in order to be included in incremental search crawls

--- a/Dnn.CommunityForums/components/Topics/TopicsController.cs
+++ b/Dnn.CommunityForums/components/Topics/TopicsController.cs
@@ -18,22 +18,17 @@
 // DEALINGS IN THE SOFTWARE.
 //
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.SqlTypes;
 using System.Linq;
-using System.Web;
-using System.Xml;
-using DotNetNuke.Services.FileSystem;
-using DotNetNuke.Services.Journal;
-using DotNetNuke.Services.Search.Entities;
 using System.Text.RegularExpressions;
 using DotNetNuke.Entities.Modules;
 using DotNetNuke.Entities.Portals;
-using System.Data.SqlTypes;
 using DotNetNuke.Instrumentation;
-using DotNetNuke.Modules.ActiveForums.Entities;
-using TopicInfo = DotNetNuke.Modules.ActiveForums.Entities.TopicInfo;
+using DotNetNuke.Services.FileSystem;
+using DotNetNuke.Services.Journal;
+using DotNetNuke.Services.Search.Entities;
 
 namespace DotNetNuke.Modules.ActiveForums
 {
@@ -42,241 +37,241 @@ namespace DotNetNuke.Modules.ActiveForums
     {
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(TopicsController));
         public int Topic_QuickCreate(int PortalId, int ModuleId, int ForumId, string Subject, string Body, int UserId, string DisplayName, bool IsApproved, string IPAddress)
-		{
-			int topicId = -1;
+        {
+            int topicId = -1;
             DotNetNuke.Modules.ActiveForums.Entities.TopicInfo ti = new DotNetNuke.Modules.ActiveForums.Entities.TopicInfo();
-			ti.AnnounceEnd = Utilities.NullDate();
-			ti.AnnounceStart = Utilities.NullDate();
-			ti.Content.AuthorId = UserId;
-			ti.Content.AuthorName = DisplayName;
-			ti.Content.Subject = Subject;
-			ti.Content.Body = Body;
-			ti.Content.Summary = string.Empty;
+            ti.AnnounceEnd = Utilities.NullDate();
+            ti.AnnounceStart = Utilities.NullDate();
+            ti.Content.AuthorId = UserId;
+            ti.Content.AuthorName = DisplayName;
+            ti.Content.Subject = Subject;
+            ti.Content.Body = Body;
+            ti.Content.Summary = string.Empty;
 
-			ti.Content.IPAddress = IPAddress;
+            ti.Content.IPAddress = IPAddress;
 
-			DateTime dt = DateTime.Now;
-			ti.Content.DateCreated = dt;
-			ti.Content.DateUpdated = dt;
-			ti.IsAnnounce = false;
-			ti.IsApproved = IsApproved;
-			ti.IsArchived = false;
-			ti.IsDeleted = false;
-			ti.IsLocked = false;
-			ti.IsPinned = false;
-			ti.ReplyCount = 0;
-			ti.StatusId = -1;
-			ti.TopicIcon = string.Empty;
-			ti.TopicType = TopicTypes.Topic;
-			ti.ViewCount = 0;
-			topicId = TopicSave(PortalId, ModuleId, ti);
+            DateTime dt = DateTime.Now;
+            ti.Content.DateCreated = dt;
+            ti.Content.DateUpdated = dt;
+            ti.IsAnnounce = false;
+            ti.IsApproved = IsApproved;
+            ti.IsArchived = false;
+            ti.IsDeleted = false;
+            ti.IsLocked = false;
+            ti.IsPinned = false;
+            ti.ReplyCount = 0;
+            ti.StatusId = -1;
+            ti.TopicIcon = string.Empty;
+            ti.TopicType = TopicTypes.Topic;
+            ti.ViewCount = 0;
+            topicId = TopicSave(PortalId, ModuleId, ti);
 
-			UpdateModuleLastContentModifiedOnDate(ModuleId);
+            UpdateModuleLastContentModifiedOnDate(ModuleId);
 
             if (topicId > 0)
-			{
-				Topics_SaveToForum(ForumId, topicId, PortalId, ModuleId);
-				if (UserId > 0)
-				{
-					Data.Profiles uc = new Data.Profiles();
-					uc.Profile_UpdateTopicCount(PortalId, UserId);
-				}
-			}
-			return topicId;
-		}
+            {
+                Topics_SaveToForum(ForumId, topicId, PortalId, ModuleId);
+                if (UserId > 0)
+                {
+                    Data.Profiles uc = new Data.Profiles();
+                    uc.Profile_UpdateTopicCount(PortalId, UserId);
+                }
+            }
+            return topicId;
+        }
 
-		public void Replies_Split(int OldTopicId, int NewTopicId, string listreplies, bool isNew)
-		{
-			Regex rgx = new Regex(@"^\d+(\|\d+)*$");
-			if (OldTopicId > 0 && NewTopicId > 0 && rgx.IsMatch(listreplies))
-			{
-				if (isNew)
-				{
-					string[] slistreplies = listreplies.Split("|".ToCharArray(), 2);
-					string str = "";
-					if (slistreplies.Length > 1) str = slistreplies[1];
-					DataProvider.Instance().Replies_Split(OldTopicId, NewTopicId, str, DateTime.Now, Convert.ToInt32(slistreplies[0]));
-				}
-				else
-				{
-					DataProvider.Instance().Replies_Split(OldTopicId, NewTopicId, listreplies, DateTime.Now, 0);
-				}
-			}
-		}
+        public void Replies_Split(int OldTopicId, int NewTopicId, string listreplies, bool isNew)
+        {
+            Regex rgx = new Regex(@"^\d+(\|\d+)*$");
+            if (OldTopicId > 0 && NewTopicId > 0 && rgx.IsMatch(listreplies))
+            {
+                if (isNew)
+                {
+                    string[] slistreplies = listreplies.Split("|".ToCharArray(), 2);
+                    string str = "";
+                    if (slistreplies.Length > 1) str = slistreplies[1];
+                    DataProvider.Instance().Replies_Split(OldTopicId, NewTopicId, str, DateTime.Now, Convert.ToInt32(slistreplies[0]));
+                }
+                else
+                {
+                    DataProvider.Instance().Replies_Split(OldTopicId, NewTopicId, listreplies, DateTime.Now, 0);
+                }
+            }
+        }
         [Obsolete("Deprecated in Community Forums. Scheduled removal in 09.00.00. Use TopicsController.TopicSave(int PortalId, int ModuleId, TopicInfo ti)")]
         public int TopicSave(int PortalId, TopicInfo ti)
         {
-			return TopicSave(PortalId, -1, ti);          
+            return TopicSave(PortalId, -1, ti);
         }
         public int TopicSave(int PortalId, int ModuleId, DotNetNuke.Modules.ActiveForums.Entities.TopicInfo ti)
         {
             // Clear profile Cache to make sure the LastPostDate is updated for Flood Control
-            UserProfileController.Profiles_ClearCache(ModuleId , ti.Content.AuthorId);
+            UserProfileController.Profiles_ClearCache(ModuleId, ti.Content.AuthorId);
 
             return Convert.ToInt32(DataProvider.Instance().Topics_Save(PortalId, ti.TopicId, ti.ViewCount, ti.ReplyCount, ti.IsLocked, ti.IsPinned, ti.TopicIcon, ti.StatusId, ti.IsApproved, ti.IsDeleted, ti.IsAnnounce, ti.IsArchived, ti.AnnounceStart, ti.AnnounceEnd, ti.Content.Subject.Trim(), ti.Content.Body.Trim(), ti.Content.Summary.Trim(), ti.Content.DateCreated, ti.Content.DateUpdated, ti.Content.AuthorId, ti.Content.AuthorName, ti.Content.IPAddress, (int)ti.TopicType, ti.Priority, ti.TopicUrl, ti.TopicData));
 
         }
         public int Topics_SaveToForum(int ForumId, int TopicId, int PortalId, int ModuleId)
-		{
-			int id = Topics_SaveToForum(ForumId, TopicId, PortalId, ModuleId, -1);
-			return id;
-		}
-		public int Topics_SaveToForum(int ForumId, int TopicId, int PortalId, int ModuleId, int LastReplyId)
-		{
-            UpdateModuleLastContentModifiedOnDate (ModuleId); 
-			int id = Convert.ToInt32(DataProvider.Instance().Topics_SaveToForum(ForumId, TopicId, LastReplyId)); 
-            
-			return id;
-		}
-		public DotNetNuke.Modules.ActiveForums.Entities.TopicInfo Topics_Get(int PortalId, int ModuleId, int TopicId)
-		{
-			return Topics_Get(PortalId, ModuleId, TopicId, -1, -1, false);
-		}
-		public DotNetNuke.Modules.ActiveForums.Entities.TopicInfo Topics_Get(int PortalId, int ModuleId, int TopicId, int ForumId, int UserId, bool WithSecurity)
-		{
-			IDataReader dr = DataProvider.Instance().Topics_Get(PortalId, ModuleId, TopicId, ForumId, UserId, WithSecurity);
+        {
+            int id = Topics_SaveToForum(ForumId, TopicId, PortalId, ModuleId, -1);
+            return id;
+        }
+        public int Topics_SaveToForum(int ForumId, int TopicId, int PortalId, int ModuleId, int LastReplyId)
+        {
+            UpdateModuleLastContentModifiedOnDate(ModuleId);
+            int id = Convert.ToInt32(DataProvider.Instance().Topics_SaveToForum(ForumId, TopicId, LastReplyId));
+
+            return id;
+        }
+        public DotNetNuke.Modules.ActiveForums.Entities.TopicInfo Topics_Get(int PortalId, int ModuleId, int TopicId)
+        {
+            return Topics_Get(PortalId, ModuleId, TopicId, -1, -1, false);
+        }
+        public DotNetNuke.Modules.ActiveForums.Entities.TopicInfo Topics_Get(int PortalId, int ModuleId, int TopicId, int ForumId, int UserId, bool WithSecurity)
+        {
+            IDataReader dr = DataProvider.Instance().Topics_Get(PortalId, ModuleId, TopicId, ForumId, UserId, WithSecurity);
             DotNetNuke.Modules.ActiveForums.Entities.TopicInfo ti = null;
-			while (dr.Read())
-			{
-				ti = new DotNetNuke.Modules.ActiveForums.Entities.TopicInfo();
+            while (dr.Read())
+            {
+                ti = new DotNetNuke.Modules.ActiveForums.Entities.TopicInfo();
 
-				if (!(dr["AnnounceEnd"] == DBNull.Value))
-				{
-					ti.AnnounceEnd = Convert.ToDateTime(dr["AnnounceEnd"]);
-				}
+                if (!(dr["AnnounceEnd"] == DBNull.Value))
+                {
+                    ti.AnnounceEnd = Convert.ToDateTime(dr["AnnounceEnd"]);
+                }
 
-				if (!(dr["AnnounceStart"] == DBNull.Value))
-				{
-					ti.AnnounceStart = Convert.ToDateTime(dr["AnnounceStart"]);
-				}
-				ti.Content.AuthorId = Convert.ToInt32(dr["AuthorId"]);
-				ti.Content.AuthorName = dr["AuthorName"].ToString();
-				ti.Content.Body = dr["Body"].ToString();
-				ti.Content.ContentId = Convert.ToInt32(dr["ContentId"]);
-				ti.Content.DateCreated = Convert.ToDateTime(dr["DateCreated"]);
-				ti.Content.DateUpdated = Convert.ToDateTime(dr["DateUpdated"]);
-				ti.Content.IsDeleted = Convert.ToBoolean(dr["IsDeleted"]);
-				ti.Content.Subject = dr["Subject"].ToString();
-				ti.Content.Summary = dr["Summary"].ToString();
-				ti.ContentId = Convert.ToInt32(dr["ContentId"]);
-				ti.Author.AuthorId = ti.Content.AuthorId;
-				ti.Author.DisplayName = dr["DisplayName"].ToString();
-				ti.Author.Email = dr["Email"].ToString();
-				ti.Author.FirstName = dr["FirstName"].ToString();
-				ti.Author.LastName = dr["LastName"].ToString();
-				ti.Author.Username = dr["Username"].ToString();
-				ti.IsAnnounce = Convert.ToBoolean(dr["IsAnnounce"]);
-				ti.IsApproved = Convert.ToBoolean(dr["IsApproved"]);
-				ti.IsArchived = Convert.ToBoolean(dr["IsArchived"]);
-				ti.IsDeleted = Convert.ToBoolean(dr["IsDeleted"]);
-				ti.IsLocked = Convert.ToBoolean(dr["IsLocked"]);
-				ti.IsPinned = Convert.ToBoolean(dr["IsPinned"]);
-				ti.ReplyCount = Convert.ToInt32(dr["ReplyCount"]);
-				ti.StatusId = Convert.ToInt32(dr["StatusId"]);
-				ti.TopicIcon = Convert.ToString(dr["TopicIcon"]);
-				ti.TopicId = Convert.ToInt32(dr["TopicId"]);
-				ti.TopicType = (TopicTypes)(dr["TopicType"]);
-				ti.ViewCount = Convert.ToInt32(dr["ViewCount"]);
-				ti.Tags = dr["Tags"].ToString();
-				ti.Priority = Convert.ToInt32(dr["Priority"].ToString());
-				ti.Categories = dr["Categories"].ToString();
-				ti.ForumURL = dr["ForumURL"].ToString();
-				ti.TopicUrl = dr["TopicURL"].ToString();
-				//.URL = dr("URL").ToString
-				try
-				{
-					ti.TopicData = dr["TopicData"].ToString();
-				}
-				catch (Exception ex)
-				{
-					ti.TopicData = string.Empty;
-				}
+                if (!(dr["AnnounceStart"] == DBNull.Value))
+                {
+                    ti.AnnounceStart = Convert.ToDateTime(dr["AnnounceStart"]);
+                }
+                ti.Content.AuthorId = Convert.ToInt32(dr["AuthorId"]);
+                ti.Content.AuthorName = dr["AuthorName"].ToString();
+                ti.Content.Body = dr["Body"].ToString();
+                ti.Content.ContentId = Convert.ToInt32(dr["ContentId"]);
+                ti.Content.DateCreated = Convert.ToDateTime(dr["DateCreated"]);
+                ti.Content.DateUpdated = Convert.ToDateTime(dr["DateUpdated"]);
+                ti.Content.IsDeleted = Convert.ToBoolean(dr["IsDeleted"]);
+                ti.Content.Subject = dr["Subject"].ToString();
+                ti.Content.Summary = dr["Summary"].ToString();
+                ti.ContentId = Convert.ToInt32(dr["ContentId"]);
+                ti.Author.AuthorId = ti.Content.AuthorId;
+                ti.Author.DisplayName = dr["DisplayName"].ToString();
+                ti.Author.Email = dr["Email"].ToString();
+                ti.Author.FirstName = dr["FirstName"].ToString();
+                ti.Author.LastName = dr["LastName"].ToString();
+                ti.Author.Username = dr["Username"].ToString();
+                ti.IsAnnounce = Convert.ToBoolean(dr["IsAnnounce"]);
+                ti.IsApproved = Convert.ToBoolean(dr["IsApproved"]);
+                ti.IsArchived = Convert.ToBoolean(dr["IsArchived"]);
+                ti.IsDeleted = Convert.ToBoolean(dr["IsDeleted"]);
+                ti.IsLocked = Convert.ToBoolean(dr["IsLocked"]);
+                ti.IsPinned = Convert.ToBoolean(dr["IsPinned"]);
+                ti.ReplyCount = Convert.ToInt32(dr["ReplyCount"]);
+                ti.StatusId = Convert.ToInt32(dr["StatusId"]);
+                ti.TopicIcon = Convert.ToString(dr["TopicIcon"]);
+                ti.TopicId = Convert.ToInt32(dr["TopicId"]);
+                ti.TopicType = (TopicTypes)(dr["TopicType"]);
+                ti.ViewCount = Convert.ToInt32(dr["ViewCount"]);
+                ti.Tags = dr["Tags"].ToString();
+                ti.Priority = Convert.ToInt32(dr["Priority"].ToString());
+                ti.Categories = dr["Categories"].ToString();
+                ti.ForumURL = dr["ForumURL"].ToString();
+                ti.TopicUrl = dr["TopicURL"].ToString();
+                //.URL = dr("URL").ToString
+                try
+                {
+                    ti.TopicData = dr["TopicData"].ToString();
+                }
+                catch (Exception ex)
+                {
+                    ti.TopicData = string.Empty;
+                }
 
-			}
-			//If WithSecurity Then
-			//    dr.NextResult()
-			//    'Dim tmpDr As IDataReader = dr
-			//    ti.Security = CType(DotNetNuke.Common.Utilities.CBO.FillObject(dr, GetType(PermissionInfo)), PermissionInfo)
-			//End If
+            }
+            //If WithSecurity Then
+            //    dr.NextResult()
+            //    'Dim tmpDr As IDataReader = dr
+            //    ti.Security = CType(DotNetNuke.Common.Utilities.CBO.FillObject(dr, GetType(PermissionInfo)), PermissionInfo)
+            //End If
 
-			if (!dr.IsClosed)
-			{
-				dr.Close();
-			}
+            if (!dr.IsClosed)
+            {
+                dr.Close();
+            }
 
-			return ti;
-		}
-		public void Topics_Delete(int PortalId, int ModuleId, int ForumId, int TopicId, int DelBehavior)
-		{
+            return ti;
+        }
+        public void Topics_Delete(int PortalId, int ModuleId, int ForumId, int TopicId, int DelBehavior)
+        {
             UpdateModuleLastContentModifiedOnDate(ModuleId);
 
             DataProvider.Instance().Topics_Delete(ForumId, TopicId, DelBehavior);
-			DataCache.CacheClearPrefix(ModuleId, string.Format(CacheKeys.ForumViewPrefix, ModuleId));
-			try
-			{
-				var objectKey = string.Format("{0}:{1}", ForumId, TopicId);
-				JournalController.Instance.DeleteJournalItemByKey(PortalId, objectKey);
-			}
-			catch (Exception ex)
-			{
+            DataCache.CacheClearPrefix(ModuleId, string.Format(CacheKeys.ForumViewPrefix, ModuleId));
+            try
+            {
+                var objectKey = string.Format("{0}:{1}", ForumId, TopicId);
+                JournalController.Instance.DeleteJournalItemByKey(PortalId, objectKey);
+            }
+            catch (Exception ex)
+            {
 
-			}
+            }
 
-			if (DelBehavior != 0)
-				return;
+            if (DelBehavior != 0)
+                return;
 
-			// If it's a hard delete, delete associated attachments
-			var attachmentController = new Data.AttachController();
-			var fileManager = FileManager.Instance;
-			var folderManager = FolderManager.Instance;
-			var attachmentFolder = folderManager.GetFolder(PortalId, "activeforums_Attach");
+            // If it's a hard delete, delete associated attachments
+            var attachmentController = new Data.AttachController();
+            var fileManager = FileManager.Instance;
+            var folderManager = FolderManager.Instance;
+            var attachmentFolder = folderManager.GetFolder(PortalId, "activeforums_Attach");
 
-			foreach (var attachment in attachmentController.ListForPost(TopicId, null))
-			{
-				attachmentController.Delete(attachment.AttachmentId);
+            foreach (var attachment in attachmentController.ListForPost(TopicId, null))
+            {
+                attachmentController.Delete(attachment.AttachmentId);
 
-				var file = attachment.FileId.HasValue ? fileManager.GetFile(attachment.FileId.Value) : fileManager.GetFile(attachmentFolder, attachment.FileName);
+                var file = attachment.FileId.HasValue ? fileManager.GetFile(attachment.FileId.Value) : fileManager.GetFile(attachmentFolder, attachment.FileName);
 
-				// Only delete the file if it exists in the attachment folder
-				if (file != null && file.FolderId == attachmentFolder.FolderID)
-					fileManager.DeleteFile(file);
-			}
+                // Only delete the file if it exists in the attachment folder
+                if (file != null && file.FolderId == attachmentFolder.FolderID)
+                    fileManager.DeleteFile(file);
+            }
 
-		}
-		public void Topics_Move(int PortalId, int ModuleId, int ForumId, int TopicId)
-		{
-			SettingsInfo settings = SettingsBase.GetModuleSettings(ModuleId);
-			if (settings.URLRewriteEnabled)
-			{
-				try
-				{
-					Data.ForumsDB db = new Data.ForumsDB();
-					int oldForumId = -1;
-					oldForumId = db.Forum_GetByTopicId(TopicId);
-					ForumController fc = new ForumController();
-					Forum fi = fc.Forums_Get(oldForumId, -1, false);
+        }
+        public void Topics_Move(int PortalId, int ModuleId, int ForumId, int TopicId)
+        {
+            SettingsInfo settings = SettingsBase.GetModuleSettings(ModuleId);
+            if (settings.URLRewriteEnabled)
+            {
+                try
+                {
+                    Data.ForumsDB db = new Data.ForumsDB();
+                    int oldForumId = -1;
+                    oldForumId = db.Forum_GetByTopicId(TopicId);
+                    ForumController fc = new ForumController();
+                    Forum fi = fc.Forums_Get(portalId: PortalId, moduleId: ModuleId, forumId: oldForumId, useCache: true);
 
-					if (!(string.IsNullOrEmpty(fi.PrefixURL)))
-					{
-						Data.Common dbC = new Data.Common();
-						string sURL = dbC.GetUrl(ModuleId, fi.ForumGroupId, oldForumId, TopicId, -1, -1);
-						if (!(string.IsNullOrEmpty(sURL)))
-						{
-							dbC.ArchiveURL(PortalId, fi.ForumGroupId, ForumId, TopicId, sURL);
-						}
-					}
-				}
-				catch (Exception ex)
-				{
+                    if (!(string.IsNullOrEmpty(fi.PrefixURL)))
+                    {
+                        Data.Common dbC = new Data.Common();
+                        string sURL = dbC.GetUrl(ModuleId, fi.ForumGroupId, oldForumId, TopicId, -1, -1);
+                        if (!(string.IsNullOrEmpty(sURL)))
+                        {
+                            dbC.ArchiveURL(PortalId, fi.ForumGroupId, ForumId, TopicId, sURL);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
 
-				}
-			}
+                }
+            }
             DataProvider.Instance().Topics_Move(PortalId, ModuleId, ForumId, TopicId);
             UpdateModuleLastContentModifiedOnDate(ModuleId);
         }
 
-		#region "Obsolete ISearchable replaced by DotNetNuke.Entities.Modules.ModuleSearchBase.GetModifiedSearchDocuments "
-		/*
+        #region "Obsolete ISearchable replaced by DotNetNuke.Entities.Modules.ModuleSearchBase.GetModifiedSearchDocuments "
+        /*
 		public DotNetNuke.Services.Search.SearchItemInfoCollection GetSearchItems(DotNetNuke.Entities.Modules.ModuleInfo ModInfo)
 		{
 			DotNetNuke.Services.Search.SearchItemInfoCollection SearchItemCollection = new DotNetNuke.Services.Search.SearchItemInfoCollection();
@@ -337,55 +332,55 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 		}
 		*/
-		#endregion "Obsolete ISearchable replaced by DotNetNuke.Entities.Modules.ModuleSearchBase.GetModifiedSearchDocuments "
+        #endregion "Obsolete ISearchable replaced by DotNetNuke.Entities.Modules.ModuleSearchBase.GetModifiedSearchDocuments "
 
-		public DotNetNuke.Modules.ActiveForums.Entities.TopicInfo ApproveTopic(int PortalId, int TabId, int ModuleId, int ForumId, int TopicId)
-		{
-			SettingsInfo ms = SettingsBase.GetModuleSettings(ModuleId);
-			ForumController fc = new ForumController();
-			Forum fi = fc.Forums_Get(ForumId, -1, false, true);
+        public DotNetNuke.Modules.ActiveForums.Entities.TopicInfo ApproveTopic(int PortalId, int TabId, int ModuleId, int ForumId, int TopicId)
+        {
+            SettingsInfo ms = SettingsBase.GetModuleSettings(ModuleId);
+            ForumController fc = new ForumController();
+            Forum fi = fc.Forums_Get(portalId: PortalId, moduleId: ModuleId, forumId: ForumId, useCache: true);
 
-			TopicsController tc = new TopicsController();
+            TopicsController tc = new TopicsController();
             DotNetNuke.Modules.ActiveForums.Entities.TopicInfo topic = tc.Topics_Get(PortalId, ModuleId, TopicId, ForumId, -1, false);
-			if (topic == null)
-			{
-				return null;
-			}
-			topic.IsApproved = true;
-			tc.TopicSave(PortalId, ModuleId, topic);
-			tc.Topics_SaveToForum(ForumId, TopicId, PortalId, ModuleId);
-            
+            if (topic == null)
+            {
+                return null;
+            }
+            topic.IsApproved = true;
+            tc.TopicSave(PortalId, ModuleId, topic);
+            tc.Topics_SaveToForum(ForumId, TopicId, PortalId, ModuleId);
+
             if (fi.ModApproveTemplateId > 0 & topic.Author.AuthorId > 0)
-			{
-				Email.SendEmail(fi.ModApproveTemplateId, PortalId, ModuleId, TabId, ForumId, TopicId, 0, string.Empty, topic.Author);
-			}
+            {
+                Email.SendEmail(fi.ModApproveTemplateId, PortalId, ModuleId, TabId, ForumId, TopicId, 0, string.Empty, topic.Author);
+            }
 
-			Subscriptions.SendSubscriptions(PortalId, ModuleId, TabId, ForumId, TopicId, 0, topic.Content.AuthorId);
+            Subscriptions.SendSubscriptions(PortalId, ModuleId, TabId, ForumId, TopicId, 0, topic.Content.AuthorId);
 
-			try
-			{
-				ControlUtils ctlUtils = new ControlUtils();
-				string sUrl = ctlUtils.BuildUrl(TabId, ModuleId, fi.ForumGroup.PrefixURL, fi.PrefixURL, fi.ForumGroupId, fi.ForumID, TopicId, topic.TopicUrl, -1, -1, string.Empty, 1, -1, fi.SocialGroupId);
-				Social amas = new Social();
-				amas.AddTopicToJournal(PortalId, ModuleId,TabId, ForumId, TopicId, topic.Author.AuthorId, sUrl, topic.Content.Subject, string.Empty, topic.Content.Body,  fi.Security.Read, fi.SocialGroupId);
-			}
-			catch (Exception ex)
-			{
-				DotNetNuke.Services.Exceptions.Exceptions.LogException(ex);
-			}
-			return topic;
-		}
+            try
+            {
+                ControlUtils ctlUtils = new ControlUtils();
+                string sUrl = ctlUtils.BuildUrl(TabId, ModuleId, fi.ForumGroup.PrefixURL, fi.PrefixURL, fi.ForumGroupId, fi.ForumID, TopicId, topic.TopicUrl, -1, -1, string.Empty, 1, -1, fi.SocialGroupId);
+                Social amas = new Social();
+                amas.AddTopicToJournal(PortalId, ModuleId, TabId, ForumId, TopicId, topic.Author.AuthorId, sUrl, topic.Content.Subject, string.Empty, topic.Content.Body, fi.Security.Read, fi.SocialGroupId);
+            }
+            catch (Exception ex)
+            {
+                DotNetNuke.Services.Exceptions.Exceptions.LogException(ex);
+            }
+            return topic;
+        }
         public void UpdateModuleLastContentModifiedOnDate(int ModuleId)
         {
-			// signal to platform that module has updated content in order to be included in incremental search crawls
+            // signal to platform that module has updated content in order to be included in incremental search crawls
             DotNetNuke.Data.DataProvider.Instance().UpdateModuleLastContentModifiedOnDate(ModuleId);
         }
 
         #region ModuleSearchBase
 
         public override IList<SearchDocument> GetModifiedSearchDocuments(ModuleInfo moduleInfo, DateTime beginDateUtc)
-		{
-			/*
+        {
+            /*
 			 * NOTE: In search results, the "source" display name comes from Module's display name, e.g. "Active Forums".
 			 * If you want to override this, 
 			 *     add an entry to ~/DesktopModules/Admin/SearchResults/App_LocalResources/SearchableModules.resx for the Module_[MODULENAME].text 
@@ -398,143 +393,143 @@ namespace DotNetNuke.Modules.ActiveForums
 			 * A possible future enhancement might be to write this entry or to perhaps change the module definition ...
 			 * 
 			 */
-			var ms = new SettingsInfo { MainSettings = moduleInfo.ModuleSettings };
+            var ms = new SettingsInfo { MainSettings = moduleInfo.ModuleSettings };
             /* if not using soft deletes, remove and rebuild entire index; 
 			   note that this "internals" method is suggested by blog post (https://www.dnnsoftware.com/community-blog/cid/154913/integrating-with-search-introducing-modulesearchbase#Comment106)
 			   and also is used by the Community Links module (https://github.com/DNNCommunity/DNN.Links/blob/development/Components/FeatureController.cs)
 			*/
             if (ms.DeleteBehavior != 1)
-			{
-				DotNetNuke.Services.Search.Internals.InternalSearchController.Instance.DeleteSearchDocumentsByModule(moduleInfo.PortalID, moduleInfo.ModuleID, moduleInfo.ModuleDefID);
-				beginDateUtc = SqlDateTime.MinValue.Value.AddDays(1);
+            {
+                DotNetNuke.Services.Search.Internals.InternalSearchController.Instance.DeleteSearchDocumentsByModule(moduleInfo.PortalID, moduleInfo.ModuleID, moduleInfo.ModuleDefID);
+                beginDateUtc = SqlDateTime.MinValue.Value.AddDays(1);
             }
 
-			/* since this code runs without HttpContext, get https:// by looking at page settings */
-			bool isHttps = DotNetNuke.Entities.Tabs.TabController.Instance.GetTab(moduleInfo.TabID, moduleInfo.PortalID).IsSecure;
+            /* since this code runs without HttpContext, get https:// by looking at page settings */
+            bool isHttps = DotNetNuke.Entities.Tabs.TabController.Instance.GetTab(moduleInfo.TabID, moduleInfo.PortalID).IsSecure;
             bool useFriendlyURLs = Utilities.UseFriendlyURLs(moduleInfo.ModuleID);
             string primaryPortalAlias = DotNetNuke.Entities.Portals.PortalAliasController.Instance.GetPortalAliasesByPortalId(moduleInfo.PortalID).FirstOrDefault(x => x.IsPrimary).HTTPAlias;
-			
-			ForumController fc = new ForumController();
-			Dictionary<int, string> AuthorizedRolesForForum = new Dictionary<int, string>();
-			Dictionary<int, string> ForumUrlPrefixes = new Dictionary<int, string>();
-			 
-			List<string> roles = new List<string>();
-			foreach (DotNetNuke.Security.Roles.RoleInfo r in DotNetNuke.Security.Roles.RoleController.Instance.GetRoles(portalId: moduleInfo.PortalID))
-			{
-				roles.Add(r.RoleName);
-			}
-			string roleIds = Permissions.GetRoleIds(roles.ToArray(), moduleInfo.PortalID);
 
-			string queryString = string.Empty;
-			System.Text.StringBuilder qsb = new System.Text.StringBuilder();
-			List<SearchDocument> searchDocuments = new List<SearchDocument>();
-			IDataReader dr = null;
-			try
-			{
-				dr = DataProvider.Instance().Search_DotNetNuke(moduleInfo.ModuleID, beginDateUtc);
-				while (dr.Read())
-				{
+            ForumController fc = new ForumController();
+            Dictionary<int, string> AuthorizedRolesForForum = new Dictionary<int, string>();
+            Dictionary<int, string> ForumUrlPrefixes = new Dictionary<int, string>();
+
+            List<string> roles = new List<string>();
+            foreach (DotNetNuke.Security.Roles.RoleInfo r in DotNetNuke.Security.Roles.RoleController.Instance.GetRoles(portalId: moduleInfo.PortalID))
+            {
+                roles.Add(r.RoleName);
+            }
+            string roleIds = Permissions.GetRoleIds(roles.ToArray(), moduleInfo.PortalID);
+
+            string queryString = string.Empty;
+            System.Text.StringBuilder qsb = new System.Text.StringBuilder();
+            List<SearchDocument> searchDocuments = new List<SearchDocument>();
+            IDataReader dr = null;
+            try
+            {
+                dr = DataProvider.Instance().Search_DotNetNuke(moduleInfo.ModuleID, beginDateUtc);
+                while (dr.Read())
+                {
                     string subject = dr["Subject"].ToString();
-					string description = string.Empty;
-					string body = dr["Body"].ToString();
-					List<string> tags = dr["Tags"].ToString().Split(",".ToCharArray()).ToList();
-					DateTime dateupdated = Convert.ToDateTime(dr["DateUpdated"]);
-					int authorid = Convert.ToInt32(dr["AuthorId"]);
-					bool isDeleted = Convert.ToBoolean(dr["isDeleted"]);
-					bool isApproved = Convert.ToBoolean(dr["isApproved"]);
-					int contentid = Convert.ToInt32(dr["ContentId"]);
-					int forumid = Convert.ToInt32(dr["ForumId"]);
-					int topicid = Convert.ToInt32(dr["TopicId"]);
-					int replyId = Convert.ToInt32(dr["ReplyId"]);
-					int jumpid = (replyId > 0) ? replyId : topicid;
-					body = Common.Utilities.HtmlUtils.Clean(body, false);
-					if (!(string.IsNullOrEmpty(body)))
-					{
-						description = body.Length > 100 ? body.Substring(0, 100) + "..." : body;
-					};
+                    string description = string.Empty;
+                    string body = dr["Body"].ToString();
+                    List<string> tags = dr["Tags"].ToString().Split(",".ToCharArray()).ToList();
+                    DateTime dateupdated = Convert.ToDateTime(dr["DateUpdated"]);
+                    int authorid = Convert.ToInt32(dr["AuthorId"]);
+                    bool isDeleted = Convert.ToBoolean(dr["isDeleted"]);
+                    bool isApproved = Convert.ToBoolean(dr["isApproved"]);
+                    int contentid = Convert.ToInt32(dr["ContentId"]);
+                    int forumid = Convert.ToInt32(dr["ForumId"]);
+                    int topicid = Convert.ToInt32(dr["TopicId"]);
+                    int replyId = Convert.ToInt32(dr["ReplyId"]);
+                    int jumpid = (replyId > 0) ? replyId : topicid;
+                    body = Common.Utilities.HtmlUtils.Clean(body, false);
+                    if (!(string.IsNullOrEmpty(body)))
+                    {
+                        description = body.Length > 100 ? body.Substring(0, 100) + "..." : body;
+                    };
 
-					// NOTE: indexer is called from scheduler and has no httpcontext 
-					// so any code that relies on HttpContext cannot be used...
+                    // NOTE: indexer is called from scheduler and has no httpcontext 
+                    // so any code that relies on HttpContext cannot be used...
 
-					string forumPrefixUrl = string.Empty;
-					if (!ForumUrlPrefixes.TryGetValue(forumid, out forumPrefixUrl))
-					{
-						forumPrefixUrl = fc.Forums_Get(forumid, -1, false, true).PrefixURL;
-						ForumUrlPrefixes.Add(forumid, forumPrefixUrl);
-					}
-					string link = string.Empty;
-					if (!string.IsNullOrEmpty(forumPrefixUrl) && useFriendlyURLs)
-					{
-						link = new Data.Common().GetUrl(moduleInfo.ModuleID, -1, forumid, topicid, -1, contentid);
-					}
-					else
+                    string forumPrefixUrl = string.Empty;
+                    if (!ForumUrlPrefixes.TryGetValue(forumid, out forumPrefixUrl))
+                    {
+                        forumPrefixUrl = fc.Forums_Get(portalId: moduleInfo.PortalID, moduleId: moduleInfo.ModuleID, forumId: forumid, useCache: true).PrefixURL;
+                        ForumUrlPrefixes.Add(forumid, forumPrefixUrl);
+                    }
+                    string link = string.Empty;
+                    if (!string.IsNullOrEmpty(forumPrefixUrl) && useFriendlyURLs)
+                    {
+                        link = new Data.Common().GetUrl(moduleInfo.ModuleID, -1, forumid, topicid, -1, contentid);
+                    }
+                    else
                     {
                         PortalSettings portalSettings = DotNetNuke.Modules.ActiveForums.Utilities.GetPortalSettings();
-						string[] additionalParameters;
-						try
+                        string[] additionalParameters;
+                        try
                         {
                             if (replyId == 0)
-							{
-								additionalParameters = ms.UseShortUrls ? new[] { ParamKeys.TopicId + "=" + topicid } : new[] { ParamKeys.ForumId + "=" + forumid, ParamKeys.ViewType + "=" + Views.Topic, ParamKeys.TopicId + "=" + topicid };
-							}
-							else
-							{
+                            {
+                                additionalParameters = ms.UseShortUrls ? new[] { ParamKeys.TopicId + "=" + topicid } : new[] { ParamKeys.ForumId + "=" + forumid, ParamKeys.ViewType + "=" + Views.Topic, ParamKeys.TopicId + "=" + topicid };
+                            }
+                            else
+                            {
                                 additionalParameters = ms.UseShortUrls ? new[] { ParamKeys.TopicId + "=" + topicid, ParamKeys.ContentJumpId + "=" + replyId } : new[] { ParamKeys.ForumId + "=" + forumid, ParamKeys.ViewType + "=" + Views.Topic, ParamKeys.TopicId + "=" + topicid, ParamKeys.ContentJumpId + "=" + replyId };
                             }
-							link = Common.Globals.NavigateURL(settings:portalSettings, tabID: moduleInfo.TabID, controlKey: string.Empty, additionalParameters: additionalParameters);
+                            link = Common.Globals.NavigateURL(settings: portalSettings, tabID: moduleInfo.TabID, controlKey: string.Empty, additionalParameters: additionalParameters);
                         }
-						catch 
-						{
-						}
-					}
-					if (!(string.IsNullOrEmpty(link)) && !(link.StartsWith("http")) && !link.StartsWith("/"))
-					{
-						link = (isHttps ? "https://" : "http://") + primaryPortalAlias + "/" + link;
-					}
-					queryString = qsb.Clear().Append(ParamKeys.ForumId).Append("=").Append(forumid).Append("&").Append(ParamKeys.TopicId).Append("=").Append(topicid).Append("&").Append(ParamKeys.ViewType).Append("=").Append(Views.Topic).Append("&").Append(ParamKeys.ContentJumpId).Append("=").Append(jumpid).ToString();
-					string permittedRolesCanView = string.Empty;
-					if (!AuthorizedRolesForForum.TryGetValue(forumid, out permittedRolesCanView))
-					{
-						var canView = new Data.Common().WhichRolesCanViewForum(moduleInfo.ModuleID, forumid, roleIds);
-						permittedRolesCanView = Permissions.GetRoleNames(moduleInfo.PortalID, string.Join(";", canView.Split(":".ToCharArray())));
-						AuthorizedRolesForForum.Add(forumid, permittedRolesCanView);
-					}
-					var searchDoc = new SearchDocument
-					{
-						UniqueKey = moduleInfo.ModuleID.ToString() + "-" + contentid.ToString(),
-						AuthorUserId = authorid,
-						PortalId = moduleInfo.PortalID,
-						Title = subject,
-						Description = description,
-						Body = body,
-						Url = link,
-						QueryString = queryString,
-						ModifiedTimeUtc = dateupdated,
-						Tags = (tags.Count > 0 ? tags : null),
-						Permissions = permittedRolesCanView,
-						IsActive = (isApproved && !isDeleted)
-					};
-					searchDocuments.Add(searchDoc);
-				};
-				dr.Close();
-				return searchDocuments;
-			}
-			catch (Exception ex)
-			{
-				return null;
-			}
-			finally
-			{
-				if (dr != null)
-				{
-					if (!dr.IsClosed)
-					{
-						dr.Close();
-					}
-				}
-			}
+                        catch
+                        {
+                        }
+                    }
+                    if (!(string.IsNullOrEmpty(link)) && !(link.StartsWith("http")) && !link.StartsWith("/"))
+                    {
+                        link = (isHttps ? "https://" : "http://") + primaryPortalAlias + "/" + link;
+                    }
+                    queryString = qsb.Clear().Append(ParamKeys.ForumId).Append("=").Append(forumid).Append("&").Append(ParamKeys.TopicId).Append("=").Append(topicid).Append("&").Append(ParamKeys.ViewType).Append("=").Append(Views.Topic).Append("&").Append(ParamKeys.ContentJumpId).Append("=").Append(jumpid).ToString();
+                    string permittedRolesCanView = string.Empty;
+                    if (!AuthorizedRolesForForum.TryGetValue(forumid, out permittedRolesCanView))
+                    {
+                        var canView = new Data.Common().WhichRolesCanViewForum(moduleInfo.ModuleID, forumid, roleIds);
+                        permittedRolesCanView = Permissions.GetRoleNames(moduleInfo.PortalID, string.Join(";", canView.Split(":".ToCharArray())));
+                        AuthorizedRolesForForum.Add(forumid, permittedRolesCanView);
+                    }
+                    var searchDoc = new SearchDocument
+                    {
+                        UniqueKey = moduleInfo.ModuleID.ToString() + "-" + contentid.ToString(),
+                        AuthorUserId = authorid,
+                        PortalId = moduleInfo.PortalID,
+                        Title = subject,
+                        Description = description,
+                        Body = body,
+                        Url = link,
+                        QueryString = queryString,
+                        ModifiedTimeUtc = dateupdated,
+                        Tags = (tags.Count > 0 ? tags : null),
+                        Permissions = permittedRolesCanView,
+                        IsActive = (isApproved && !isDeleted)
+                    };
+                    searchDocuments.Add(searchDoc);
+                };
+                dr.Close();
+                return searchDocuments;
+            }
+            catch (Exception ex)
+            {
+                return null;
+            }
+            finally
+            {
+                if (dr != null)
+                {
+                    if (!dr.IsClosed)
+                    {
+                        dr.Close();
+                    }
+                }
+            }
 
-		}
+        }
         #endregion
 
         //Public Function ActiveForums_GetPostsForSearch(ByVal ModuleID As Integer) As ArrayList
@@ -575,7 +570,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 case "07.00.12":
                     try
                     {
-						ForumsConfig.FillMissingTopicUrls();
+                        ForumsConfig.FillMissingTopicUrls();
                     }
                     catch (Exception ex)
                     {

--- a/Dnn.CommunityForums/controls/admin_manageforums_forumeditor.ascx.cs
+++ b/Dnn.CommunityForums/controls/admin_manageforums_forumeditor.ascx.cs
@@ -21,7 +21,6 @@ using System;
 using System.Linq;
 using System.Text;
 using System.Web.UI.WebControls;
-using DotNetNuke.Entities.Modules;
 using DotNetNuke.Security.Roles;
 
 using AFSettings = DotNetNuke.Modules.ActiveForums.Settings;
@@ -91,7 +90,7 @@ namespace DotNetNuke.Modules.ActiveForums
             reqForumName.Text = "<img src=\"" + Page.ResolveUrl(RequiredImage) + "\" />";
             reqGroups.Text = "<img src=\"" + Page.ResolveUrl(RequiredImage) + "\" />";
             var propImage = "<img src=\"" + Page.ResolveUrl(DotNetNuke.Modules.ActiveForums.Globals.ModuleImagesPath + "properties16.png") + "\" alt=\"[RESX:ConfigureProperties]\" />";
-            
+
             rdAttachOn.Attributes.Add("onclick", "toggleAttach(this);");
             rdAttachOn.Attributes.Add("value", "1");
             rdAttachOff.Attributes.Add("onclick", "toggleAttach(this);");
@@ -121,7 +120,7 @@ namespace DotNetNuke.Modules.ActiveForums
             txtOlderThan.Attributes.Add("onkeypress", "return onlyNumbers(event)");
             txtReplyOlderThan.Attributes.Add("onkeypress", "return onlyNumbers(event)");
             txtUserId.Attributes.Add("onkeypress", "return onlyNumbers(event)");
-            
+
             if (MainSettings.DeleteBehavior == 1)
                 lblMaintWarn.Text = string.Format(GetSharedResource("[RESX:MaintenanceWarning]"), GetSharedResource("[RESX:MaintenanceWarning:Recycle]"), GetSharedResource("[RESX:MaintenanceWarning:Recycle:Desc]"));
             else
@@ -129,12 +128,12 @@ namespace DotNetNuke.Modules.ActiveForums
 
             //drpEditorTypes.Attributes.Add("onchange", "toggleEditorFields();");
 
-            if (cbEditorAction.IsCallback) 
+            if (cbEditorAction.IsCallback)
                 return;
-            
+
             BindGroups();
             BindTemplates();
-            
+
             if (recordId > 0)
             {
                 switch (editorType)
@@ -181,166 +180,166 @@ namespace DotNetNuke.Modules.ActiveForums
             switch (e.Parameters[0].ToLowerInvariant())
             {
                 case "forumsave":
-                {
-                    var fi = new Forum();
-                    var fc = new ForumController();
-                    var bIsNew = false;
-                    int forumGroupId;
-                    var forumSettingsKey = string.Empty;
-
-                    if (Utilities.SafeConvertInt(e.Parameters[1]) <= 0)
                     {
-                        bIsNew = true;
-                        fi.ForumID = -1;
+                        var fi = new Forum();
+                        var fc = new ForumController();
+                        var bIsNew = false;
+                        int forumGroupId;
+                        var forumSettingsKey = string.Empty;
+
+                        if (Utilities.SafeConvertInt(e.Parameters[1]) <= 0)
+                        {
+                            bIsNew = true;
+                            fi.ForumID = -1;
+                        }
+                        else
+                        {
+                            fi = fc.Forums_Get(PortalId, ModuleId, Utilities.SafeConvertInt(e.Parameters[1]), false, -1);
+                            forumSettingsKey = fi.ForumSettingsKey;
+                        }
+
+                        fi.ModuleId = ModuleId;
+                        fi.PortalId = PortalId;
+                        var sParentValue = e.Parameters[2];
+                        var parentForumId = 0;
+
+                        if (sParentValue.Contains("GROUP"))
+                        {
+                            sParentValue = sParentValue.Replace("GROUP", string.Empty);
+                            forumGroupId = Utilities.SafeConvertInt(sParentValue);
+                        }
+                        else
+                        {
+                            parentForumId = Utilities.SafeConvertInt(sParentValue.Replace("FORUM", string.Empty));
+                            forumGroupId = fc.Forums_Get(portalId: PortalId, moduleId: ModuleId, forumId: parentForumId, useCache: false).ForumGroupId;
+                        }
+
+                        fi.ForumGroupId = forumGroupId;
+                        fi.ParentForumId = parentForumId;
+                        fi.ForumName = e.Parameters[3];
+                        fi.ForumDesc = e.Parameters[4];
+                        fi.Active = Utilities.SafeConvertBool(e.Parameters[5]);
+                        fi.Hidden = Utilities.SafeConvertBool(e.Parameters[6]);
+
+                        fi.SortOrder = string.IsNullOrWhiteSpace(e.Parameters[7]) ? 0 : Utilities.SafeConvertInt(e.Parameters[7]);
+
+                        var fkey = string.IsNullOrEmpty(fi.ForumSettingsKey) ? string.Empty : fi.ForumSettingsKey;
+
+                        if (Utilities.SafeConvertBool(e.Parameters[8]))
+                        {
+                            var fgc = new ForumGroupController();
+                            var fgi = fgc.GetForumGroup(ModuleId, forumGroupId);
+
+                            if (bIsNew)
+                                fi.PermissionsId = fgi.PermissionsId;
+                            else if (fi.ForumSettingsKey != "G:" + forumGroupId)
+                                fi.PermissionsId = fgi.PermissionsId;
+
+                            fi.ForumSettingsKey = "G:" + forumGroupId;
+
+                        }
+                        else if (bIsNew || fkey.Contains("G:"))
+                        {
+                            fi.ForumSettingsKey = string.Empty;
+                            if (fi.InheritSecurity)
+                                fi.PermissionsId = -1;
+                        }
+                        else
+                        {
+                            fi.ForumSettingsKey = "F:" + fi.ForumID;
+                        }
+
+                        if (forumSettingsKey != fkey && fkey.Contains("F:"))
+                            bIsNew = true;
+
+                        fi.PrefixURL = e.Parameters[9];
+                        if (!(string.IsNullOrEmpty(fi.PrefixURL)))
+                        {
+                            var db = new Data.Common();
+                            if (!(db.CheckForumURL(PortalId, ModuleId, fi.PrefixURL, fi.ForumID, fi.ForumGroupId)))
+                                fi.PrefixURL = string.Empty;
+                        }
+
+                        var forumId = fc.Forums_Save(PortalId, fi, bIsNew, Utilities.SafeConvertBool(e.Parameters[8]));
+                        recordId = forumId;
+
+                        hidEditorResult.Value = forumId.ToString();
+                        break;
                     }
-                    else
-                    {
-                        fi = fc.Forums_Get(PortalId, ModuleId, Utilities.SafeConvertInt(e.Parameters[1]), UserId, false, false, -1);
-                        forumSettingsKey = fi.ForumSettingsKey;
-                    }
-
-                    fi.ModuleId = ModuleId;
-                    fi.PortalId = PortalId;
-                    var sParentValue = e.Parameters[2];
-                    var parentForumId = 0;
-
-                    if (sParentValue.Contains("GROUP"))
-                    {
-                        sParentValue = sParentValue.Replace("GROUP", string.Empty);
-                        forumGroupId = Utilities.SafeConvertInt(sParentValue);
-                    }
-                    else
-                    {
-                        parentForumId = Utilities.SafeConvertInt(sParentValue.Replace("FORUM", string.Empty));
-                        forumGroupId = fc.Forums_GetGroupId(parentForumId);
-                    }
-
-                    fi.ForumGroupId = forumGroupId;
-                    fi.ParentForumId = parentForumId;
-                    fi.ForumName = e.Parameters[3];
-                    fi.ForumDesc = e.Parameters[4];
-                    fi.Active = Utilities.SafeConvertBool(e.Parameters[5]);
-                    fi.Hidden = Utilities.SafeConvertBool(e.Parameters[6]);
-
-                    fi.SortOrder = string.IsNullOrWhiteSpace(e.Parameters[7]) ? 0 : Utilities.SafeConvertInt(e.Parameters[7]);
-
-                    var fkey = string.IsNullOrEmpty(fi.ForumSettingsKey) ? string.Empty : fi.ForumSettingsKey;
-
-                    if (Utilities.SafeConvertBool(e.Parameters[8]))
-                    {
-                        var fgc = new ForumGroupController();
-                        var fgi = fgc.GetForumGroup(ModuleId, forumGroupId);
-                            
-                        if (bIsNew)
-                            fi.PermissionsId = fgi.PermissionsId;
-                        else if (fi.ForumSettingsKey != "G:" + forumGroupId)
-                            fi.PermissionsId = fgi.PermissionsId;
-
-                        fi.ForumSettingsKey = "G:" + forumGroupId;
-
-                    }
-                    else if (bIsNew || fkey.Contains("G:"))
-                    {
-                        fi.ForumSettingsKey = string.Empty;
-                        if (fi.InheritSecurity)
-                            fi.PermissionsId = -1;
-                    }
-                    else
-                    {
-                        fi.ForumSettingsKey = "F:" + fi.ForumID;
-                    }
-
-                    if (forumSettingsKey != fkey && fkey.Contains("F:"))
-                        bIsNew = true;
-
-                    fi.PrefixURL = e.Parameters[9];
-                    if (!(string.IsNullOrEmpty(fi.PrefixURL)))
-                    {
-                        var db = new Data.Common();
-                        if (!(db.CheckForumURL(PortalId, ModuleId, fi.PrefixURL, fi.ForumID, fi.ForumGroupId)))
-                            fi.PrefixURL = string.Empty;
-                    }
-
-                    var forumId = fc.Forums_Save(PortalId, fi, bIsNew, Utilities.SafeConvertBool(e.Parameters[8]));
-                    recordId = forumId;
-
-                    hidEditorResult.Value = forumId.ToString();
-                    break;
-                }
 
                 case "groupsave":
-                {
-                    var bIsNew = false;
-                    var groupId = Utilities.SafeConvertInt(e.Parameters[1]);        
-                    var fgc = new ForumGroupController();
-                    var gi = (groupId > 0) ? fgc.Groups_Get(ModuleId, groupId) : new ForumGroupInfo();
-
-                    var securityKey = string.Empty;
-                    if (groupId == 0)
-                        bIsNew = true;
-                    else
-                        securityKey = "G:" + groupId;
-
-                    gi.ModuleId = ModuleId;
-                    gi.ForumGroupId = groupId;
-                    gi.GroupName = e.Parameters[3];
-                    gi.Active = Utilities.SafeConvertBool(e.Parameters[5]);
-                    gi.Hidden = Utilities.SafeConvertBool(e.Parameters[6]);
-                    
-                    gi.SortOrder = string.IsNullOrWhiteSpace(e.Parameters[7]) ? 0 : Utilities.SafeConvertInt(e.Parameters[7]);
-
-                    gi.PrefixURL = e.Parameters[9];
-                    if (!(string.IsNullOrEmpty(gi.PrefixURL)))
                     {
-                        var db = new Data.Common();
-                        if (!(db.CheckGroupURL(PortalId, ModuleId, gi.PrefixURL, gi.ForumGroupId)))
-                            gi.PrefixURL = string.Empty;
+                        var bIsNew = false;
+                        var groupId = Utilities.SafeConvertInt(e.Parameters[1]);
+                        var fgc = new ForumGroupController();
+                        var gi = (groupId > 0) ? fgc.Groups_Get(ModuleId, groupId) : new ForumGroupInfo();
+
+                        var securityKey = string.Empty;
+                        if (groupId == 0)
+                            bIsNew = true;
+                        else
+                            securityKey = "G:" + groupId;
+
+                        gi.ModuleId = ModuleId;
+                        gi.ForumGroupId = groupId;
+                        gi.GroupName = e.Parameters[3];
+                        gi.Active = Utilities.SafeConvertBool(e.Parameters[5]);
+                        gi.Hidden = Utilities.SafeConvertBool(e.Parameters[6]);
+
+                        gi.SortOrder = string.IsNullOrWhiteSpace(e.Parameters[7]) ? 0 : Utilities.SafeConvertInt(e.Parameters[7]);
+
+                        gi.PrefixURL = e.Parameters[9];
+                        if (!(string.IsNullOrEmpty(gi.PrefixURL)))
+                        {
+                            var db = new Data.Common();
+                            if (!(db.CheckGroupURL(PortalId, ModuleId, gi.PrefixURL, gi.ForumGroupId)))
+                                gi.PrefixURL = string.Empty;
+                        }
+
+                        gi.GroupSettingsKey = securityKey;
+                        var gc = new ForumGroupController();
+                        groupId = gc.Groups_Save(PortalId, gi, bIsNew);
+                        recordId = groupId;
+                        hidEditorResult.Value = groupId.ToString();
+
+                        break;
                     }
 
-                    gi.GroupSettingsKey = securityKey;
-                    var gc = new ForumGroupController();
-                    groupId = gc.Groups_Save(PortalId, gi, bIsNew);
-                    recordId = groupId;
-                    hidEditorResult.Value = groupId.ToString();
-
-                    break;
-                }
-
                 case "forumsettingssave":
-                {
-                    var forumId = Utilities.SafeConvertInt(e.Parameters[1]);
-                    var sKey = "F:" + forumId;
-                    SaveSettings(sKey, e.Parameters);
+                    {
+                        var forumId = Utilities.SafeConvertInt(e.Parameters[1]);
+                        var sKey = "F:" + forumId;
+                        SaveSettings(sKey, e.Parameters);
 
-                    hidEditorResult.Value = forumId.ToString();
+                        hidEditorResult.Value = forumId.ToString();
 
-                    break;
-                }
+                        break;
+                    }
 
                 case "groupsettingssave":
-                {
-                    var forumId = Utilities.SafeConvertInt(e.Parameters[1]);
-                    var sKey = "G:" + forumId;
-                    SaveSettings(sKey, e.Parameters);
+                    {
+                        var forumId = Utilities.SafeConvertInt(e.Parameters[1]);
+                        var sKey = "G:" + forumId;
+                        SaveSettings(sKey, e.Parameters);
 
-                    hidEditorResult.Value = forumId.ToString();
-                
-                    break;
-                }
+                        hidEditorResult.Value = forumId.ToString();
+
+                        break;
+                    }
 
                 case "deleteforum":
-                {
-                    var forumId = Utilities.SafeConvertInt(e.Parameters[1]);
-                    DataProvider.Instance().Forums_Delete(PortalId, ModuleId, forumId);
-                    break;
-                }
+                    {
+                        var forumId = Utilities.SafeConvertInt(e.Parameters[1]);
+                        DataProvider.Instance().Forums_Delete(PortalId, ModuleId, forumId);
+                        break;
+                    }
 
                 case "deletegroup":
-                {
-                    var groupId = Utilities.SafeConvertInt(e.Parameters[1]);
-                    DataProvider.Instance().Groups_Delete(ModuleId, groupId);
-                    break;
-                }
+                    {
+                        var groupId = Utilities.SafeConvertInt(e.Parameters[1]);
+                        DataProvider.Instance().Groups_Delete(ModuleId, groupId);
+                        break;
+                    }
             }
             DataCache.ClearAllCache(ModuleId);
             DataCache.ClearAllCacheForTabId(TabId);
@@ -400,9 +399,9 @@ namespace DotNetNuke.Modules.ActiveForums
         private void LoadForum(int forumId)
         {
             var fc = new ForumController();
-            var fi = fc.Forums_Get(forumId, -1, false, false);
+            var fi = fc.Forums_Get(PortalId, ModuleId, forumId, false);
 
-            if (fi == null) 
+            if (fi == null)
                 return;
 
             var newForum = fc.GetForum(PortalId, ModuleId, forumId, true);
@@ -416,9 +415,9 @@ namespace DotNetNuke.Modules.ActiveForums
                 ctlSecurityGrid.ReadOnly = newForum.InheritSecurity;
 
                 plhGrid.Controls.Clear();
-                plhGrid.Controls.Add(ctlSecurityGrid); 
+                plhGrid.Controls.Add(ctlSecurityGrid);
             }
-      
+
             txtForumName.Text = fi.ForumName;
             txtForumDesc.Text = fi.ForumDesc;
             chkActive.Checked = fi.Active;
@@ -536,7 +535,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
             txtEditorHeight.Text = (fi.EditorHeight == string.Empty) ? "400" : fi.EditorHeight;
             txtEditorWidth.Text = (fi.EditorWidth == string.Empty) ? "99%" : fi.EditorWidth;
-            
+
             hidRoles.Value = fi.AutoSubscribeRoles;
             BindAutoSubRoles(fi.AutoSubscribeRoles);
         }
@@ -559,9 +558,9 @@ namespace DotNetNuke.Modules.ActiveForums
                 ctlSecurityGrid.ModuleConfiguration = ModuleConfiguration;
 
                 plhGrid.Controls.Clear();
-                plhGrid.Controls.Add(ctlSecurityGrid);    
+                plhGrid.Controls.Add(ctlSecurityGrid);
             }
-            
+
             trGroups.Visible = false;
             reqGroups.Enabled = false;
             txtForumName.Text = gi.GroupName;
@@ -585,12 +584,12 @@ namespace DotNetNuke.Modules.ActiveForums
             Utilities.SelectListItemByValue(drpEditorTypes, (int)gi.EditorType);
             Utilities.SelectListItemByValue(drpEditorMobile, (int)gi.EditorMobile);
             Utilities.SelectListItemByValue(drpPermittedRoles, (int)gi.EditorPermittedUsers);
-            
+
             txtAutoTrustLevel.Text = gi.AutoTrustLevel.ToString();
             txtEmailAddress.Text = gi.EmailAddress;
             txtCreatePostCount.Text = gi.CreatePostCount.ToString();
             txtReplyPostCount.Text = gi.ReplyPostCount.ToString();
-              
+
             rdFilterOn.Checked = gi.UseFilter;
             rdFilterOff.Checked = !gi.UseFilter;
 
@@ -625,7 +624,7 @@ namespace DotNetNuke.Modules.ActiveForums
             txtMaxAttachHeight.Text = gi.MaxAttachHeight.ToString();
             ckAttachInsertAllowed.Checked = gi.AttachInsertAllowed;
             ckConvertingToJpegAllowed.Checked = gi.ConvertingToJpegAllowed;
-            
+
             // if switching from HTML off to HTML on, switch editor to HTML editor, or vice versa
             if (rdHTMLOff.Checked && gi.AllowHTML)
             {
@@ -672,14 +671,14 @@ namespace DotNetNuke.Modules.ActiveForums
             hidRoles.Value = gi.AutoSubscribeRoles;
             BindAutoSubRoles(gi.AutoSubscribeRoles);
         }
-        
+
         private void BindAutoSubRoles(string roles)
         {
             var sb = new StringBuilder();
             sb.Append("<table id=\"tblRoles\" cellpadding=\"0\" cellspacing=\"0\" width=\"99%\">");
             sb.Append("<tr><td width=\"99%\"></td><td></td></tr>");
             if (roles != null)
-            { 
+            {
                 var arr = DotNetNuke.Security.Roles.RoleController.Instance.GetRoles(portalId: PortalId);
                 foreach (RoleInfo ri in from RoleInfo ri in arr let sRoles = roles.Split(';') from role in sRoles.Where(role => role == ri.RoleID.ToString()) select ri)
                 {
@@ -694,7 +693,7 @@ namespace DotNetNuke.Modules.ActiveForums
         {
             var dr = DataProvider.Instance().Forums_List(PortalId, ModuleId, -1, -1, false);
             drpGroups.Items.Add(new ListItem(Utilities.GetSharedResource("DropDownSelect"), "-1"));
-            
+
             var tmpGroupId = -1;
             while (dr.Read())
             {
@@ -706,9 +705,9 @@ namespace DotNetNuke.Modules.ActiveForums
                 }
 
                 var forumId = dr.GetInt("ForumId");
-                if (forumId == 0) 
+                if (forumId == 0)
                     continue;
-                
+
                 if (dr.GetInt("ParentForumID") == 0)
                     drpGroups.Items.Add(new ListItem(" - " + dr.GetString("ForumName"), "FORUM" + forumId));
             }
@@ -720,13 +719,13 @@ namespace DotNetNuke.Modules.ActiveForums
         {
             var sb = new StringBuilder();
             var sLabel = (editorType == "F") ? "[RESX:Forum]" : "[RESX:Group]";
-            
+
             sb.Append("<div id=\"divForum\" onclick=\"toggleTab(this);\" class=\"amtabsel\" style=\"margin-left:10px;\"><div id=\"divForum_text\" class=\"amtabseltext\">" + sLabel + "</div></div>");
-            
+
             if (recordId > 0)
             {
                 sb.Append("<div id=\"divSecurity\" onclick=\"toggleTab(this);\" class=\"amtab\"><div id=\"divSecurity_text\" class=\"amtabtext\">[RESX:Security]</div></div>");
-                
+
                 if (editorType == "F" && chkInheritGroup.Checked)
                     sb.Append("<div id=\"divSettings\" onclick=\"toggleTab(this);\" class=\"amtab\" style=\"display:none;\"><div id=\"divSettings_text\" class=\"amtabtext\">[RESX:Features]</div></div>");
                 else
@@ -760,7 +759,7 @@ namespace DotNetNuke.Modules.ActiveForums
             BindTemplateDropDown(drpTopicForm, Templates.TemplateTypes.TopicForm, "[RESX:Default]", "0");
             BindTemplateDropDown(drpReplyForm, Templates.TemplateTypes.ReplyForm, "[RESX:Default]", "0");
             //BindTemplateDropDown(drpQuickReplyForm, Templates.TemplateTypes.QuickReplyForm, "[RESX:Default]", "0")
-            
+
             BindTemplateDropDown(drpProfileDisplay, Templates.TemplateTypes.PostInfo, "[RESX:Default]", "0");
             BindTemplateDropDown(drpModApprovedTemplateId, Templates.TemplateTypes.ModEmail, "[RESX:DropDownDisabled]", "0");
             BindTemplateDropDown(drpModDeleteTemplateId, Templates.TemplateTypes.ModEmail, "[RESX:DropDownDisabled]", "0");

--- a/Dnn.CommunityForums/controls/af_modreport.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_modreport.ascx.cs
@@ -18,19 +18,10 @@
 // DEALINGS IN THE SOFTWARE.
 //
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Data;
-
-using System.Web;
 using System.Web.UI;
 using System.Web.UI.WebControls;
-using DotNetNuke;
-using DotNetNuke.Services.Localization;
-using DotNetNuke.Services.ClientCapability;
 using DotNetNuke.Services.Social.Notifications;
-using DotNetNuke.Modules.ActiveForums.Entities;
-using TopicInfo = DotNetNuke.Modules.ActiveForums.Entities.TopicInfo;
 
 namespace DotNetNuke.Modules.ActiveForums
 {
@@ -53,7 +44,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 if (Request.IsAuthenticated)
                 {
 
-                    string strReasons = GetSharedResource("[RESX:ReasonOptions]"); 
+                    string strReasons = GetSharedResource("[RESX:ReasonOptions]");
                     int i = 0;
                     foreach (string strReason in strReasons.Split(new char[] { ';' }))
                     {
@@ -178,7 +169,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 body = body.Replace("[Comment]", Comments);
                 body = body.Replace("[URL]", fullURL);
                 body = body.Replace("[Reason]", drpReasons.SelectedItem.Value);
-                List<DotNetNuke.Entities.Users.UserInfo> mods = Utilities.GetListOfModerators(PortalId, ForumId);
+                List<DotNetNuke.Entities.Users.UserInfo> mods = Utilities.GetListOfModerators(PortalId, ForumModuleId, ForumId);
 
 
                 string notificationKey = string.Format("{0}:{1}:{2}:{3}:{4}", TabId, ForumModuleId, ForumId, TopicId, ReplyId);

--- a/Dnn.CommunityForums/controls/af_modtopics.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_modtopics.ascx.cs
@@ -18,11 +18,7 @@
 // DEALINGS IN THE SOFTWARE.
 //
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Data;
-using DotNetNuke.Modules.ActiveForums.Entities;
-using TopicInfo = DotNetNuke.Modules.ActiveForums.Entities.TopicInfo;
 
 namespace DotNetNuke.Modules.ActiveForums
 {
@@ -81,7 +77,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 {
                     SetPermissions(Convert.ToInt32(e.Parameters[1]));
                     ForumController fc = new ForumController();
-                    fi = fc.Forums_Get(Convert.ToInt32(e.Parameters[1]), -1, false, true);
+                    fi = fc.Forums_Get(PortalId, ForumModuleId, Convert.ToInt32(e.Parameters[1]), true);
                 }
                 else
                 {
@@ -123,7 +119,7 @@ namespace DotNetNuke.Modules.ActiveForums
                                         auth = ti.Author;
                                     }
                                     tc.Topics_Delete(PortalId, ModuleId, tmpForumId, tmpTopicId, delAction);
-                                    
+
                                 }
                                 else if (tmpForumId > 0 & tmpTopicId > 0 & tmpReplyId > 0)
                                 {
@@ -152,7 +148,7 @@ namespace DotNetNuke.Modules.ActiveForums
                             ModController mc = new ModController();
                             mc.Mod_Reject(PortalId, ForumModuleId, UserId, tmpForumId, tmpTopicId, tmpReplyId);
                             if (fi.ModRejectTemplateId > 0 & tmpAuthorId > 0)
-                            { 
+                            {
                                 DotNetNuke.Entities.Users.UserInfo ui = DotNetNuke.Entities.Users.UserController.Instance.GetUser(PortalId, tmpAuthorId);
                                 if (ui != null)
                                 {
@@ -208,7 +204,7 @@ namespace DotNetNuke.Modules.ActiveForums
                                             sUrl = Utilities.NavigateUrl(TabId, "", ParamKeys.TopicId + "=" + TopicId);
                                         }
                                         Social amas = new Social();
-                                        amas.AddTopicToJournal(PortalId, ForumModuleId ,TabId, ForumId, ti.TopicId, ti.Author.AuthorId, sUrl, sSubject, ti.Content.Summary, sBody, fi.Security.Read, SocialGroupId);
+                                        amas.AddTopicToJournal(PortalId, ForumModuleId, TabId, ForumId, ti.TopicId, ti.Author.AuthorId, sUrl, sSubject, ti.Content.Summary, sBody, fi.Security.Read, SocialGroupId);
                                     }
                                     catch (Exception ex)
                                     {
@@ -225,7 +221,7 @@ namespace DotNetNuke.Modules.ActiveForums
                                     ri.IsApproved = true;
                                     sSubject = ri.Content.Subject;
                                     sBody = ri.Content.Body;
-                                    rc.Reply_Save(PortalId,ForumModuleId, ri);
+                                    rc.Reply_Save(PortalId, ForumModuleId, ri);
                                     TopicsController tc = new TopicsController();
                                     tc.Topics_SaveToForum(tmpForumId, tmpTopicId, PortalId, ModuleId, tmpReplyId);
                                     DotNetNuke.Modules.ActiveForums.Entities.TopicInfo ti = tc.Topics_Get(PortalId, ForumModuleId, tmpTopicId, tmpForumId, -1, false);
@@ -260,8 +256,8 @@ namespace DotNetNuke.Modules.ActiveForums
 
                             break;
                         }
-                } 
-                DataCache.CacheClearPrefix(ModuleId,  string.Format(CacheKeys.ForumViewPrefix, ModuleId));
+                }
+                DataCache.CacheClearPrefix(ModuleId, string.Format(CacheKeys.ForumViewPrefix, ModuleId));
             }
             BuildModList();
             litTopics.RenderControl(e.Output);
@@ -315,7 +311,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 {
                     sb.Append("<div class=\"afmodrow\">");
                     sb.Append("<table width=\"99%\">");
-                    sb.Append("<tr><td style=\"white-space:nowrap;\">" + Utilities.GetUserFormattedDateTime(Convert.ToDateTime(dr["DateCreated"]),PortalId,UserId) + "</td>");
+                    sb.Append("<tr><td style=\"white-space:nowrap;\">" + Utilities.GetUserFormattedDateTime(Convert.ToDateTime(dr["DateCreated"]), PortalId, UserId) + "</td>");
                     sb.Append("<td align=\"right\">");
                     if (bModApprove)
                     {

--- a/Dnn.CommunityForums/controls/af_post.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_post.ascx.cs
@@ -23,19 +23,17 @@ using System.Data;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Json;
-using System.Web.UI.WebControls;
-using System.Text.RegularExpressions;
 using System.Text;
+using System.Text.RegularExpressions;
+using System.Web.UI.WebControls;
 using System.Xml;
+using DotNetNuke.Common.Utilities;
+using DotNetNuke.Framework;
 using DotNetNuke.Framework.Providers;
 using DotNetNuke.Modules.ActiveForums.Controls;
 using DotNetNuke.Modules.ActiveForums.Extensions;
-using DotNetNuke.Services.Social.Notifications;
-using DotNetNuke.Framework;
 using DotNetNuke.Services.FileSystem;
-using DotNetNuke.Common.Utilities;
-using DotNetNuke.Modules.ActiveForums.Entities;
-using TopicInfo = DotNetNuke.Modules.ActiveForums.Entities.TopicInfo;
+using DotNetNuke.Services.Social.Notifications;
 
 namespace DotNetNuke.Modules.ActiveForums
 {
@@ -68,16 +66,16 @@ namespace DotNetNuke.Modules.ActiveForums
         #region Event Handlers
 
         protected override void OnInit(EventArgs e)
-		{
-			base.OnInit(e);
+        {
+            base.OnInit(e);
 
             ServicesFramework.Instance.RequestAjaxAntiForgerySupport();
-            
+
             var oLink = new System.Web.UI.HtmlControls.HtmlGenericControl("link");
             oLink.Attributes["rel"] = "stylesheet";
             oLink.Attributes["type"] = "text/css";
             oLink.Attributes["href"] = Page.ResolveUrl(Globals.ModulePath + "scripts/calendar.css");
-            
+
             var oCSS = Page.FindControl("CSS");
             if (oCSS != null)
                 oCSS.Controls.Add(oLink);
@@ -266,7 +264,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
         private void ctlForm_Click(object sender, EventArgs e)
         {
-            Page.Validate(); 
+            Page.Validate();
             if (ContactByFaxOnlyCheckBox.Checked)
             {
                 // if someone activates this checkbox send him home :-)
@@ -277,7 +275,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 plhMessage.Controls.Add(new InfoMessage { Message = "<div class=\"afmessage\">" + string.Format(GetSharedResource("[RESX:Error:FloodControl]"), MainSettings.FloodInterval) + "</div>" });
                 return;
             }
-            if (!Page.IsValid || !Utilities.InputIsValid(ctlForm.Body.Trim()) || !Utilities.InputIsValid(ctlForm.Subject)) 
+            if (!Page.IsValid || !Utilities.InputIsValid(ctlForm.Body.Trim()) || !Utilities.InputIsValid(ctlForm.Subject))
                 return;
 
             if (TopicId == -1 || (TopicId > 0 && Request.Params["action"] == "te"))
@@ -330,12 +328,12 @@ namespace DotNetNuke.Modules.ActiveForums
                     message = Utilities.ManageImagePath(message);
                     var uc = new UserController();
                     var up = uc.GetUser(PortalId, ForumModuleId, UserId) ?? new User
-                                                                                {
-                                                                                    UserId = -1,
-                                                                                    UserName = "guest",
-                                                                                    Profile = {TopicCount = 0, ReplyCount = 0},
-                                                                                    DateCreated = DateTime.UtcNow
-                                                                                };
+                    {
+                        UserId = -1,
+                        UserName = "guest",
+                        Profile = { TopicCount = 0, ReplyCount = 0 },
+                        DateCreated = DateTime.UtcNow
+                    };
                     message = TemplateUtils.PreviewTopic(topicTemplateID, PortalId, ForumModuleId, TabId, ForumInfo, UserId, message, ImagePath, up, DateTime.UtcNow, CurrentUserType, UserId, TimeZoneOffset);
                     hidPreviewText.Value = message;
                     break;
@@ -363,9 +361,9 @@ namespace DotNetNuke.Modules.ActiveForums
             else if (!_canModEdit && (ti.Content.AuthorId == UserId && _canEdit && MainSettings.EditInterval > 0 & SimulateDateDiff.DateDiff(SimulateDateDiff.DateInterval.Minute, ti.Content.DateCreated, DateTime.UtcNow) > MainSettings.EditInterval))
             {
                 var im = new InfoMessage
-                                        {
-                                            Message =  "<div class=\"afmessage\">" +  string.Format(GetSharedResource("[RESX:Message:EditIntervalReached]"),  MainSettings.EditInterval) + "</div>"
-                                        };
+                {
+                    Message = "<div class=\"afmessage\">" + string.Format(GetSharedResource("[RESX:Message:EditIntervalReached]"), MainSettings.EditInterval) + "</div>"
+                };
                 plhMessage.Controls.Add(im);
                 plhContent.Controls.Clear();
             }
@@ -401,7 +399,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     var pl = new List<PropertiesInfo>();
                     var xDoc = new XmlDocument();
                     xDoc.LoadXml(ti.TopicData);
- 
+
                     XmlNode xRoot = xDoc.DocumentElement;
                     if (xRoot != null)
                     {
@@ -413,10 +411,10 @@ namespace DotNetNuke.Modules.ActiveForums
                                 var pName = Utilities.HTMLDecode(xNodeList[i].ChildNodes[0].InnerText);
                                 var pValue = Utilities.HTMLDecode(xNodeList[i].ChildNodes[1].InnerText);
                                 var xmlAttributeCollection = xNodeList[i].Attributes;
-                                if (xmlAttributeCollection == null) 
+                                if (xmlAttributeCollection == null)
                                     continue;
                                 var pId = Convert.ToInt32(xmlAttributeCollection["id"].Value);
-                                var p = new PropertiesInfo {Name = pName, DefaultValue = pValue, PropertyId = pId};
+                                var p = new PropertiesInfo { Name = pName, DefaultValue = pValue, PropertyId = pId };
                                 pl.Add(p);
                             }
                         }
@@ -449,10 +447,10 @@ namespace DotNetNuke.Modules.ActiveForums
         {
             //Edit a Reply
             ctlForm.EditorMode = Modules.ActiveForums.Controls.SubmitForm.EditorModes.EditReply;
-            
+
             var rc = new ReplyController();
             var ri = rc.Reply_Get(PortalId, ForumModuleId, TopicId, PostId);
-            
+
             if (ri == null)
                 Response.Redirect(NavigateUrl(TabId));
             else if ((ri.Content.AuthorId != UserId && _canModEdit == false) | (ri.Content.AuthorId == UserId && _canEdit == false) | (_canEdit == false && _canModEdit))
@@ -461,9 +459,9 @@ namespace DotNetNuke.Modules.ActiveForums
             else if (!_canModEdit && (ri.Content.AuthorId == UserId && _canEdit && MainSettings.EditInterval > 0 & SimulateDateDiff.DateDiff(SimulateDateDiff.DateInterval.Minute, ri.Content.DateCreated, DateTime.UtcNow) > MainSettings.EditInterval))
             {
                 var im = new Controls.InfoMessage
-                             {
-                                 Message = "<div class=\"afmessage\">" +  string.Format(GetSharedResource("[RESX:Message:EditIntervalReached]"), MainSettings.EditInterval.ToString()) + "</div>"
-                             };
+                {
+                    Message = "<div class=\"afmessage\">" + string.Format(GetSharedResource("[RESX:Message:EditIntervalReached]"), MainSettings.EditInterval.ToString()) + "</div>"
+                };
                 plhMessage.Controls.Add(im);
                 plhContent.Controls.Clear();
             }
@@ -560,7 +558,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 var tc = new TopicsController();
                 var ti = tc.Topics_Get(PortalId, ForumModuleId, TopicId, ForumId, UserId, true);
 
-                if(ti == null)
+                if (ti == null)
                     Response.Redirect(NavigateUrl(TabId));
 
                 ctlForm.Subject = Utilities.GetSharedResource("[RESX:SubjectPrefix]") + " " + ti.Content.Subject;
@@ -605,14 +603,14 @@ namespace DotNetNuke.Modules.ActiveForums
                         {
                             ti = tc.Topics_Get(PortalId, ForumModuleId, TopicId);
                             ci = ti.Content;
-                            sPostedBy = string.Format(sPostedBy, UserProfiles.GetDisplayName(ForumModuleId, true, false, false, ti.Content.AuthorId, ti.Author.Username, ti.Author.FirstName, ti.Author.LastName, ti.Author.DisplayName), Utilities.GetSharedResource("On.Text"), Utilities.GetUserFormattedDateTime(ti.Content.DateCreated,PortalId, UserId));
+                            sPostedBy = string.Format(sPostedBy, UserProfiles.GetDisplayName(ForumModuleId, true, false, false, ti.Content.AuthorId, ti.Author.Username, ti.Author.FirstName, ti.Author.LastName, ti.Author.DisplayName), Utilities.GetSharedResource("On.Text"), Utilities.GetUserFormattedDateTime(ti.Content.DateCreated, PortalId, UserId));
                         }
                         else
                         {
                             var rc = new ReplyController();
                             var ri = rc.Reply_Get(PortalId, ForumModuleId, TopicId, postId);
                             ci = ri.Content;
-                            sPostedBy = string.Format(sPostedBy, UserProfiles.GetDisplayName(ForumModuleId, true, false, false, ri.Content.AuthorId, ri.Author.Username, ri.Author.FirstName, ri.Author.LastName, ri.Author.DisplayName), Utilities.GetSharedResource("On.Text"), Utilities.GetUserFormattedDateTime(ri.Content.DateCreated,PortalId,UserId));
+                            sPostedBy = string.Format(sPostedBy, UserProfiles.GetDisplayName(ForumModuleId, true, false, false, ri.Content.AuthorId, ri.Author.Username, ri.Author.FirstName, ri.Author.LastName, ri.Author.DisplayName), Utilities.GetSharedResource("On.Text"), Utilities.GetUserFormattedDateTime(ri.Content.DateCreated, PortalId, UserId));
                         }
 
                         if (ci != null)
@@ -737,9 +735,9 @@ namespace DotNetNuke.Modules.ActiveForums
                     body = body.Replace(m.Value, m.Value.Replace("<br>", System.Environment.NewLine));
             }
 
-            ti.TopicUrl = DotNetNuke.Modules.ActiveForums.Controllers.UrlController.BuildTopicUrl(PortalId: PortalId, ModuleId: ForumModuleId, TopicId:TopicId, subject:subject, forumInfo: ForumInfo);
+            ti.TopicUrl = DotNetNuke.Modules.ActiveForums.Controllers.UrlController.BuildTopicUrl(PortalId: PortalId, ModuleId: ForumModuleId, TopicId: TopicId, subject: subject, forumInfo: ForumInfo);
 
-            ti.Content.Body = body; 
+            ti.Content.Body = body;
             ti.Content.Subject = subject;
             ti.Content.Summary = summary;
             ti.IsAnnounce = ti.AnnounceEnd != Utilities.NullDate() && ti.AnnounceStart != Utilities.NullDate();
@@ -872,7 +870,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
                 if (ti.IsApproved == false)
                 {
-                    var mods = Utilities.GetListOfModerators(PortalId, ForumId);
+                    var mods = Utilities.GetListOfModerators(PortalId, ForumModuleId, ForumId);
                     var notificationType = NotificationsController.Instance.GetNotificationType("AF-ForumModeration");
 
                     var notifySubject = Utilities.GetSharedResource("NotificationSubjectTopic");
@@ -907,7 +905,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     var ctlUtils = new ControlUtils();
 
                     var sUrl = ctlUtils.BuildUrl(TabId, ForumModuleId, ForumInfo.ForumGroup.PrefixURL, ForumInfo.PrefixURL, ForumInfo.ForumGroupId, ForumInfo.ForumID, TopicId, ti.TopicUrl, -1, -1, string.Empty, 1, -1, SocialGroupId);
-                    
+
                     if (sUrl.Contains("~/"))
                         sUrl = Utilities.NavigateUrl(TabId, "", ParamKeys.TopicId + "=" + TopicId);
 
@@ -916,7 +914,7 @@ namespace DotNetNuke.Modules.ActiveForums
                         try
                         {
                             var amas = new Social();
-                            amas.AddTopicToJournal(PortalId, ForumModuleId, TabId, ForumId, TopicId, UserId, sUrl, subject, summary, body,ForumInfo.Security.Read, SocialGroupId);
+                            amas.AddTopicToJournal(PortalId, ForumModuleId, TabId, ForumId, TopicId, UserId, sUrl, subject, summary, body, ForumInfo.Security.Read, SocialGroupId);
                         }
                         catch (Exception ex)
                         {
@@ -933,7 +931,7 @@ namespace DotNetNuke.Modules.ActiveForums
             }
         }
 
-        
+
 
         private void SaveReply()
         {
@@ -941,7 +939,7 @@ namespace DotNetNuke.Modules.ActiveForums
             var body = ctlForm.Body;
             subject = Utilities.CleanString(PortalId, subject, false, EditorTypes.TEXTBOX, _fi.UseFilter, false, ForumModuleId, _themePath, false);
             body = Utilities.CleanString(PortalId, body, _allowHTML, _editorType, _fi.UseFilter, _fi.AllowScript, ForumModuleId, _themePath, _fi.AllowEmoticons);
-			// This HTML decode is used to make Quote functionality work properly even when it appears in Text Box instead of Editor
+            // This HTML decode is used to make Quote functionality work properly even when it appears in Text Box instead of Editor
             if (Request.Params[ParamKeys.QuoteId] != null)
             {
                 body = Utilities.HTMLDecode(body);
@@ -984,7 +982,7 @@ namespace DotNetNuke.Modules.ActiveForums
             var tc = new TopicsController();
             var rc = new ReplyController();
             DotNetNuke.Modules.ActiveForums.ReplyInfo ri;
-            
+
             if (PostId > 0)
             {
                 ri = rc.Reply_Get(PortalId, ForumModuleId, TopicId, PostId);
@@ -1027,12 +1025,12 @@ namespace DotNetNuke.Modules.ActiveForums
             var tmpReplyId = rc.Reply_Save(PortalId, ForumModuleId, ri);
             rc.UpdateModuleLastContentModifiedOnDate(ForumModuleId);
             ri = rc.Reply_Get(PortalId, ForumModuleId, TopicId, tmpReplyId);
-            SaveAttachments(ri.ContentId); 
+            SaveAttachments(ri.ContentId);
             DataCache.ContentCacheClear(ForumModuleId, string.Format(CacheKeys.TopicViewForUser, ForumModuleId, ri.TopicId, ri.Content.AuthorId));
             DataCache.CacheClearPrefix(ForumModuleId, string.Format(CacheKeys.ForumViewPrefix, ForumModuleId));
             try
             {
-               if (bSend && !_isEdit)
+                if (bSend && !_isEdit)
                 {
                     Subscriptions.SendSubscriptions(PortalId, ForumModuleId, TabId, _fi, TopicId, tmpReplyId, ri.Content.AuthorId);
                 }
@@ -1040,7 +1038,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 {
                     var ti = tc.Topics_Get(PortalId, ForumModuleId, TopicId);
 
-                    var mods = Utilities.GetListOfModerators(PortalId, ForumId);
+                    var mods = Utilities.GetListOfModerators(PortalId, ForumModuleId, ForumId);
                     var notificationType = NotificationsController.Instance.GetNotificationType("AF-ForumModeration");
                     var notifySubject = Utilities.GetSharedResource("NotificationSubjectReply");
                     notifySubject = notifySubject.Replace("[DisplayName]", UserInfo.DisplayName);
@@ -1050,14 +1048,14 @@ namespace DotNetNuke.Modules.ActiveForums
                     var notificationKey = string.Format("{0}:{1}:{2}:{3}:{4}", TabId, ForumModuleId, ForumId, TopicId, ri.ReplyId);
 
                     var notification = new Notification
-                                           {
-                                               NotificationTypeID = notificationType.NotificationTypeId,
-                                               Subject = notifySubject,
-                                               Body = notifyBody,
-                                               IncludeDismissAction = false,
-                                               SenderUserID = UserInfo.UserID,
-                                               Context = notificationKey
-                                           };
+                    {
+                        NotificationTypeID = notificationType.NotificationTypeId,
+                        Subject = notifySubject,
+                        Body = notifyBody,
+                        IncludeDismissAction = false,
+                        SenderUserID = UserInfo.UserID,
+                        Context = notificationKey
+                    };
 
                     NotificationsController.Instance.SendNotification(notification, PortalId, null, mods);
 
@@ -1069,11 +1067,11 @@ namespace DotNetNuke.Modules.ActiveForums
                     var ctlUtils = new ControlUtils();
                     var ti = tc.Topics_Get(PortalId, ForumModuleId, TopicId, ForumId, -1, false);
                     var fullURL = ctlUtils.BuildUrl(TabId, ForumModuleId, ForumInfo.ForumGroup.PrefixURL, ForumInfo.PrefixURL, ForumInfo.ForumGroupId, ForumInfo.ForumID, TopicId, ti.TopicUrl, -1, -1, string.Empty, 1, tmpReplyId, SocialGroupId);
-                    
+
                     if (fullURL.Contains("~/"))
                         fullURL = Utilities.NavigateUrl(TabId, "", new[] { ParamKeys.TopicId + "=" + TopicId, ParamKeys.ContentJumpId + "=" + tmpReplyId });
-                    
-                    if (fullURL.EndsWith("/")) 
+
+                    if (fullURL.EndsWith("/"))
                         fullURL += Utilities.UseFriendlyURLs(ForumModuleId) ? String.Concat("#", tmpReplyId) : String.Concat("?", ParamKeys.ContentJumpId, "=", tmpReplyId);
 
                     if (!_isEdit)
@@ -1116,7 +1114,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
             // Read the attachment list sent in the hidden field as json
             var attachmentsJson = hidAttachments.Value;
-            var serializer = new DataContractJsonSerializer(typeof (List<ClientAttachment>));
+            var serializer = new DataContractJsonSerializer(typeof(List<ClientAttachment>));
             var ms = new MemoryStream(Encoding.UTF8.GetBytes(attachmentsJson));
             var attachmentsNew = (List<ClientAttachment>)serializer.ReadObject(ms);
             ms.Close();
@@ -1126,22 +1124,22 @@ namespace DotNetNuke.Modules.ActiveForums
             var attachmentsOld = adb.ListForContent(contentId).Where(o => !o.AllowDownload.HasValue || o.AllowDownload.Value);
 
             // Save all of the new attachments
-            foreach(var attachment in attachmentsNew)
+            foreach (var attachment in attachmentsNew)
             {
                 // Don't need to do anything with existing attachments
-                if(attachment.AttachmentId.HasValue && attachment.AttachmentId.Value > 0)
+                if (attachment.AttachmentId.HasValue && attachment.AttachmentId.Value > 0)
                     continue;
 
                 IFileInfo file = null;
-                
+
                 var fileId = attachment.FileId.GetValueOrDefault();
-                if(fileId > 0 && userFolder != null)
+                if (fileId > 0 && userFolder != null)
                 {
                     // Make sure that the file exists and it actually belongs to the user who is trying to attach it
                     file = fileManager.GetFile(fileId);
-                    if(file == null || file.FolderId != userFolder.FolderID) continue;
+                    if (file == null || file.FolderId != userFolder.FolderID) continue;
                 }
-                else if(!string.IsNullOrWhiteSpace(attachment.UploadId) && !string.IsNullOrWhiteSpace(attachment.FileName))
+                else if (!string.IsNullOrWhiteSpace(attachment.UploadId) && !string.IsNullOrWhiteSpace(attachment.FileName))
                 {
                     if (!Regex.IsMatch(attachment.UploadId, @"^[\w\-. ]+$")) // Check for shenanigans.
                         continue;
@@ -1154,7 +1152,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     // Store the files with a filename format that prevents overwrites.
                     var index = 0;
                     var fileName = string.Format(fileNameTemplate, contentId, index, Regex.Replace(attachment.FileName, @"[^\w\-. ]+", string.Empty));
-                    while(fileManager.FileExists(attachmentFolder, fileName))
+                    while (fileManager.FileExists(attachmentFolder, fileName))
                     {
                         index++;
                         fileName = string.Format(fileNameTemplate, contentId, index, Regex.Replace(attachment.FileName, @"[^\w\-. ]+", string.Empty));
@@ -1165,11 +1163,11 @@ namespace DotNetNuke.Modules.ActiveForums
                     {
                         file = fileManager.AddFile(attachmentFolder, fileName, fileStream);
                     }
-                    
+
                     File.Delete(uploadFilePath);
                 }
-                
-                if(file == null)
+
+                if (file == null)
                     continue;
 
                 adb.Save(contentId, UserId, file.FileName, file.ContentType, file.Size, file.FileId);
@@ -1177,14 +1175,14 @@ namespace DotNetNuke.Modules.ActiveForums
 
             // Remove any attachments that are no longer in the list of attachments
             var attachmentsToRemove = attachmentsOld.Where(a1 => attachmentsNew.All(a2 => a2.AttachmentId != a1.AttachmentId));
-            foreach(var attachment in attachmentsToRemove)
+            foreach (var attachment in attachmentsToRemove)
             {
                 adb.Delete(attachment.AttachmentId);
 
                 var file = attachment.FileId.HasValue ? fileManager.GetFile(attachment.FileId.Value) : fileManager.GetFile(attachmentFolder, attachment.FileName);
 
                 // Only delete the file if it exists in the attachment folder
-                if(file != null && file.FolderId == attachmentFolder.FolderID)
+                if (file != null && file.FolderId == attachmentFolder.FolderID)
                     fileManager.DeleteFile(file);
             }
         }
@@ -1192,7 +1190,7 @@ namespace DotNetNuke.Modules.ActiveForums
         private void PrepareAttachments(int? contentId = null)
         {
             // Handle the case where we don't yet have a topic id (new posts)
-            if(!contentId.HasValue || contentId.Value <= 0)
+            if (!contentId.HasValue || contentId.Value <= 0)
             {
                 hidAttachments.Value = "[]"; // JSON for an empty array
                 return;
@@ -1203,24 +1201,24 @@ namespace DotNetNuke.Modules.ActiveForums
 
             var clientAttachments = attachments.Select(attachment => new ClientAttachment
             {
-                AttachmentId = attachment.AttachmentId, 
-                ContentType = attachment.ContentType, 
-                FileId = attachment.FileId, 
+                AttachmentId = attachment.AttachmentId,
+                ContentType = attachment.ContentType,
+                FileId = attachment.FileId,
                 FileName = Regex.Replace(attachment.FileName.TextOrEmpty(), @"^__\d+__\d+__", string.Empty), // Remove our unique file prefix before sending to the client.
                 FileSize = attachment.FileSize
             }).ToList();
 
-            var serializer = new DataContractJsonSerializer(typeof(List<ClientAttachment>)); 
-            
-            using(var ms = new MemoryStream())
+            var serializer = new DataContractJsonSerializer(typeof(List<ClientAttachment>));
+
+            using (var ms = new MemoryStream())
             {
                 serializer.WriteObject(ms, clientAttachments);
                 ms.Seek(0, 0);
-                using(var sr = new StreamReader(ms, Encoding.UTF8))
+                using (var sr = new StreamReader(ms, Encoding.UTF8))
                 {
                     hidAttachments.Value = sr.ReadToEnd();
                 }
-            } 
+            }
         }
 
         #endregion

--- a/Dnn.CommunityForums/controls/af_quickreply.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_quickreply.ascx.cs
@@ -19,21 +19,11 @@
 //
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Data;
-
-using System.Web;
 using System.Web.UI;
-using System.Web.UI.WebControls;
-using DotNetNuke;
-using System.Text.RegularExpressions;
+using DotNetNuke.Modules.ActiveForums.Controls;
 //using DotNetNuke.Services.ClientCapability;
 using DotNetNuke.Services.Social.Notifications;
-using DotNetNuke.Services.Localization;
-using DotNetNuke.Modules.ActiveForums.Controls;
-using DotNetNuke.Modules.ActiveForums.Entities;
-using TopicInfo = DotNetNuke.Modules.ActiveForums.Entities.TopicInfo;
 
 namespace DotNetNuke.Modules.ActiveForums
 {
@@ -64,8 +54,8 @@ namespace DotNetNuke.Modules.ActiveForums
         #endregion
         #region Event Handlers
         protected override void OnLoad(EventArgs e)
-		{
-			base.OnLoad(e);
+        {
+            base.OnLoad(e);
 
             try
             {
@@ -187,8 +177,8 @@ namespace DotNetNuke.Modules.ActiveForums
         private object designerPlaceholderDeclaration;
 
         protected override void OnInit(EventArgs e)
-		{
-			base.OnInit(e);
+        {
+            base.OnInit(e);
 
             //CODEGEN: This method call is required by the Web Form Designer
             //Do not modify it using the code editor.
@@ -296,7 +286,7 @@ namespace DotNetNuke.Modules.ActiveForums
             ReplyId = rc.Reply_Save(PortalId, ModuleId, ri);
             rc.UpdateModuleLastContentModifiedOnDate(ModuleId);
             DataCache.ContentCacheClear(ModuleId, string.Format(CacheKeys.TopicViewForUser, ModuleId, ri.TopicId, ri.Content.AuthorId));
-            DataCache.CacheClearPrefix(ModuleId,string.Format(CacheKeys.ForumViewPrefix, ModuleId));
+            DataCache.CacheClearPrefix(ModuleId, string.Format(CacheKeys.ForumViewPrefix, ModuleId));
 
 
             DotNetNuke.Modules.ActiveForums.Entities.TopicInfo ti = new TopicsController().Topics_Get(PortalId, ForumModuleId, TopicId, ForumId, -1, false);
@@ -308,7 +298,8 @@ namespace DotNetNuke.Modules.ActiveForums
             }
             if (fullURL.EndsWith("/"))
             {
-                fullURL += Utilities.UseFriendlyURLs(ForumModuleId) ? String.Concat("#", ReplyId) : String.Concat("?", ParamKeys.ContentJumpId, "=", ReplyId);            }
+                fullURL += Utilities.UseFriendlyURLs(ForumModuleId) ? String.Concat("#", ReplyId) : String.Concat("?", ParamKeys.ContentJumpId, "=", ReplyId);
+            }
             if (isApproved)
             {
 
@@ -337,7 +328,7 @@ namespace DotNetNuke.Modules.ActiveForums
             }
             else if (isApproved == false)
             {
-                List<DotNetNuke.Entities.Users.UserInfo> mods = Utilities.GetListOfModerators(PortalId, ForumId);
+                List<DotNetNuke.Entities.Users.UserInfo> mods = Utilities.GetListOfModerators(PortalId, ForumModuleId, ForumId);
                 NotificationType notificationType = NotificationsController.Instance.GetNotificationType("AF-ForumModeration");
                 string subject = Utilities.GetSharedResource("NotificationSubjectReply");
                 subject = subject.Replace("[DisplayName]", UserInfo.DisplayName);
@@ -373,7 +364,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 try
                 {
                     Social amas = new Social();
-                    amas.AddReplyToJournal(PortalId, ForumModuleId,TabId, ForumId, TopicId, ReplyId, UserId, fullURL, Subject, string.Empty, sBody, ForumInfo.Security.Read, SocialGroupId);
+                    amas.AddReplyToJournal(PortalId, ForumModuleId, TabId, ForumId, TopicId, ReplyId, UserId, fullURL, Subject, string.Empty, sBody, ForumInfo.Security.Read, SocialGroupId);
                 }
                 catch (Exception ex)
                 {

--- a/Dnn.CommunityForums/handlers/forumhelper.ashx.cs
+++ b/Dnn.CommunityForums/handlers/forumhelper.ashx.cs
@@ -18,687 +18,679 @@
 // DEALINGS IN THE SOFTWARE.
 //
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Data;
-
-using System.Web;
-using System.Web.Services;
 using System.Text;
-using System.Xml;
+using System.Web;
 using DotNetNuke.Services.FileSystem;
 using DotNetNuke.Services.Journal;
-using DotNetNuke.Modules.ActiveForums.Data;
-using DotNetNuke.Modules.ActiveForums.Entities;
-using TopicInfo = DotNetNuke.Modules.ActiveForums.Entities.TopicInfo;
 
 namespace DotNetNuke.Modules.ActiveForums.Handlers
 {
     public class forumhelper : HandlerBase
-	{
-		public enum Actions: int
-		{
-			None,
-			UserPing, /* no longer used */
-			GetUsersOnline,/* no longer used */
+    {
+        public enum Actions : int
+        {
+            None,
+            UserPing, /* no longer used */
+            GetUsersOnline,/* no longer used */
             TopicSubscribe,/* no longer used */
             ForumSubscribe,
-			RateTopic,
-			DeleteTopic,
-			MoveTopic,
-			PinTopic,/* no longer used */
+            RateTopic,
+            DeleteTopic,
+            MoveTopic,
+            PinTopic,/* no longer used */
             LockTopic,/* no longer used */
             MarkAnswer,
-			TagsAutoComplete,
-			DeletePost,
-			LoadTopic,
-			SaveTopic,
-			ForumList,
+            TagsAutoComplete,
+            DeletePost,
+            LoadTopic,
+            SaveTopic,
+            ForumList,
             LikePost /*no longer used*/
 
-		}
-		public override void ProcessRequest(HttpContext context)
-		{
-			AdminRequired = false;
-			base.AdminRequired = false;
-			base.ProcessRequest(context);
-			string sOut = "{\"result\":\"success\"}";
-			Actions action = Actions.None;
-			if (Params != null && Params.Count > 0)
-			{
-				if (Params["action"] != null && SimulateIsNumeric.IsNumeric(Params["action"]))
-				{
-					action = (Actions)(Convert.ToInt32(Params["action"].ToString()));
-				}
-			}
-			else if (HttpContext.Current.Request.QueryString["action"] != null && SimulateIsNumeric.IsNumeric(HttpContext.Current.Request.QueryString["action"]))
-			{
-				if (int.Parse(HttpContext.Current.Request.QueryString["action"]) == 11)
-				{
-					action = Actions.TagsAutoComplete;
-				}
-			}
-			switch (action)
-			{
-				case Actions.UserPing:
-					throw new NotImplementedException();
-					////sOut = UserOnline();
-					////break;
+        }
+        public override void ProcessRequest(HttpContext context)
+        {
+            AdminRequired = false;
+            base.AdminRequired = false;
+            base.ProcessRequest(context);
+            string sOut = "{\"result\":\"success\"}";
+            Actions action = Actions.None;
+            if (Params != null && Params.Count > 0)
+            {
+                if (Params["action"] != null && SimulateIsNumeric.IsNumeric(Params["action"]))
+                {
+                    action = (Actions)(Convert.ToInt32(Params["action"].ToString()));
+                }
+            }
+            else if (HttpContext.Current.Request.QueryString["action"] != null && SimulateIsNumeric.IsNumeric(HttpContext.Current.Request.QueryString["action"]))
+            {
+                if (int.Parse(HttpContext.Current.Request.QueryString["action"]) == 11)
+                {
+                    action = Actions.TagsAutoComplete;
+                }
+            }
+            switch (action)
+            {
+                case Actions.UserPing:
+                    throw new NotImplementedException();
+                ////sOut = UserOnline();
+                ////break;
                 case Actions.GetUsersOnline:
                     throw new NotImplementedException();
-					////sOut = GetUserOnlineList();
-					////break;
-				case Actions.TopicSubscribe:
+                ////sOut = GetUserOnlineList();
+                ////break;
+                case Actions.TopicSubscribe:
                     throw new NotImplementedException();
-     //               sOut = SubscribeTopic();
-					//break;
-				case Actions.ForumSubscribe:
-					sOut = SubscribeForum();
-					break;
-				case Actions.RateTopic:
-					sOut = RateTopic();
-					break;
-				case Actions.DeleteTopic:
-					sOut = DeleteTopic();
-					break;
-				case Actions.MoveTopic:
-					sOut = MoveTopic();
-					break;
-				case Actions.PinTopic:
+                //               sOut = SubscribeTopic();
+                //break;
+                case Actions.ForumSubscribe:
+                    sOut = SubscribeForum();
+                    break;
+                case Actions.RateTopic:
+                    sOut = RateTopic();
+                    break;
+                case Actions.DeleteTopic:
+                    sOut = DeleteTopic();
+                    break;
+                case Actions.MoveTopic:
+                    sOut = MoveTopic();
+                    break;
+                case Actions.PinTopic:
                     throw new NotImplementedException();
-     //               sOut = PinTopic();
-					//break;
-				case Actions.LockTopic:
+                //               sOut = PinTopic();
+                //break;
+                case Actions.LockTopic:
                     throw new NotImplementedException();
-     //               sOut = LockTopic();
-					//break;
-				case Actions.MarkAnswer:
-					sOut = MarkAnswer();
-					break;
-				case Actions.TagsAutoComplete:
-					sOut = TagsAutoComplete();
-					break;
-				case Actions.DeletePost:
-					sOut = DeletePost();
-					break;
-				case Actions.LoadTopic:
-					sOut = LoadTopic();
-					break;
-				case Actions.SaveTopic:
-					sOut = SaveTopic();
-					break;
-				case Actions.ForumList:
-					sOut = ForumList();
-					break;
+                //               sOut = LockTopic();
+                //break;
+                case Actions.MarkAnswer:
+                    sOut = MarkAnswer();
+                    break;
+                case Actions.TagsAutoComplete:
+                    sOut = TagsAutoComplete();
+                    break;
+                case Actions.DeletePost:
+                    sOut = DeletePost();
+                    break;
+                case Actions.LoadTopic:
+                    sOut = LoadTopic();
+                    break;
+                case Actions.SaveTopic:
+                    sOut = SaveTopic();
+                    break;
+                case Actions.ForumList:
+                    sOut = ForumList();
+                    break;
                 case Actions.LikePost:
-					throw new NotImplementedException();
+                    throw new NotImplementedException();
                     //sOut = LikePost();
                     //break;
-			}
-			context.Response.ContentType = "text/plain";
-			context.Response.Write(sOut);
-		}
-		private string ForumList()
-		{
-			ForumController fc = new ForumController();
-			return fc.GetForumsHtmlOption(PortalId, ModuleId, ForumUser);
-		}
-		private string SubscribeForum()
-		{
-			if (UserId <= 0)
-			{
-				return BuildOutput(string.Empty, OutputCodes.AuthenticationFailed, true);
-			}
-			int rUserId = -1;
+            }
+            context.Response.ContentType = "text/plain";
+            context.Response.Write(sOut);
+        }
+        private string ForumList()
+        {
+            ForumController fc = new ForumController();
+            return fc.GetForumsHtmlOption(PortalId, ModuleId, ForumUser);
+        }
+        private string SubscribeForum()
+        {
+            if (UserId <= 0)
+            {
+                return BuildOutput(string.Empty, OutputCodes.AuthenticationFailed, true);
+            }
+            int rUserId = -1;
 
-			if (Params.ContainsKey("userid") && SimulateIsNumeric.IsNumeric(Params["userid"]))
-			{
-				rUserId = int.Parse(Params["userid"].ToString());
+            if (Params.ContainsKey("userid") && SimulateIsNumeric.IsNumeric(Params["userid"]))
+            {
+                rUserId = int.Parse(Params["userid"].ToString());
 
-			}
-			if (rUserId > 0 & rUserId != ForumUser.UserId & ! ForumUser.IsAdmin)
-			{
-				return BuildOutput(string.Empty, OutputCodes.AuthenticationFailed, true);
-			}
-			rUserId = UserId;
-			int iStatus = 0;
-			SubscriptionController sc = new SubscriptionController();
-			int forumId = -1;
-			if (Params.ContainsKey("forumid") && SimulateIsNumeric.IsNumeric(Params["forumid"]))
-			{
-				forumId = int.Parse(Params["forumid"].ToString());
-			}
-			iStatus = sc.Subscription_Update(PortalId, ModuleId, forumId, -1, 1, rUserId, ForumUser.UserRoles);
+            }
+            if (rUserId > 0 & rUserId != ForumUser.UserId & !ForumUser.IsAdmin)
+            {
+                return BuildOutput(string.Empty, OutputCodes.AuthenticationFailed, true);
+            }
+            rUserId = UserId;
+            int iStatus = 0;
+            SubscriptionController sc = new SubscriptionController();
+            int forumId = -1;
+            if (Params.ContainsKey("forumid") && SimulateIsNumeric.IsNumeric(Params["forumid"]))
+            {
+                forumId = int.Parse(Params["forumid"].ToString());
+            }
+            iStatus = sc.Subscription_Update(PortalId, ModuleId, forumId, -1, 1, rUserId, ForumUser.UserRoles);
 
-			if (iStatus == 1)
-			{
-				return BuildOutput("{\"subscribed\":true,\"text\":\"" + Utilities.JSON.EscapeJsonString(Utilities.GetSharedResource("[RESX:ForumSubscribe:TRUE]")) + "\",\"forumid\":" + forumId.ToString() + "}", OutputCodes.Success, true, true);
-			}
-			else
-			{
-				return BuildOutput("{\"subscribed\":false,\"text\":\"" + Utilities.JSON.EscapeJsonString(Utilities.GetSharedResource("[RESX:ForumSubscribe:FALSE]")) + "\",\"forumid\":" + forumId.ToString() + "}", OutputCodes.Success, true, true);
-			}
+            if (iStatus == 1)
+            {
+                return BuildOutput("{\"subscribed\":true,\"text\":\"" + Utilities.JSON.EscapeJsonString(Utilities.GetSharedResource("[RESX:ForumSubscribe:TRUE]")) + "\",\"forumid\":" + forumId.ToString() + "}", OutputCodes.Success, true, true);
+            }
+            else
+            {
+                return BuildOutput("{\"subscribed\":false,\"text\":\"" + Utilities.JSON.EscapeJsonString(Utilities.GetSharedResource("[RESX:ForumSubscribe:FALSE]")) + "\",\"forumid\":" + forumId.ToString() + "}", OutputCodes.Success, true, true);
+            }
 
 
-		}
-		private string RateTopic()
-		{
-			int r = 0;
-			int topicId = -1;
-			if (Params.ContainsKey("rate") && SimulateIsNumeric.IsNumeric(Params["rate"]))
-			{
-				r = int.Parse(Params["rate"].ToString());
-			}
-			if (Params.ContainsKey("topicid") && SimulateIsNumeric.IsNumeric(Params["topicid"]))
-			{
-				topicId = int.Parse(Params["topicid"].ToString());
-			}
-			if (r >= 1 && r <= 5 && topicId > 0)
-			{
-				DataProvider.Instance().Topics_AddRating(topicId, UserId, r, string.Empty, HttpContext.Current.Request.UserHostAddress.ToString());
-			}
-			r = DataProvider.Instance().Topics_GetRating(topicId);
-			return BuildOutput(r.ToString(), OutputCodes.Success, true, false);
-		}
-		private string DeleteTopic()
-		{
-			int topicId = -1;
-			int forumId = -1;
-			if (Params.ContainsKey("topicid") && SimulateIsNumeric.IsNumeric(Params["topicid"]))
-			{
-				topicId = int.Parse(Params["topicid"].ToString());
-			}
-			if (topicId > 0)
-			{
-				TopicsController tc = new TopicsController();
+        }
+        private string RateTopic()
+        {
+            int r = 0;
+            int topicId = -1;
+            if (Params.ContainsKey("rate") && SimulateIsNumeric.IsNumeric(Params["rate"]))
+            {
+                r = int.Parse(Params["rate"].ToString());
+            }
+            if (Params.ContainsKey("topicid") && SimulateIsNumeric.IsNumeric(Params["topicid"]))
+            {
+                topicId = int.Parse(Params["topicid"].ToString());
+            }
+            if (r >= 1 && r <= 5 && topicId > 0)
+            {
+                DataProvider.Instance().Topics_AddRating(topicId, UserId, r, string.Empty, HttpContext.Current.Request.UserHostAddress.ToString());
+            }
+            r = DataProvider.Instance().Topics_GetRating(topicId);
+            return BuildOutput(r.ToString(), OutputCodes.Success, true, false);
+        }
+        private string DeleteTopic()
+        {
+            int topicId = -1;
+            int forumId = -1;
+            if (Params.ContainsKey("topicid") && SimulateIsNumeric.IsNumeric(Params["topicid"]))
+            {
+                topicId = int.Parse(Params["topicid"].ToString());
+            }
+            if (topicId > 0)
+            {
+                TopicsController tc = new TopicsController();
                 DotNetNuke.Modules.ActiveForums.Entities.TopicInfo t = tc.Topics_Get(PortalId, ModuleId, topicId);
-				Data.ForumsDB db = new Data.ForumsDB();
-				forumId = db.Forum_GetByTopicId(topicId);
-				ForumController fc = new ForumController();
-				Forum f = fc.Forums_Get(forumId, this.UserId, true);
-				if (f != null)
-				{
-					if (Permissions.HasPerm(f.Security.ModDelete, ForumUser.UserRoles) || (t.Author.AuthorId == this.UserId && Permissions.HasAccess(f.Security.Delete, ForumUser.UserRoles)))
-					{
-						tc.Topics_Delete(PortalId, ModuleId, forumId, topicId, MainSettings.DeleteBehavior);
+                Data.ForumsDB db = new Data.ForumsDB();
+                forumId = db.Forum_GetByTopicId(topicId);
+                ForumController fc = new ForumController();
+                Forum f = fc.Forums_Get(portalId: PortalId, moduleId: ModuleId, forumId: forumId, useCache: true);
+                if (f != null)
+                {
+                    if (Permissions.HasPerm(f.Security.ModDelete, ForumUser.UserRoles) || (t.Author.AuthorId == this.UserId && Permissions.HasAccess(f.Security.Delete, ForumUser.UserRoles)))
+                    {
+                        tc.Topics_Delete(PortalId, ModuleId, forumId, topicId, MainSettings.DeleteBehavior);
                         return BuildOutput(string.Empty, OutputCodes.Success, true);
-					}
-				}
-			}
-			return BuildOutput(string.Empty, OutputCodes.UnsupportedRequest, false);
-		}
-		private string MoveTopic()
-		{
-			int topicId = -1;
-			int forumId = -1;
-			int targetForumId = -1;
-			if (Params.ContainsKey("topicid") && SimulateIsNumeric.IsNumeric(Params["topicid"]))
-			{
-				topicId = int.Parse(Params["topicid"].ToString());
-			}
-			if (Params.ContainsKey("forumid") && SimulateIsNumeric.IsNumeric(Params["forumid"]))
-			{
-				targetForumId = int.Parse(Params["forumid"].ToString());
-			}
-			if (topicId > 0)
-			{
-				TopicsController tc = new TopicsController();
+                    }
+                }
+            }
+            return BuildOutput(string.Empty, OutputCodes.UnsupportedRequest, false);
+        }
+        private string MoveTopic()
+        {
+            int topicId = -1;
+            int forumId = -1;
+            int targetForumId = -1;
+            if (Params.ContainsKey("topicid") && SimulateIsNumeric.IsNumeric(Params["topicid"]))
+            {
+                topicId = int.Parse(Params["topicid"].ToString());
+            }
+            if (Params.ContainsKey("forumid") && SimulateIsNumeric.IsNumeric(Params["forumid"]))
+            {
+                targetForumId = int.Parse(Params["forumid"].ToString());
+            }
+            if (topicId > 0)
+            {
+                TopicsController tc = new TopicsController();
                 DotNetNuke.Modules.ActiveForums.Entities.TopicInfo t = tc.Topics_Get(PortalId, ModuleId, topicId);
-				Data.ForumsDB db = new Data.ForumsDB();
-				forumId = db.Forum_GetByTopicId(topicId);
-				ForumController fc = new ForumController();
-				Forum f = fc.Forums_Get(forumId, this.UserId, true);
-				if (f != null)
-				{
-					if (Permissions.HasPerm(f.Security.ModMove, ForumUser.UserRoles))
-					{
-						tc.Topics_Move(PortalId, ModuleId, targetForumId, topicId);
+                Data.ForumsDB db = new Data.ForumsDB();
+                forumId = db.Forum_GetByTopicId(topicId);
+                ForumController fc = new ForumController();
+                Forum f = fc.Forums_Get(portalId: PortalId, moduleId: ModuleId, forumId: forumId, useCache: true);
+                if (f != null)
+                {
+                    if (Permissions.HasPerm(f.Security.ModMove, ForumUser.UserRoles))
+                    {
+                        tc.Topics_Move(PortalId, ModuleId, targetForumId, topicId);
                         DataCache.CacheClearPrefix(ModuleId, string.Format(CacheKeys.ForumViewPrefix, ModuleId));
-						return BuildOutput(string.Empty, OutputCodes.Success, true);
-					}
-				}
+                        return BuildOutput(string.Empty, OutputCodes.Success, true);
+                    }
+                }
 
-			}
-			return BuildOutput(string.Empty, OutputCodes.UnsupportedRequest, false);
-		}
-		private string MarkAnswer()
-		{
-			int topicId = -1;
-			int forumId = -1;
-			int replyId = -1;
-			if (Params.ContainsKey("topicid") && SimulateIsNumeric.IsNumeric(Params["topicid"]))
-			{
-				topicId = int.Parse(Params["topicid"].ToString());
-			}
-			if (Params.ContainsKey("replyid") && SimulateIsNumeric.IsNumeric(Params["replyid"]))
-			{
-				replyId = int.Parse(Params["replyid"].ToString());
-			}
-			if (topicId > 0 & UserId > 0)
-			{
-				TopicsController tc = new TopicsController();
+            }
+            return BuildOutput(string.Empty, OutputCodes.UnsupportedRequest, false);
+        }
+        private string MarkAnswer()
+        {
+            int topicId = -1;
+            int forumId = -1;
+            int replyId = -1;
+            if (Params.ContainsKey("topicid") && SimulateIsNumeric.IsNumeric(Params["topicid"]))
+            {
+                topicId = int.Parse(Params["topicid"].ToString());
+            }
+            if (Params.ContainsKey("replyid") && SimulateIsNumeric.IsNumeric(Params["replyid"]))
+            {
+                replyId = int.Parse(Params["replyid"].ToString());
+            }
+            if (topicId > 0 & UserId > 0)
+            {
+                TopicsController tc = new TopicsController();
                 DotNetNuke.Modules.ActiveForums.Entities.TopicInfo t = tc.Topics_Get(PortalId, ModuleId, topicId);
-				Data.ForumsDB db = new Data.ForumsDB();
-				forumId = db.Forum_GetByTopicId(topicId);
-				ForumController fc = new ForumController();
-				Forum f = fc.Forums_Get(forumId, this.UserId, true);
-				if ((this.UserId == t.Author.AuthorId && ! t.IsLocked) || Permissions.HasAccess(f.Security.ModEdit, ForumUser.UserRoles))
-				{
-					DataProvider.Instance().Reply_UpdateStatus(PortalId, ModuleId, topicId, replyId, UserId, 1, Permissions.HasAccess(f.Security.ModEdit, ForumUser.UserRoles));
+                Data.ForumsDB db = new Data.ForumsDB();
+                forumId = db.Forum_GetByTopicId(topicId);
+                ForumController fc = new ForumController();
+                Forum f = fc.Forums_Get(portalId: PortalId, moduleId: ModuleId, forumId: forumId, useCache: true);
+                if ((this.UserId == t.Author.AuthorId && !t.IsLocked) || Permissions.HasAccess(f.Security.ModEdit, ForumUser.UserRoles))
+                {
+                    DataProvider.Instance().Reply_UpdateStatus(PortalId, ModuleId, topicId, replyId, UserId, 1, Permissions.HasAccess(f.Security.ModEdit, ForumUser.UserRoles));
 
-				}
-				return BuildOutput(string.Empty, OutputCodes.Success, true);
-			}
-			else
-			{
-				return BuildOutput(string.Empty, OutputCodes.UnsupportedRequest, false);
-			}
-		}
-		private string TagsAutoComplete()
-		{
-			System.Text.StringBuilder sb = new System.Text.StringBuilder();
-			string q = string.Empty;
-			if (! (string.IsNullOrEmpty(HttpContext.Current.Request.QueryString["q"])))
-			{
-				q = HttpContext.Current.Request.QueryString["q"].Trim();
-				q = Utilities.Text.RemoveHTML(q);
-				q = Utilities.Text.CheckSqlString(q);
-				if (! (string.IsNullOrEmpty(q)))
-				{
-					if (q.Length > 20)
-					{
-						q = q.Substring(0, 20);
-					}
-				}
-			}
-			int i = 0;
-			if (! (string.IsNullOrEmpty(q)))
-			{
-				using (IDataReader dr = DataProvider.Instance().Tags_Search(PortalId, ModuleId, q))
-				{
-					while (dr.Read())
-					{
-						sb.AppendLine("{\"id\":\"" + dr["TagId"].ToString() + "\",\"name\":\"" + dr["TagName"].ToString() + "\",\"type\":\"0\"},");
-						i += 1;
-					}
-					dr.Close();
-				}
-			}
-			string @out = "[";
-			if (i > 0)
-			{
-				@out += sb.ToString().Trim();
-				@out = @out.Substring(0, @out.Length - 1);
-			}
-			@out += "]";
-			return @out;
-		}
-		private string DeletePost()
-		{
-			int replyId = -1;
-			int TopicId = -1;
-			if (Params.ContainsKey("topicid") && SimulateIsNumeric.IsNumeric(Params["topicid"]))
-			{
-				TopicId = int.Parse(Params["topicid"].ToString());
-			}
-			if (Params.ContainsKey("replyid") && SimulateIsNumeric.IsNumeric(Params["replyid"]))
-			{
-				replyId = int.Parse(Params["replyid"].ToString());
-			}
-			int forumId = -1;
-			Data.ForumsDB db = new Data.ForumsDB();
-			forumId = db.Forum_GetByTopicId(TopicId);
-			ForumController fc = new ForumController();
-			Forum f = fc.Forums_Get(forumId, this.UserId, true);
+                }
+                return BuildOutput(string.Empty, OutputCodes.Success, true);
+            }
+            else
+            {
+                return BuildOutput(string.Empty, OutputCodes.UnsupportedRequest, false);
+            }
+        }
+        private string TagsAutoComplete()
+        {
+            System.Text.StringBuilder sb = new System.Text.StringBuilder();
+            string q = string.Empty;
+            if (!(string.IsNullOrEmpty(HttpContext.Current.Request.QueryString["q"])))
+            {
+                q = HttpContext.Current.Request.QueryString["q"].Trim();
+                q = Utilities.Text.RemoveHTML(q);
+                q = Utilities.Text.CheckSqlString(q);
+                if (!(string.IsNullOrEmpty(q)))
+                {
+                    if (q.Length > 20)
+                    {
+                        q = q.Substring(0, 20);
+                    }
+                }
+            }
+            int i = 0;
+            if (!(string.IsNullOrEmpty(q)))
+            {
+                using (IDataReader dr = DataProvider.Instance().Tags_Search(PortalId, ModuleId, q))
+                {
+                    while (dr.Read())
+                    {
+                        sb.AppendLine("{\"id\":\"" + dr["TagId"].ToString() + "\",\"name\":\"" + dr["TagName"].ToString() + "\",\"type\":\"0\"},");
+                        i += 1;
+                    }
+                    dr.Close();
+                }
+            }
+            string @out = "[";
+            if (i > 0)
+            {
+                @out += sb.ToString().Trim();
+                @out = @out.Substring(0, @out.Length - 1);
+            }
+            @out += "]";
+            return @out;
+        }
+        private string DeletePost()
+        {
+            int replyId = -1;
+            int TopicId = -1;
+            if (Params.ContainsKey("topicid") && SimulateIsNumeric.IsNumeric(Params["topicid"]))
+            {
+                TopicId = int.Parse(Params["topicid"].ToString());
+            }
+            if (Params.ContainsKey("replyid") && SimulateIsNumeric.IsNumeric(Params["replyid"]))
+            {
+                replyId = int.Parse(Params["replyid"].ToString());
+            }
+            int forumId = -1;
+            Data.ForumsDB db = new Data.ForumsDB();
+            forumId = db.Forum_GetByTopicId(TopicId);
+            ForumController fc = new ForumController();
+            Forum f = fc.Forums_Get(portalId: PortalId, moduleId: ModuleId, forumId: forumId, useCache: true);
 
-			// Need to get the list of attachments BEFORE we remove the post recods
-			var attachmentController = new Data.AttachController();
-			var attachmentList = (MainSettings.DeleteBehavior == 0)
-									 ? attachmentController.ListForPost(TopicId, replyId)
-									 : null;
+            // Need to get the list of attachments BEFORE we remove the post recods
+            var attachmentController = new Data.AttachController();
+            var attachmentList = (MainSettings.DeleteBehavior == 0)
+                                     ? attachmentController.ListForPost(TopicId, replyId)
+                                     : null;
 
 
-			if (TopicId > 0 & replyId < 1)
-			{
-				TopicsController tc = new TopicsController();
+            if (TopicId > 0 & replyId < 1)
+            {
+                TopicsController tc = new TopicsController();
                 DotNetNuke.Modules.ActiveForums.Entities.TopicInfo ti = tc.Topics_Get(PortalId, ModuleId, TopicId);
 
-				if (Permissions.HasAccess(f.Security.ModDelete, ForumUser.UserRoles) || (Permissions.HasAccess(f.Security.Delete, ForumUser.UserRoles) && ti.Content.AuthorId == UserId && ti.IsLocked == false))
-				{
-					DataProvider.Instance().Topics_Delete(forumId, TopicId, MainSettings.DeleteBehavior);
-					string journalKey = string.Format("{0}:{1}", forumId.ToString(), TopicId.ToString());
-					JournalController.Instance.DeleteJournalItemByKey(PortalId, journalKey);
-				}
-				else
-				{
-					return BuildOutput(string.Empty, OutputCodes.UnsupportedRequest, false);
-				}
-			}
-			else
-			{
-				ReplyController rc = new ReplyController();
-				DotNetNuke.Modules.ActiveForums.ReplyInfo ri = rc.Reply_Get(PortalId, ModuleId, TopicId, replyId);
-				if (Permissions.HasAccess(f.Security.ModDelete, ForumUser.UserRoles) || (Permissions.HasAccess(f.Security.Delete, ForumUser.UserRoles) && ri.Content.AuthorId == UserId))
-				{
-					DataProvider.Instance().Reply_Delete(forumId, TopicId, replyId, MainSettings.DeleteBehavior);
-					string journalKey = string.Format("{0}:{1}:{2}", forumId.ToString(), TopicId.ToString(), replyId.ToString());
-					JournalController.Instance.DeleteJournalItemByKey(PortalId, journalKey);
+                if (Permissions.HasAccess(f.Security.ModDelete, ForumUser.UserRoles) || (Permissions.HasAccess(f.Security.Delete, ForumUser.UserRoles) && ti.Content.AuthorId == UserId && ti.IsLocked == false))
+                {
+                    DataProvider.Instance().Topics_Delete(forumId, TopicId, MainSettings.DeleteBehavior);
+                    string journalKey = string.Format("{0}:{1}", forumId.ToString(), TopicId.ToString());
+                    JournalController.Instance.DeleteJournalItemByKey(PortalId, journalKey);
+                }
+                else
+                {
+                    return BuildOutput(string.Empty, OutputCodes.UnsupportedRequest, false);
+                }
+            }
+            else
+            {
+                ReplyController rc = new ReplyController();
+                DotNetNuke.Modules.ActiveForums.ReplyInfo ri = rc.Reply_Get(PortalId, ModuleId, TopicId, replyId);
+                if (Permissions.HasAccess(f.Security.ModDelete, ForumUser.UserRoles) || (Permissions.HasAccess(f.Security.Delete, ForumUser.UserRoles) && ri.Content.AuthorId == UserId))
+                {
+                    DataProvider.Instance().Reply_Delete(forumId, TopicId, replyId, MainSettings.DeleteBehavior);
+                    string journalKey = string.Format("{0}:{1}:{2}", forumId.ToString(), TopicId.ToString(), replyId.ToString());
+                    JournalController.Instance.DeleteJournalItemByKey(PortalId, journalKey);
 
-				}
-				else
-				{
-					return BuildOutput(string.Empty, OutputCodes.UnsupportedRequest, false);
-				}
+                }
+                else
+                {
+                    return BuildOutput(string.Empty, OutputCodes.UnsupportedRequest, false);
+                }
 
-			}
+            }
 
-			// If it's a hard delete, delete associated attachments
-			// attachmentList will only be populated if the DeleteBehavior is 0
-			if (attachmentList != null)
-			{      
-				var fileManager = FileManager.Instance;
-				var folderManager = FolderManager.Instance;
-				var attachmentFolder = folderManager.GetFolder(PortalId, "activeforums_Attach");
+            // If it's a hard delete, delete associated attachments
+            // attachmentList will only be populated if the DeleteBehavior is 0
+            if (attachmentList != null)
+            {
+                var fileManager = FileManager.Instance;
+                var folderManager = FolderManager.Instance;
+                var attachmentFolder = folderManager.GetFolder(PortalId, "activeforums_Attach");
 
-				foreach (var attachment in attachmentList)
-				{
-					attachmentController.Delete(attachment.AttachmentId);
+                foreach (var attachment in attachmentList)
+                {
+                    attachmentController.Delete(attachment.AttachmentId);
 
-					var file = attachment.FileId.HasValue
-								   ? fileManager.GetFile(attachment.FileId.Value)
-								   : fileManager.GetFile(attachmentFolder, attachment.FileName);
+                    var file = attachment.FileId.HasValue
+                                   ? fileManager.GetFile(attachment.FileId.Value)
+                                   : fileManager.GetFile(attachmentFolder, attachment.FileName);
 
-					// Only delete the file if it exists in the attachment folder
-					if (file != null && file.FolderId == attachmentFolder.FolderID)
-						fileManager.DeleteFile(file);
-				}
-			}
+                    // Only delete the file if it exists in the attachment folder
+                    if (file != null && file.FolderId == attachmentFolder.FolderID)
+                        fileManager.DeleteFile(file);
+                }
+            }
 
-			// Return the result
-			DataCache.CacheClearPrefix(ModuleId, string.Format(CacheKeys.ForumViewPrefix, ModuleId));
-			return BuildOutput(TopicId + "|" + replyId, OutputCodes.Success, true);
-		}
-		private string LoadTopic()
-		{
-			int topicId = -1;
-			int forumId = -1;
-			if (Params.ContainsKey("topicid") && SimulateIsNumeric.IsNumeric(Params["topicid"]))
-			{
-				topicId = int.Parse(Params["topicid"].ToString());
-			}
-			if (topicId > 0)
-			{
-				TopicsController tc = new TopicsController();
+            // Return the result
+            DataCache.CacheClearPrefix(ModuleId, string.Format(CacheKeys.ForumViewPrefix, ModuleId));
+            return BuildOutput(TopicId + "|" + replyId, OutputCodes.Success, true);
+        }
+        private string LoadTopic()
+        {
+            int topicId = -1;
+            int forumId = -1;
+            if (Params.ContainsKey("topicid") && SimulateIsNumeric.IsNumeric(Params["topicid"]))
+            {
+                topicId = int.Parse(Params["topicid"].ToString());
+            }
+            if (topicId > 0)
+            {
+                TopicsController tc = new TopicsController();
                 DotNetNuke.Modules.ActiveForums.Entities.TopicInfo t = tc.Topics_Get(PortalId, ModuleId, topicId);
-				Data.ForumsDB db = new Data.ForumsDB();
-				forumId = db.Forum_GetByTopicId(topicId);
-				ForumController fc = new ForumController();
-				Forum f = fc.Forums_Get(PortalId, -1, forumId, this.UserId, true, false, -1);
-				if (f != null)
-				{
-					if (Permissions.HasPerm(f.Security.ModEdit, ForumUser.UserRoles))
-					{
-						StringBuilder sb = new StringBuilder();
-						sb.Append("{");
-						sb.Append(Utilities.JSON.Pair("topicid", t.TopicId.ToString()));
-						sb.Append(",");
-						sb.Append(Utilities.JSON.Pair("subject", t.Content.Subject));
-						sb.Append(",");
-						sb.Append(Utilities.JSON.Pair("authorid", t.Content.AuthorId.ToString()));
-						sb.Append(",");
-						sb.Append(Utilities.JSON.Pair("locked", t.IsLocked.ToString()));
-						sb.Append(",");
-						sb.Append(Utilities.JSON.Pair("pinned", t.IsPinned.ToString()));
-						sb.Append(",");
-						sb.Append(Utilities.JSON.Pair("priority", t.Priority.ToString()));
-						sb.Append(",");
-						sb.Append(Utilities.JSON.Pair("status", t.StatusId.ToString()));
-						sb.Append(",");
-						sb.Append(Utilities.JSON.Pair("forumid", forumId.ToString()));
-						sb.Append(",");
-						sb.Append(Utilities.JSON.Pair("forumname", f.ForumName));
-						sb.Append(",");
-						sb.Append(Utilities.JSON.Pair("tags", t.Tags));
-						sb.Append(",");
-						sb.Append(Utilities.JSON.Pair("categories", t.Categories));
-						sb.Append(",");
-						sb.Append("\"properties\":[");
-						string sCats = string.Empty;
-						if (f.Properties != null)
-						{
-							int i = 0;
-							foreach (PropertiesInfo p in f.Properties)
-							{
-								sb.Append("{");
-								sb.Append(Utilities.JSON.Pair("propertyid", p.PropertyId.ToString()));
-								sb.Append(",");
-								sb.Append(Utilities.JSON.Pair("datatype", p.DataType));
-								sb.Append(",");
-								sb.Append(Utilities.JSON.Pair("propertyname", p.Name));
-								sb.Append(",");
-								string pvalue = p.DefaultValue;
-								foreach (PropertiesInfo tp in t.TopicProperties)
-								{
-									if (tp.PropertyId == p.PropertyId)
-									{
-										pvalue = tp.DefaultValue;
-									}
-								}
+                Data.ForumsDB db = new Data.ForumsDB();
+                forumId = db.Forum_GetByTopicId(topicId);
+                ForumController fc = new ForumController();
+                Forum f = fc.Forums_Get(PortalId, ModuleId, forumId, false, -1);
+                if (f != null)
+                {
+                    if (Permissions.HasPerm(f.Security.ModEdit, ForumUser.UserRoles))
+                    {
+                        StringBuilder sb = new StringBuilder();
+                        sb.Append("{");
+                        sb.Append(Utilities.JSON.Pair("topicid", t.TopicId.ToString()));
+                        sb.Append(",");
+                        sb.Append(Utilities.JSON.Pair("subject", t.Content.Subject));
+                        sb.Append(",");
+                        sb.Append(Utilities.JSON.Pair("authorid", t.Content.AuthorId.ToString()));
+                        sb.Append(",");
+                        sb.Append(Utilities.JSON.Pair("locked", t.IsLocked.ToString()));
+                        sb.Append(",");
+                        sb.Append(Utilities.JSON.Pair("pinned", t.IsPinned.ToString()));
+                        sb.Append(",");
+                        sb.Append(Utilities.JSON.Pair("priority", t.Priority.ToString()));
+                        sb.Append(",");
+                        sb.Append(Utilities.JSON.Pair("status", t.StatusId.ToString()));
+                        sb.Append(",");
+                        sb.Append(Utilities.JSON.Pair("forumid", forumId.ToString()));
+                        sb.Append(",");
+                        sb.Append(Utilities.JSON.Pair("forumname", f.ForumName));
+                        sb.Append(",");
+                        sb.Append(Utilities.JSON.Pair("tags", t.Tags));
+                        sb.Append(",");
+                        sb.Append(Utilities.JSON.Pair("categories", t.Categories));
+                        sb.Append(",");
+                        sb.Append("\"properties\":[");
+                        string sCats = string.Empty;
+                        if (f.Properties != null)
+                        {
+                            int i = 0;
+                            foreach (PropertiesInfo p in f.Properties)
+                            {
+                                sb.Append("{");
+                                sb.Append(Utilities.JSON.Pair("propertyid", p.PropertyId.ToString()));
+                                sb.Append(",");
+                                sb.Append(Utilities.JSON.Pair("datatype", p.DataType));
+                                sb.Append(",");
+                                sb.Append(Utilities.JSON.Pair("propertyname", p.Name));
+                                sb.Append(",");
+                                string pvalue = p.DefaultValue;
+                                foreach (PropertiesInfo tp in t.TopicProperties)
+                                {
+                                    if (tp.PropertyId == p.PropertyId)
+                                    {
+                                        pvalue = tp.DefaultValue;
+                                    }
+                                }
 
-								sb.Append(Utilities.JSON.Pair("propertyvalue", pvalue));
-								if (p.DataType.Contains("list"))
-								{
-									sb.Append(",\"listdata\":[");
-									if (p.DataType.Contains("list|categories"))
-									{
-										using (IDataReader dr = DataProvider.Instance().Tags_List(PortalId, f.ModuleId, true, 0, 200, "ASC", "TagName", forumId, f.ForumGroupId))
-										{
-											dr.NextResult();
-											while (dr.Read())
-											{
-												sCats += "{";
-												sCats += Utilities.JSON.Pair("id", dr["TagId"].ToString());
-												sCats += ",";
-												sCats += Utilities.JSON.Pair("name", dr["TagName"].ToString());
-												sCats += ",";
-												sCats += Utilities.JSON.Pair("selected", IsSelected(dr["TagName"].ToString(), t.Categories).ToString());
-												sCats += "},";
-											}
-											dr.Close();
-										}
-										if (! (string.IsNullOrEmpty(sCats)))
-										{
-											sCats = sCats.Substring(0, sCats.Length - 1);
-										}
-										sb.Append(sCats);
-									}
-									else
-									{
-										DotNetNuke.Common.Lists.ListController lists = new DotNetNuke.Common.Lists.ListController();
-										string lName = p.DataType.Substring(p.DataType.IndexOf("|") + 1);
-										DotNetNuke.Common.Lists.ListEntryInfoCollection lc = lists.GetListEntryInfoCollection(lName, string.Empty);
-										int il = 0;
-										foreach (DotNetNuke.Common.Lists.ListEntryInfo l in lc)
-										{
-											sb.Append("{");
-											sb.Append(Utilities.JSON.Pair("itemId", l.Value));
-											sb.Append(",");
-											sb.Append(Utilities.JSON.Pair("itemName", l.Text));
-											sb.Append("}");
-											il += 1;
-											if (il < lc.Count)
-											{
-												sb.Append(",");
-											}
-										}
-									}
-									sb.Append("]");
-								}
-								sb.Append("}");
-								i += 1;
-								if (i < f.Properties.Count)
-								{
-									sb.Append(",");
-								}
+                                sb.Append(Utilities.JSON.Pair("propertyvalue", pvalue));
+                                if (p.DataType.Contains("list"))
+                                {
+                                    sb.Append(",\"listdata\":[");
+                                    if (p.DataType.Contains("list|categories"))
+                                    {
+                                        using (IDataReader dr = DataProvider.Instance().Tags_List(PortalId, f.ModuleId, true, 0, 200, "ASC", "TagName", forumId, f.ForumGroupId))
+                                        {
+                                            dr.NextResult();
+                                            while (dr.Read())
+                                            {
+                                                sCats += "{";
+                                                sCats += Utilities.JSON.Pair("id", dr["TagId"].ToString());
+                                                sCats += ",";
+                                                sCats += Utilities.JSON.Pair("name", dr["TagName"].ToString());
+                                                sCats += ",";
+                                                sCats += Utilities.JSON.Pair("selected", IsSelected(dr["TagName"].ToString(), t.Categories).ToString());
+                                                sCats += "},";
+                                            }
+                                            dr.Close();
+                                        }
+                                        if (!(string.IsNullOrEmpty(sCats)))
+                                        {
+                                            sCats = sCats.Substring(0, sCats.Length - 1);
+                                        }
+                                        sb.Append(sCats);
+                                    }
+                                    else
+                                    {
+                                        DotNetNuke.Common.Lists.ListController lists = new DotNetNuke.Common.Lists.ListController();
+                                        string lName = p.DataType.Substring(p.DataType.IndexOf("|") + 1);
+                                        DotNetNuke.Common.Lists.ListEntryInfoCollection lc = lists.GetListEntryInfoCollection(lName, string.Empty);
+                                        int il = 0;
+                                        foreach (DotNetNuke.Common.Lists.ListEntryInfo l in lc)
+                                        {
+                                            sb.Append("{");
+                                            sb.Append(Utilities.JSON.Pair("itemId", l.Value));
+                                            sb.Append(",");
+                                            sb.Append(Utilities.JSON.Pair("itemName", l.Text));
+                                            sb.Append("}");
+                                            il += 1;
+                                            if (il < lc.Count)
+                                            {
+                                                sb.Append(",");
+                                            }
+                                        }
+                                    }
+                                    sb.Append("]");
+                                }
+                                sb.Append("}");
+                                i += 1;
+                                if (i < f.Properties.Count)
+                                {
+                                    sb.Append(",");
+                                }
 
-							}
-						}
-
-
+                            }
+                        }
 
 
-						sb.Append("],\"categories\":[");
-						sCats = string.Empty;
-						using (IDataReader dr = DataProvider.Instance().Tags_List(PortalId, f.ModuleId, true, 0, 200, "ASC", "TagName", forumId, f.ForumGroupId))
-						{
-							dr.NextResult();
-							while (dr.Read())
-							{
-								sCats += "{";
-								sCats += Utilities.JSON.Pair("id", dr["TagId"].ToString());
-								sCats += ",";
-								sCats += Utilities.JSON.Pair("name", dr["TagName"].ToString());
-								sCats += ",";
-								sCats += Utilities.JSON.Pair("selected", IsSelected(dr["TagName"].ToString(), t.Categories).ToString());
-								sCats += "},";
-							}
-							dr.Close();
-						}
-						if (! (string.IsNullOrEmpty(sCats)))
-						{
-							sCats = sCats.Substring(0, sCats.Length - 1);
-						}
-						sb.Append(sCats);
-						sb.Append("]");
-						sb.Append("}");
-						return BuildOutput(sb.ToString(), OutputCodes.Success, true, true);
-					}
-				}
 
-			}
-			return BuildOutput(string.Empty, OutputCodes.UnsupportedRequest, false);
-		}
-		private string SaveTopic()
-		{
-			int topicId = -1;
-			int forumId = -1;
-			if (Params.ContainsKey("topicid") && SimulateIsNumeric.IsNumeric(Params["topicid"]))
-			{
-				topicId = int.Parse(Params["topicid"].ToString());
-			}
-			if (topicId > 0)
-			{
-				TopicsController tc = new TopicsController();
+
+                        sb.Append("],\"categories\":[");
+                        sCats = string.Empty;
+                        using (IDataReader dr = DataProvider.Instance().Tags_List(PortalId, f.ModuleId, true, 0, 200, "ASC", "TagName", forumId, f.ForumGroupId))
+                        {
+                            dr.NextResult();
+                            while (dr.Read())
+                            {
+                                sCats += "{";
+                                sCats += Utilities.JSON.Pair("id", dr["TagId"].ToString());
+                                sCats += ",";
+                                sCats += Utilities.JSON.Pair("name", dr["TagName"].ToString());
+                                sCats += ",";
+                                sCats += Utilities.JSON.Pair("selected", IsSelected(dr["TagName"].ToString(), t.Categories).ToString());
+                                sCats += "},";
+                            }
+                            dr.Close();
+                        }
+                        if (!(string.IsNullOrEmpty(sCats)))
+                        {
+                            sCats = sCats.Substring(0, sCats.Length - 1);
+                        }
+                        sb.Append(sCats);
+                        sb.Append("]");
+                        sb.Append("}");
+                        return BuildOutput(sb.ToString(), OutputCodes.Success, true, true);
+                    }
+                }
+
+            }
+            return BuildOutput(string.Empty, OutputCodes.UnsupportedRequest, false);
+        }
+        private string SaveTopic()
+        {
+            int topicId = -1;
+            int forumId = -1;
+            if (Params.ContainsKey("topicid") && SimulateIsNumeric.IsNumeric(Params["topicid"]))
+            {
+                topicId = int.Parse(Params["topicid"].ToString());
+            }
+            if (topicId > 0)
+            {
+                TopicsController tc = new TopicsController();
                 DotNetNuke.Modules.ActiveForums.Entities.TopicInfo t = tc.Topics_Get(PortalId, ModuleId, topicId);
-				Data.ForumsDB db = new Data.ForumsDB();
-				forumId = db.Forum_GetByTopicId(topicId);
-				ForumController fc = new ForumController();
-				Forum ForumInfo = fc.Forums_Get(PortalId, -1, forumId, this.UserId, true, false, -1);
-				if (Permissions.HasPerm(ForumInfo.Security.ModEdit, ForumUser.UserRoles))
-				{
-					string subject = Params["subject"].ToString();
-					subject = Utilities.XSSFilter(subject, true);
+                Data.ForumsDB db = new Data.ForumsDB();
+                forumId = db.Forum_GetByTopicId(topicId);
+                ForumController fc = new ForumController();
+                Forum ForumInfo = fc.Forums_Get(PortalId, ModuleId, forumId, false, -1);
+                if (Permissions.HasPerm(ForumInfo.Security.ModEdit, ForumUser.UserRoles))
+                {
+                    string subject = Params["subject"].ToString();
+                    subject = Utilities.XSSFilter(subject, true);
                     t.TopicUrl = DotNetNuke.Modules.ActiveForums.Controllers.UrlController.BuildTopicUrl(PortalId: PortalId, ModuleId: ForumInfo.ModuleId, TopicId: topicId, subject: subject, forumInfo: ForumInfo);
-                    
-					t.Content.Subject = subject;
-					t.IsPinned = bool.Parse(Params["pinned"].ToString());
-					t.IsLocked = bool.Parse(Params["locked"].ToString());
-					t.Priority = int.Parse(Params["priority"].ToString());
-					t.StatusId = int.Parse(Params["status"].ToString());
-					if (ForumInfo.Properties != null)
-					{
-						StringBuilder tData = new StringBuilder();
-						tData.Append("<topicdata>");
-						tData.Append("<properties>");
-						foreach (PropertiesInfo p in ForumInfo.Properties)
-						{
-							string pkey = "prop-" + p.PropertyId.ToString();
 
-							tData.Append("<property id=\"" + p.PropertyId.ToString() + "\">");
-							tData.Append("<name><![CDATA[");
-							tData.Append(p.Name);
-							tData.Append("]]></name>");
-							if (Params[pkey] != null)
-							{
-								tData.Append("<value><![CDATA[");
-								tData.Append(Utilities.XSSFilter(Params[pkey].ToString()));
-								tData.Append("]]></value>");
-							}
-							else
-							{
-								tData.Append("<value></value>");
-							}
-							tData.Append("</property>");
-						}
-						tData.Append("</properties>");
-						tData.Append("</topicdata>");
-						t.TopicData = tData.ToString();
-					}
-				}
-				tc.TopicSave(PortalId, ModuleId, t);
+                    t.Content.Subject = subject;
+                    t.IsPinned = bool.Parse(Params["pinned"].ToString());
+                    t.IsLocked = bool.Parse(Params["locked"].ToString());
+                    t.Priority = int.Parse(Params["priority"].ToString());
+                    t.StatusId = int.Parse(Params["status"].ToString());
+                    if (ForumInfo.Properties != null)
+                    {
+                        StringBuilder tData = new StringBuilder();
+                        tData.Append("<topicdata>");
+                        tData.Append("<properties>");
+                        foreach (PropertiesInfo p in ForumInfo.Properties)
+                        {
+                            string pkey = "prop-" + p.PropertyId.ToString();
+
+                            tData.Append("<property id=\"" + p.PropertyId.ToString() + "\">");
+                            tData.Append("<name><![CDATA[");
+                            tData.Append(p.Name);
+                            tData.Append("]]></name>");
+                            if (Params[pkey] != null)
+                            {
+                                tData.Append("<value><![CDATA[");
+                                tData.Append(Utilities.XSSFilter(Params[pkey].ToString()));
+                                tData.Append("]]></value>");
+                            }
+                            else
+                            {
+                                tData.Append("<value></value>");
+                            }
+                            tData.Append("</property>");
+                        }
+                        tData.Append("</properties>");
+                        tData.Append("</topicdata>");
+                        t.TopicData = tData.ToString();
+                    }
+                }
+                tc.TopicSave(PortalId, ModuleId, t);
                 tc.UpdateModuleLastContentModifiedOnDate(ModuleId);
                 if (Params["tags"] != null)
-				{
-					DataProvider.Instance().Tags_DeleteByTopicId(PortalId, ForumInfo.ModuleId, topicId);
-					string tagForm = string.Empty;
-					if (Params["tags"] != null)
-					{
-						tagForm = Params["tags"].ToString();
-					}
-					if (! (tagForm == string.Empty))
-					{
-						string[] Tags = tagForm.Split(',');
-						foreach (string tag in Tags)
-						{
-							string sTag = Utilities.CleanString(PortalId, tag.Trim(), false, EditorTypes.TEXTBOX, false, false, ForumInfo.ModuleId, string.Empty, false);
-							DataProvider.Instance().Tags_Save(PortalId, ForumInfo.ModuleId, -1, sTag, 0, 1, 0, topicId, false, -1, -1);
-						}
-					}
-				}
+                {
+                    DataProvider.Instance().Tags_DeleteByTopicId(PortalId, ForumInfo.ModuleId, topicId);
+                    string tagForm = string.Empty;
+                    if (Params["tags"] != null)
+                    {
+                        tagForm = Params["tags"].ToString();
+                    }
+                    if (!(tagForm == string.Empty))
+                    {
+                        string[] Tags = tagForm.Split(',');
+                        foreach (string tag in Tags)
+                        {
+                            string sTag = Utilities.CleanString(PortalId, tag.Trim(), false, EditorTypes.TEXTBOX, false, false, ForumInfo.ModuleId, string.Empty, false);
+                            DataProvider.Instance().Tags_Save(PortalId, ForumInfo.ModuleId, -1, sTag, 0, 1, 0, topicId, false, -1, -1);
+                        }
+                    }
+                }
 
-				if (Params["categories"] != null)
-				{
-					string[] cats = Params["categories"].ToString().Split(';');
-					DataProvider.Instance().Tags_DeleteTopicToCategory(PortalId, ForumInfo.ModuleId, -1, topicId);
-					foreach (string c in cats)
-					{
-						int cid = -1;
-						if (! (string.IsNullOrEmpty(c)) && SimulateIsNumeric.IsNumeric(c))
-						{
-							cid = Convert.ToInt32(c);
-							if (cid > 0)
-							{
-								DataProvider.Instance().Tags_AddTopicToCategory(PortalId, ForumInfo.ModuleId, cid, topicId);
-							}
-						}
-					}
-				}
-			}
+                if (Params["categories"] != null)
+                {
+                    string[] cats = Params["categories"].ToString().Split(';');
+                    DataProvider.Instance().Tags_DeleteTopicToCategory(PortalId, ForumInfo.ModuleId, -1, topicId);
+                    foreach (string c in cats)
+                    {
+                        int cid = -1;
+                        if (!(string.IsNullOrEmpty(c)) && SimulateIsNumeric.IsNumeric(c))
+                        {
+                            cid = Convert.ToInt32(c);
+                            if (cid > 0)
+                            {
+                                DataProvider.Instance().Tags_AddTopicToCategory(PortalId, ForumInfo.ModuleId, cid, topicId);
+                            }
+                        }
+                    }
+                }
+            }
 
 
-			return BuildOutput(string.Empty, OutputCodes.UnsupportedRequest, false);
-		}
-		private bool IsSelected(string TagName, string selectedValues)
-		{
-			if (string.IsNullOrEmpty(selectedValues))
-			{
-				return false;
-			}
-			else
-			{
-				foreach (string s in selectedValues.Split('|'))
-				{
-					if (! (string.IsNullOrEmpty(s)))
-					{
-						if (s.ToLowerInvariant().Trim() == TagName.ToLowerInvariant().Trim())
-						{
-							return true;
-						}
-					}
-				}
-			}
+            return BuildOutput(string.Empty, OutputCodes.UnsupportedRequest, false);
+        }
+        private bool IsSelected(string TagName, string selectedValues)
+        {
+            if (string.IsNullOrEmpty(selectedValues))
+            {
+                return false;
+            }
+            else
+            {
+                foreach (string s in selectedValues.Split('|'))
+                {
+                    if (!(string.IsNullOrEmpty(s)))
+                    {
+                        if (s.ToLowerInvariant().Trim() == TagName.ToLowerInvariant().Trim())
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
 
-			return false;
-		}
-	}
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
### Description of PR...
Forum settings in Control Panel were reverting back to previous settings. 
In 08.00.00, where caches are now separated by moduleId to support separate caches for multiple installs of the Forums module. In the Control Panel, forum settings changes were being saved with module ID but lookups were not including the module id, so the caches were not synchronized.



## Changes made
- Change all forum get method calls to pass module id
- Refactor forum get methods 
 
## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #429 