### PR TITLE
FIX: theme name duplicated in icon URL causing 404 on some pages

### DIFF
--- a/Dnn.CommunityForums/controls/af_grid.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_grid.ascx.cs
@@ -407,14 +407,14 @@ namespace DotNetNuke.Modules.ActiveForums
             var locked = Convert.ToBoolean(_currentRow["IsLocked"]);
 
             if(pinned && locked)
-                return MainSettings.ThemeLocation + theme + "/images/topic_pinlocked.png";
+                return MainSettings.ThemeLocation + "/images/topic_pinlocked.png";
 
             if (pinned)
-                return MainSettings.ThemeLocation + theme + "/images/topic_pin.png";
+                return MainSettings.ThemeLocation + "/images/topic_pin.png";
 
             
             if (locked)
-                return MainSettings.ThemeLocation + theme + "/images/topic_lock.png";
+                return MainSettings.ThemeLocation + "/images/topic_lock.png";
 
             // Unread has to be calculated based on a few fields
             //var topicId = Convert.ToInt32(_currentRow["TopicId"]);
@@ -427,9 +427,9 @@ namespace DotNetNuke.Modules.ActiveForums
             var isRead = _currentRow.GetBoolean("IsRead");
 
             if (isRead)
-                return MainSettings.ThemeLocation + theme + "/images/topic.png";
+                return MainSettings.ThemeLocation + "/images/topic.png";
 
-            return MainSettings.ThemeLocation + theme + "/images/topic_new.png";
+            return MainSettings.ThemeLocation + "/images/topic_new.png";
         }
 
         public string GetMiniPager()

--- a/Dnn.CommunityForums/controls/af_search.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_search.ascx.cs
@@ -619,13 +619,13 @@ namespace DotNetNuke.Modules.ActiveForums
             var locked = Convert.ToBoolean(_currentRow["IsLocked"]);
 
             if(pinned && locked)
-                return MainSettings.ThemeLocation + theme + "/images/topic_pinlocked.png";
+                return MainSettings.ThemeLocation + "/images/topic_pinlocked.png";
 
             if(pinned)
-                return MainSettings.ThemeLocation + theme + "/images/topic_pin.png";
+                return MainSettings.ThemeLocation + "/images/topic_pin.png";
 
             if(locked)
-                return MainSettings.ThemeLocation + theme + "/images/topic_lock.png";
+                return MainSettings.ThemeLocation + "/images/topic_lock.png";
 
             // Unread has to be calculated based on a few fields
             var topicId = Convert.ToInt32(_currentRow["TopicId"]);
@@ -636,9 +636,9 @@ namespace DotNetNuke.Modules.ActiveForums
             var unread = (replyCount <= 0 && topicId > userLastTopicRead) || (lastReplyId > userLastReplyRead);
 
             if(unread)
-                return MainSettings.ThemeLocation + theme + "/images/topic.png";
+                return MainSettings.ThemeLocation + "/images/topic.png";
 
-            return MainSettings.ThemeLocation + theme + "/images/topic_new.png";
+            return MainSettings.ThemeLocation + "/images/topic_new.png";
         }
 
         public string GetMiniPager()


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Theme name duplicated in icon URLs resulting in 404 errors.

## Changes made
- remove duplicated theme name from URL

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #437 