### PR TITLE
ENH: rename an existing "_default" theme to "_legacy"

### DIFF
--- a/Dnn.CommunityForums/CustomControls/UserControls/SubmitForm.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/SubmitForm.cs
@@ -346,7 +346,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
         private string ParseForm(string template)
         {
-            template = "<%@ Register TagPrefix=\"am\" Namespace=\"DotNetNuke.Modules.ActiveForums.Controls\" Assembly=\"DotNetNuke.Modules.ActiveForums\" %>" + template;
+            template = Globals.ControlRegisterTag + template;
             template = "<%@ register src=\"~/DesktopModules/ActiveForums/controls/af_posticonlist.ascx\" tagprefix=\"af\" tagname=\"posticons\" %>" + template;
             template = template.Replace("[AF:INPUT:SUBJECT]", "<asp:textbox id=\"txtSubject\" cssclass=\"aftextbox\" runat=\"server\" />");
             template = template.Replace("[AF:REQ:SUBJECT]", "<asp:requiredfieldvalidator id=\"reqSubject\" validationgroup=\"afform\" ControlToValidate=\"txtSubject\" runat=\"server\" />");

--- a/Dnn.CommunityForums/CustomControls/UserControls/UserProfile.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/UserProfile.cs
@@ -126,26 +126,11 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
         protected override void OnLoad(EventArgs e)
 		{
 			base.OnLoad(e);
-
-            string sTemplate = string.Empty;
-
-            SettingsInfo moduleSettings = SettingsBase.GetModuleSettings(ForumModuleId);
-            string templateFilePathFileName = HttpContext.Current.Server.MapPath(moduleSettings.TemplatePath + "_userprofile.ascx");
-            if (!System.IO.File.Exists(templateFilePathFileName))
-            {
-                templateFilePathFileName = HttpContext.Current.Server.MapPath(Globals.TemplatesPath + "_userprofile.ascx");
-                if (!System.IO.File.Exists(templateFilePathFileName))
-                {
-                    templateFilePathFileName = HttpContext.Current.Server.MapPath(Globals.DefaultTemplatePath + "_userprofile.ascx");
-                }
-            }
-            sTemplate = Utilities.GetFileContent(templateFilePathFileName);
-            sTemplate = Utilities.ParseSpacer(sTemplate);
-            sTemplate = sTemplate.Replace("[TRESX:", "[RESX:");
+            string sTemplate = TemplateCache.GetCachedTemplate(ForumModuleId, "_userprofile", 0);
 
             if (ProfileMode == ProfileModes.Edit)
             {
-                sTemplate = "<%@ Register TagPrefix=\"dnn\" Assembly=\"DotNetNuke\" Namespace=\"DotNetNuke.UI.WebControls\"%>" + sTemplate;
+                sTemplate = Globals.DnnControlsRegisterTag + sTemplate;
             }
             Literal lit = new Literal();
             UserController upc = new UserController();
@@ -644,11 +629,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                         string tmp = TemplateUtils.GetTemplateSection(sOut, match.Value, match.Value.Replace("[AM", "[/AM"));
                         if (tmp.Contains("<dnn:"))
                         {
-                            tmp = "<%@ Register TagPrefix=\"dnn\" Assembly=\"DotNetNuke\" Namespace=\"DotNetNuke.UI.WebControls\"%>" + tmp;
-                        }
-                        if (tmp.Contains("<social:"))
-                        {
-                            tmp = Globals.SocialRegisterTag + tmp;
+                            tmp =  Globals.DnnControlsRegisterTag + tmp;
                         }
                         Control ctl = this.ParseControl(tmp);
                         tbc.Controls.Add(ctl);

--- a/Dnn.CommunityForums/class/ForumsConfig.cs
+++ b/Dnn.CommunityForums/class/ForumsConfig.cs
@@ -321,27 +321,42 @@ namespace DotNetNuke.Modules.ActiveForums
 				DotNetNuke.Services.Exceptions.Exceptions.LogException(ex);
 			}
 		}
-		internal void Install_Or_Upgrade_RenameThemeCssFiles()
-		{
-			try
-			{
+        internal void Install_Or_Upgrade_RenameDefaultThemeToLegacy()
+        {
+            try
+			{ 
+				if (System.IO.Directory.Exists(HttpContext.Current.Server.MapPath(Globals.ThemesPath + "_default")))
+				{
+					System.IO.Directory.Move(HttpContext.Current.Server.MapPath(Globals.ThemesPath + "_default"), HttpContext.Current.Server.MapPath(Globals.ThemesPath + "_legacy"));
+                }
+            }
+            catch (Exception ex)
+            {
+                DotNetNuke.Services.Exceptions.Exceptions.LogException(ex);
+            }
+        }
+
+        internal void Install_Or_Upgrade_RenameThemeCssFiles()
+        {
+            try
+            {
                 var di = new System.IO.DirectoryInfo(HttpContext.Current.Server.MapPath(Globals.ThemesPath));
                 System.IO.DirectoryInfo[] themeFolders = di.GetDirectories();
                 foreach (System.IO.DirectoryInfo themeFolder in themeFolders)
                 {
-                    foreach (var fullFilePathName in System.IO.Directory.EnumerateFiles(path:themeFolder.FullName, searchPattern: "module.css", searchOption: System.IO.SearchOption.TopDirectoryOnly))
+                    foreach (var fullFilePathName in System.IO.Directory.EnumerateFiles(path: themeFolder.FullName, searchPattern: "module.css", searchOption: System.IO.SearchOption.TopDirectoryOnly))
                     {
-						System.IO.File.Copy(fullFilePathName, fullFilePathName.Replace("module.css", "theme.css"), true);
+                        System.IO.File.Copy(fullFilePathName, fullFilePathName.Replace("module.css", "theme.css"), true);
                         System.IO.File.Delete(fullFilePathName);
                     }
-                }				
-			}
-			catch (Exception ex)
-			{
-				DotNetNuke.Services.Exceptions.Exceptions.LogException(ex);
-			}
-		}
-		internal void Install_Or_Upgrade_MoveTemplates()
+                }
+            }
+            catch (Exception ex)
+            {
+                DotNetNuke.Services.Exceptions.Exceptions.LogException(ex);
+            }
+        }
+        internal void Install_Or_Upgrade_MoveTemplates()
 		{
 			if (!System.IO.Directory.Exists(HttpContext.Current.Server.MapPath(Globals.TemplatesPath)))
 			{

--- a/Dnn.CommunityForums/class/Globals.cs
+++ b/Dnn.CommunityForums/class/Globals.cs
@@ -146,7 +146,6 @@ namespace DotNetNuke.Modules.ActiveForums
 
         public const string ControlRegisterTag = "<%@ Register TagPrefix=\"am\" Namespace=\"DotNetNuke.Modules.ActiveForums.Controls\" Assembly=\"DotNetNuke.Modules.ActiveForums\" %>";
 		public const string ControlRegisterAFTag = "<%@ Register TagPrefix=\"af\" Namespace=\"DotNetNuke.Modules.ActiveForums.Controls\" Assembly=\"DotNetNuke.Modules.ActiveForums\" %>";
-        public const string SocialRegisterTag = "<%@ Register TagPrefix=\"social\" Namespace=\"Active.Modules.Social.Controls\" Assembly=\"Active.Modules.Social\" %>";
         public const string DnnControlsRegisterTag = "<%@ Register TagPrefix=\"dnn\" Assembly=\"DotNetNuke\" Namespace=\"DotNetNuke.UI.WebControls\"%>";
         public const string BannerRegisterTag = "<%@ Register TagPrefix=\"dnn\" TagName=\"BANNER\" Src=\"~/Admin/Skins/Banner.ascx\" %>";
 

--- a/Dnn.CommunityForums/class/Settings.cs
+++ b/Dnn.CommunityForums/class/Settings.cs
@@ -155,7 +155,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			get
 			{
 			    var result = MainSettings.GetString(SettingKeys.Theme);
-			    return string.IsNullOrWhiteSpace(result) ? "_default" : result; 
+			    return string.IsNullOrWhiteSpace(result) ? "_legacy" : result; 
 			}
         }
         public string ThemeLocation

--- a/Dnn.CommunityForums/class/TemplateCache.cs
+++ b/Dnn.CommunityForums/class/TemplateCache.cs
@@ -23,7 +23,7 @@ using System.Web;
 
 namespace DotNetNuke.Modules.ActiveForums
 {
-    internal class TemplateCache
+    internal static class TemplateCache
     {
         public static string GetCachedTemplate(int ModuleId, string TemplateType, int TemplateId)
         {
@@ -48,7 +48,7 @@ namespace DotNetNuke.Modules.ActiveForums
                         SettingsInfo moduleSettings = SettingsBase.GetModuleSettings(ModuleId);
                         string templateFilePathFileName = HttpContext.Current.Server.MapPath(moduleSettings.TemplatePath + fileName);
                         if (!System.IO.File.Exists(templateFilePathFileName))
-                        {
+                        {                            
                             templateFilePathFileName = HttpContext.Current.Server.MapPath(Globals.TemplatesPath + fileName);
                             if (!System.IO.File.Exists(templateFilePathFileName))
                             {
@@ -80,6 +80,19 @@ namespace DotNetNuke.Modules.ActiveForums
                         sTemplate = Utilities.ParseSpacer(sTemplate);
                     }
                 }
+            }
+            sTemplate = sTemplate.Replace("[TRESX:", "[RESX:");
+            if (sTemplate.ToLowerInvariant().Contains("<dnn:"))
+            {
+                sTemplate = Globals.DnnControlsRegisterTag + sTemplate;
+            }
+            if (sTemplate.ToLowerInvariant().Contains("<am:"))
+            {
+                sTemplate = Globals.ControlRegisterTag + sTemplate;
+            }
+            if (sTemplate.ToLowerInvariant().Contains("<af:"))
+            {
+                sTemplate = Globals.ControlRegisterAFTag + sTemplate;
             }
             if (SettingsBase.GetModuleSettings(ModuleId).CacheTemplates)
             {

--- a/Dnn.CommunityForums/class/Templates.cs
+++ b/Dnn.CommunityForums/class/Templates.cs
@@ -101,12 +101,24 @@ namespace DotNetNuke.Modules.ActiveForums
             // now save to the template file
             try
             {
-                SettingsInfo moduleSettings = SettingsBase.GetModuleSettings(templateInfo.ModuleId); 
-				if (!System.IO.Directory.Exists(HttpContext.Current.Server.MapPath(moduleSettings.TemplatePath)))
+                string templatePathFileName = Globals.TemplatesPath + TemplateInfo.FileName;
+                if (templateInfo.ModuleId > 0)
                 {
-                    System.IO.Directory.CreateDirectory(HttpContext.Current.Server.MapPath(moduleSettings.TemplatePath));
+                    SettingsInfo moduleSettings = SettingsBase.GetModuleSettings(templateInfo.ModuleId);
+                    templatePathFileName = moduleSettings.TemplatePath + TemplateInfo.FileName;
+                    if (!System.IO.Directory.Exists(HttpContext.Current.Server.MapPath(moduleSettings.TemplatePath)))
+                    {
+                        System.IO.Directory.CreateDirectory(HttpContext.Current.Server.MapPath(moduleSettings.TemplatePath));
+                    }
                 }
-                System.IO.File.WriteAllText(HttpContext.Current.Server.MapPath( moduleSettings.TemplatePath + TemplateInfo.FileName), TemplateInfo.Template);
+                else
+                { 
+                    if (!System.IO.Directory.Exists(HttpContext.Current.Server.MapPath(Globals.TemplatesPath)))
+                    {
+                        System.IO.Directory.CreateDirectory(HttpContext.Current.Server.MapPath(Globals.TemplatesPath));
+                    }
+                }
+                System.IO.File.WriteAllText(HttpContext.Current.Server.MapPath(templatePathFileName), TemplateInfo.Template);
             }
             catch (Exception exc)
             {
@@ -157,8 +169,8 @@ namespace DotNetNuke.Modules.ActiveForums
                         templateFilePathFileName = HttpContext.Current.Server.MapPath(Globals.TemplatesPath + ti.FileName);
                         if (!System.IO.File.Exists(templateFilePathFileName))
                         {
-                            templateFilePathFileName = HttpContext.Current.Server.MapPath(Globals.DefaultTemplatePath + ti.FileName);
-                        }
+                        templateFilePathFileName = HttpContext.Current.Server.MapPath(Globals.DefaultTemplatePath + ti.FileName);
+                    }
                     }
                     ti.Template = Utilities.GetFileContent(templateFilePathFileName).Replace("[TRESX:", "[RESX:");
 					return tiWithinLoop;
@@ -242,13 +254,13 @@ namespace DotNetNuke.Modules.ActiveForums
                     }; 
 					SettingsInfo moduleSettings = SettingsBase.GetModuleSettings(ti.ModuleId);
 					string templateFilePathFileName = HttpContext.Current.Server.MapPath(moduleSettings.TemplatePath + ti.FileName);
-					if (!System.IO.File.Exists(templateFilePathFileName))
+                    if (!System.IO.File.Exists(templateFilePathFileName))
                     {
                         templateFilePathFileName = HttpContext.Current.Server.MapPath(Globals.TemplatesPath + ti.FileName);
                         if (!System.IO.File.Exists(templateFilePathFileName))
 						{
-							templateFilePathFileName = HttpContext.Current.Server.MapPath(Globals.DefaultTemplatePath + ti.FileName);
-                        }							
+                        templateFilePathFileName = HttpContext.Current.Server.MapPath(Globals.DefaultTemplatePath + ti.FileName);
+                    }
 					}
                     ti.Template = Utilities.GetFileContent(templateFilePathFileName);
                     if (string.IsNullOrEmpty(ti.Template))

--- a/Dnn.CommunityForums/components/Common/ForumSettingsBase.cs
+++ b/Dnn.CommunityForums/components/Common/ForumSettingsBase.cs
@@ -71,7 +71,7 @@ namespace DotNetNuke.Modules.ActiveForums
 		{
 			get
 			{
-                return Settings.GetString(SettingKeys.Theme, "_default");
+                return Settings.GetString(SettingKeys.Theme, "_legacy");
 			}
 			set
 			{

--- a/Dnn.CommunityForums/components/Topics/TopicsController.cs
+++ b/Dnn.CommunityForums/components/Topics/TopicsController.cs
@@ -586,6 +586,7 @@ namespace DotNetNuke.Modules.ActiveForums
                         var fc = new ForumsConfig();
                         fc.Install_Or_Upgrade_MoveTemplates();
                         fc.Install_Or_Upgrade_RenameThemeCssFiles();
+                        fc.Install_Or_Upgrade_RenameDefaultThemeToLegacy();
                         ForumsConfig.FillMissingTopicUrls(); /* for anyone upgrading from 07.00.12-> 08.00.00 */
                     }
                     catch (Exception ex)

--- a/Dnn.CommunityForums/sql/08.00.00.SqlDataProvider
+++ b/Dnn.CommunityForums/sql/08.00.00.SqlDataProvider
@@ -248,3 +248,16 @@ BEGIN
 END
 GO
 /* issues 254 -- end -- Unable to move forums / forum groups up/down when forums or groups have been deleted */
+
+/* issues 462 -- begin -- change theme called "_default" to "_legacy" */
+
+SET NOCOUNT ON 
+UPDATE ms SET SettingValue = '_legacy' 
+FROM {databaseOwner}{objectQualifier}ModuleSettings ms 
+INNER JOIN {databaseOwner}{objectQualifier}Modules m ON m.ModuleID = ms.ModuleID 
+INNER JOIN {databaseOwner}{objectQualifier}ModuleDefinitions md ON md.ModuleDefID = m.ModuleDefID 
+INNER JOIN {databaseOwner}{objectQualifier}DesktopModules dm on dm.DesktopModuleID = md.DesktopModuleID 
+WHERE dm.ModuleName = 'Active Forums' AND ms.SettingName = 'THEME' AND ms.SettingValue = '_default'
+GO
+
+/* issues 462 -- end -- change theme called "_default" to "_legacy" */


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Rename an existing "_default" theme to "_legacy"

## Changes made
- change upgrade code to rename folder
- sql code to change module setting if found

## How did you test these updates?   
- Tested against copy of dnncommunity.org
  - ensure that default templates are properly loaded during a new install
  - ensure that existing templates are properly upgraded from 07.00.12
  - ensure that template editor in control panel functions properly without HTML/text email templates
  - ensure basic forums functionality (post topic/reply, etc.)
  - ensure that email notifications are properly sent out with HTML templates
  
## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #462