### PR TITLE
INSTALLER: Don't rename themes/module.css to theme.css

### DIFF
--- a/Dnn.CommunityForums/ReleaseNotes.txt
+++ b/Dnn.CommunityForums/ReleaseNotes.txt
@@ -4,8 +4,23 @@
 </style>
 <div class="uv-install-wrapper">
 	<h3><b>Community Forums</b> Module for DNN</h3>
-	<hr/>
-
+	<div class="dnnClear"><hr/>
+	<h3>Important Note about CSS when upgrading</h3>
+	<p>
+		CSS loading has been improved to deliver robust CSS both within the module, across all themes, and then theme-specific with a custom override.</p>
+		<p>New Community Forums's CSS Load order :
+		<br />
+	~/DesktopModules/ActiveForums/module.css (already existing)
+		<br />
+	~/DesktopModules/ActiveForums/themes/theme.css (already existing / new name / to be used across all themes)
+		<br />
+	~/DesktopModules/ActiveForums/themes/_currenttheme_/theme.css (already existing / new name)
+		<br />
+	~/DesktopModules/ActiveForums/themes/_currenttheme_/custom/theme.css (new)has been updated.  
+	</p>
+	<p>If you are upgrading the Community Forums module and you have an <strong>existing</strong> ~/DesktopModules/ActiveForums/themes/module.css, it will be retained, but will no longer be loaded. You can move any relevant CSS to ~/DesktopModules/ActiveForums/themes/theme.css.
+	</p>
+		</div><hr/>
 	<div class="dnnClear">
 		<h3>07.00.12</h3>
 		<h4>Features, Enhancements, and Bug Fixes</h4>

--- a/Dnn.CommunityForums/class/ForumsConfig.cs
+++ b/Dnn.CommunityForums/class/ForumsConfig.cs
@@ -333,12 +333,16 @@ namespace DotNetNuke.Modules.ActiveForums
 		{
 			try
 			{
-				SettingsInfo MainSettings = SettingsBase.GetModuleSettings(-1);
-				foreach (var fullFilePathName in System.IO.Directory.EnumerateFiles(path: HttpContext.Current.Server.MapPath(Globals.ThemesPath), searchPattern: "module.css", searchOption: System.IO.SearchOption.AllDirectories))
-				{
-					System.IO.File.Copy(fullFilePathName, fullFilePathName.Replace("module.css", "theme.css"), true);
-					System.IO.File.Delete(fullFilePathName);
-				}
+                var di = new System.IO.DirectoryInfo(HttpContext.Current.Server.MapPath(Globals.ThemesPath));
+                System.IO.DirectoryInfo[] themeFolders = di.GetDirectories();
+                foreach (System.IO.DirectoryInfo themeFolder in themeFolders)
+                {
+                    foreach (var fullFilePathName in System.IO.Directory.EnumerateFiles(path:themeFolder.FullName, searchPattern: "module.css", searchOption: System.IO.SearchOption.TopDirectoryOnly))
+                    {
+						System.IO.File.Copy(fullFilePathName, fullFilePathName.Replace("module.css", "theme.css"), true);
+                        System.IO.File.Delete(fullFilePathName);
+                    }
+                }				
 			}
 			catch (Exception ex)
 			{


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR... 
Correct an issue encountered related to #229 during 08.00.00 upgrade testing.

During an 8.0 install, a new themes/theme.css file gets installed.
However, if it's an upgrade, any existing themes/module.css gets renamed to theme.css.
Instead, leave the existing module.css, and document in release notes.

## Changes made
- don't rename themes/module.css to theme.css
- add note to release notes
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/a02efdb0-c137-464e-80bf-1f62f5677f6e)

## How did you test these updates?  

Installed 07.00.12, and upgraded to 08.00.00. 
Verified that themes/module.css and themes/theme.css exist.
## PR Template Checklist

- [ ] Fixes Bug
- [ ] Feature solution
- [X] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #441