### PR TITLE
FIX: Forums toolbar caching needs user-type

### DIFF
--- a/Dnn.CommunityForums/class/Globals.cs
+++ b/Dnn.CommunityForums/class/Globals.cs
@@ -337,7 +337,7 @@ namespace DotNetNuke.Modules.ActiveForums
         public const string TopicsViewPrefix = "AF-{0}-TVS-";
         public const string TopicsViewForUser = "AF-{0}-TVS-{1}-{2}";
         public const string ForumViewTemplate = "AF-{0}-fvt-{1}";
-        public const string Toolbar = "AF-{0}-tb";
+        public const string Toolbar = "AF-{0}-tb-{1}";
         public const string TemplatePrefix = "AF-{0}-tmpl-";
         public const string Template = "AF-{0}-tmpl-{1}-{2}";
         public const string QuickReply = "AF-{0}-qr";

--- a/Dnn.CommunityForums/class/Utilities.cs
+++ b/Dnn.CommunityForums/class/Utilities.cs
@@ -172,7 +172,7 @@ namespace DotNetNuke.Modules.ActiveForums
         {
             string sToolbar =
                 Convert.ToString(
-                    DataCache.SettingsCacheRetrieve(forumModuleId, string.Format(CacheKeys.Toolbar, forumModuleId)));
+                    DataCache.SettingsCacheRetrieve(forumModuleId, string.Format(CacheKeys.Toolbar, forumModuleId, currentUserType)));
             if (string.IsNullOrEmpty(sToolbar))
             {
 
@@ -190,7 +190,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 sToolbar = Utilities.GetFileContent(templateFilePathFileName);
                 sToolbar = sToolbar.Replace("[TRESX:", "[RESX:");
                 sToolbar = Utilities.ParseToolBar(template: sToolbar, forumTabId: forumTabId, forumModuleId: forumModuleId, tabId: tabId, moduleId: moduleId, currentUserType: currentUserType);
-                DataCache.SettingsCacheStore(ModuleId: forumModuleId, cacheKey: string.Format(CacheKeys.Toolbar, forumModuleId), sToolbar);
+                DataCache.SettingsCacheStore(ModuleId: forumModuleId, cacheKey: string.Format(CacheKeys.Toolbar, forumModuleId ,currentUserType), sToolbar);
             }
 
             return sToolbar;


### PR DESCRIPTION
The forums toolbar template and content are now cached, but need to be cached depending on the type of user (superuser, moderator, regular user, anonymous, etc.).
 

### Description of PR...
The forums toolbar template and content are now cached, but need to be cached depending on the type of user (superuser, moderator, regular user, anonymous, etc.).
 

## Changes made
- Add user type to cache key

## How did you test these updates?  

As superuser:
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/4b83987e-a997-4a28-ae8e-68798bd19364)

Logout (anonymous/unathenticated):
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/d1326af3-be69-4d35-bb55-dac09f045ece)



## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #431