### PR TITLE
FIX: if no templates loaded, default templates should still work

### DIFF
--- a/Dnn.CommunityForums/class/Email.cs
+++ b/Dnn.CommunityForums/class/Email.cs
@@ -55,7 +55,7 @@ namespace DotNetNuke.Modules.ActiveForums
             var mainSettings = SettingsBase.GetModuleSettings(moduleId);
             var sTemplate = string.Empty;
             var tc = new TemplateController();
-            var ti = tc.Template_Get(templateId, portalId, moduleId);
+            var ti = tc.Template_Get(templateId);
             string subject = TemplateUtils.ParseEmailTemplate(ti.Subject, string.Empty, portalId, moduleId, tabId, forumId, topicId, replyId, string.Empty, author.AuthorId, Utilities.GetCultureInfoForUser(portalId, author.AuthorId), Utilities.GetTimeZoneOffsetForUser(portalId, author.AuthorId));
             string body = TemplateUtils.ParseEmailTemplate(ti.Template, string.Empty, portalId, moduleId, tabId, forumId, topicId, replyId, string.Empty, author.AuthorId, Utilities.GetCultureInfoForUser(portalId, author.AuthorId), Utilities.GetTimeZoneOffsetForUser(portalId, author.AuthorId));
             body = body.Replace("[REASON]", comments);

--- a/Dnn.CommunityForums/class/TemplateCache.cs
+++ b/Dnn.CommunityForums/class/TemplateCache.cs
@@ -40,7 +40,7 @@ namespace DotNetNuke.Modules.ActiveForums
             }
             else
             {
-                if (TemplateId == 0)
+                if (TemplateId < 1)
                 {
                     try
                     {
@@ -72,7 +72,6 @@ namespace DotNetNuke.Modules.ActiveForums
                 }
                 else
                 {
-                    var objTemplates = new TemplateController();
                     TemplateInfo templateInfo = new TemplateController().Template_Get(TemplateId);
                     if (templateInfo != null)
                     {

--- a/Dnn.CommunityForums/class/TemplateUtils.cs
+++ b/Dnn.CommunityForums/class/TemplateUtils.cs
@@ -26,11 +26,13 @@ using System.Data;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Web;
 using DotNetNuke.Entities.Portals;
 using Microsoft.ApplicationBlocks.Data;
+using static DotNetNuke.Modules.ActiveForums.Controls.ActiveGrid;
 
 namespace DotNetNuke.Modules.ActiveForums
 {
@@ -65,9 +67,10 @@ namespace DotNetNuke.Modules.ActiveForums
                 DataCache.SettingsCacheStore(moduleID, ti.Subject + "_Subject_" + moduleID, ti.Subject);
             }
         }
-
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
         private static TemplateInfo GetTemplateByName(string templateName, int moduleId, int portalId)
         {
+
             var tc = new TemplateController();
             TemplateInfo ti;
             try
@@ -78,55 +81,61 @@ namespace DotNetNuke.Modules.ActiveForums
             {
                 ti = new TemplateInfo { Template = string.Concat("Error loading ", templateName, " template.") };
             }
-
+            if (ti == null) {
+                ti = new TemplateInfo { Template = string.Concat("Error loading ", templateName, " template.") };
+            }; 
             return ti;
         }
 
         #region Email
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
         public static string ParseEmailTemplate(string template, string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, int timeZoneOffset)
         {
             return ParseEmailTemplate(template, templateName, portalID, moduleID, tabID, forumID, topicId, replyId, string.Empty, null, -1, Utilities.GetCultureInfoForUser(portalID, -1), new TimeSpan(hours: 0, minutes: timeZoneOffset, seconds: 0), false);
         }
-
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
         public static string ParseEmailTemplate(string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, int timeZoneOffset)
         {
             return ParseEmailTemplate(string.Empty, templateName, portalID, moduleID, tabID, forumID, topicId, replyId, string.Empty, null, -1, Utilities.GetCultureInfoForUser(portalID, -1), new TimeSpan(hours: 0, minutes: timeZoneOffset, seconds: 0), false);
         }
-
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
         public static string ParseEmailTemplate(string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, string comments, int timeZoneOffset)
         {
             return ParseEmailTemplate(string.Empty, templateName, portalID, moduleID, tabID, forumID, topicId, replyId, comments, null, -1, Utilities.GetCultureInfoForUser(portalID, -1), new TimeSpan(hours: 0, minutes: timeZoneOffset, seconds: 0), false);
         }
-
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
         public static string ParseEmailTemplate(string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, DotNetNuke.Entities.Users.UserInfo user, int timeZoneOffset)
         {
             return ParseEmailTemplate(string.Empty, templateName, portalID, moduleID, tabID, forumID, topicId, replyId, string.Empty, user, -1, Utilities.GetCultureInfoForUser(portalID, -1), new TimeSpan(hours: 0, minutes: timeZoneOffset, seconds: 0), false);
         }
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
         public static string ParseEmailTemplate(string template, string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, string comments, int userId, int timeZoneOffset)
         {
             var uc = new DotNetNuke.Entities.Users.UserController();
             var usr = uc.GetUser(portalID, userId);
             return ParseEmailTemplate(template, templateName, portalID, moduleID, tabID, forumID, topicId, replyId, comments, usr, userId, Utilities.GetCultureInfoForUser(portalID, userId), new TimeSpan(hours: 0, minutes: timeZoneOffset, seconds: 0), false);
         }
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
         public static string ParseEmailTemplate(string template, string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, string comments, DotNetNuke.Entities.Users.UserInfo user, int userId, int timeZoneOffset)
         {
             return ParseEmailTemplate(template, templateName, portalID, moduleID, tabID, forumID, topicId: topicId, replyId: replyId, comments: comments, user: user, userId: userId, userCultureInfo: Utilities.GetCultureInfoForUser(portalID, userId), timeZoneOffset: new TimeSpan(hours: 0, minutes: timeZoneOffset, seconds: 0), topicSubscriber: false);
         }
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
         public static string ParseEmailTemplate(string template, string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, CultureInfo userCulture, TimeSpan timeZoneOffset)
         {
             return ParseEmailTemplate(template, templateName: templateName, portalID: portalID, moduleID: moduleID, tabID: tabID, forumID: forumID, topicId: topicId, replyId: replyId, comments: string.Empty, userId: 0, userCulture: userCulture, timeZoneOffset: timeZoneOffset, topicSubscriber: false);
         }
-
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
         public static string ParseEmailTemplate(string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, CultureInfo userCulture, TimeSpan timeZoneOffset)
         {
             return ParseEmailTemplate(template: string.Empty, templateName: templateName, portalID: portalID, moduleID: moduleID, tabID: tabID, forumID: forumID, topicId: topicId, replyId: replyId, comments: string.Empty, user: null, userId: -1, userCultureInfo: userCulture, timeZoneOffset: timeZoneOffset, topicSubscriber: false);
         }
-
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
         public static string ParseEmailTemplate(string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, string comments, CultureInfo userCulture, TimeSpan timeZoneOffset)
         {
             return ParseEmailTemplate(template: string.Empty, templateName: templateName, portalID: portalID, moduleID: moduleID, tabID: tabID, forumID: forumID, topicId: topicId, replyId: replyId, comments: comments, user: null, userId: -1, userCultureInfo: userCulture, timeZoneOffset: timeZoneOffset, topicSubscriber: false);
         }
-
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
         public static string ParseEmailTemplate(string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, DotNetNuke.Entities.Users.UserInfo user, CultureInfo userCulture, TimeSpan timeZoneOffset)
         {
             return ParseEmailTemplate(string.Empty, templateName, portalID, moduleID, tabID, forumID: forumID, topicId: topicId, replyId: replyId, comments: string.Empty, user: user, userId: -1, userCultureInfo: userCulture, timeZoneOffset: timeZoneOffset, topicSubscriber: false);
@@ -158,12 +167,8 @@ namespace DotNetNuke.Modules.ActiveForums
                 if (templateName.Contains("_Subject_"))
                 {
                     templateName = templateName.Replace(string.Concat("_Subject_", moduleID), string.Empty);
-                    sOut = GetTemplateByName(templateName, moduleID, portalID).Subject;
                 }
-                else
-                {
-                    sOut = GetTemplateByName(templateName, moduleID, portalID).Template;
-                }
+                sOut = TemplateCache.GetCachedTemplate(moduleID, templateName, -1);
             }
 
             // Load Subject and body from topic or reply
@@ -427,13 +432,11 @@ namespace DotNetNuke.Modules.ActiveForums
             var myTemplate = Convert.ToString(DataCache.SettingsCacheRetrieve(moduleId, cacheKey));
             if (string.IsNullOrEmpty(myTemplate))
             {
-                myTemplate = GetTemplateByName("ProfileInfo", moduleId, portalId).Template;
+                myTemplate = TemplateCache.GetCachedTemplate(moduleId, "ProfileInfo", -1);
                 if (cacheKey != string.Empty)
                     DataCache.SettingsCacheStore(moduleId, cacheKey, myTemplate);
             }
-
             myTemplate = ParseProfileTemplate(myTemplate, up, portalId, moduleId, imagePath, currentUserType, true, userPrefHideAvatar, false, ipAddress, currentUserId, timeZoneOffset);
-
             return myTemplate;
         }
         [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Use ParseProfileTemplate(string profileTemplate, User up, int portalId, int moduleId, string imagePath, CurrentUserTypes currentUserType, bool legacyTemplate, bool userPrefHideAvatar, bool userPrefHideSignature, string ipAddress, int currentUserId, TimeSpan timeZoneOffset)")]

--- a/Dnn.CommunityForums/controls/admin_templates_edit.ascx.cs
+++ b/Dnn.CommunityForums/controls/admin_templates_edit.ascx.cs
@@ -61,7 +61,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
 			TemplateInfo ti = null;
 			TemplateController tc = new TemplateController();
-			ti = tc.Template_Get(TemplateId, PortalId, ModuleId);
+			ti = tc.Template_Get(TemplateId);
 			if (ti != null)
 			{
 				txtTitle.Text = ti.Title;
@@ -97,7 +97,7 @@ namespace DotNetNuke.Modules.ActiveForums
 						if (e.Parameters[1].ToString() != "")
 						{
 							templateId = Convert.ToInt32(e.Parameters[1]);
-							ti = tc.Template_Get(templateId, PortalId, ModuleId);
+							ti = tc.Template_Get(templateId);
 						}
 						else
 						{
@@ -134,7 +134,7 @@ namespace DotNetNuke.Modules.ActiveForums
 						if (e.Parameters[1].ToString() != "")
 						{
 							templateid = Convert.ToInt32(e.Parameters[1]);
-							ti = tc.Template_Get(templateid, PortalId, ModuleId);
+							ti = tc.Template_Get(templateid);
 							if (! (ti.IsSystem == true))
 							{
 								tc.Template_Delete(templateid, PortalId, ModuleId);

--- a/Dnn.CommunityForums/controls/af_modreport.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_modreport.ascx.cs
@@ -127,16 +127,18 @@ namespace DotNetNuke.Modules.ActiveForums
                 string Comments = null;
                 Comments = drpReasons.SelectedItem.Value + "<br>";
                 Comments += Utilities.CleanString(PortalId, txtComments.Text, false, EditorTypes.TEXTBOX, false, false, ModuleId, string.Empty, false);
-                int templateId = 0;
-                TemplateController tc = new TemplateController();
-                TemplateInfo ti = tc.Template_Get("ModAlert", PortalId, ModuleId);
                 string sUrl;
-                if (SocialGroupId > 0) sUrl = NavigateUrl(Convert.ToInt32(Request.QueryString["TabId"]), "", new string[] { ParamKeys.ForumId + "=" + ForumId, ParamKeys.TopicId + "=" + TopicId, ParamKeys.ViewType + "=confirmaction", ParamKeys.ConfirmActionId + "=" + ConfirmActions.AlertSent + "&" + ParamKeys.GroupIdName + "=" + SocialGroupId });
-                else sUrl = NavigateUrl(Convert.ToInt32(Request.QueryString["TabId"]), "", new string[] { ParamKeys.ForumId + "=" + ForumId, ParamKeys.TopicId + "=" + TopicId, ParamKeys.ViewType + "=confirmaction", ParamKeys.ConfirmActionId + "=" + ConfirmActions.AlertSent });
+                if (SocialGroupId > 0)
+                {
+                    sUrl = NavigateUrl(Convert.ToInt32(Request.QueryString["TabId"]), "", new string[] { ParamKeys.ForumId + "=" + ForumId, ParamKeys.TopicId + "=" + TopicId, ParamKeys.ViewType + "=confirmaction", ParamKeys.ConfirmActionId + "=" + ConfirmActions.AlertSent + "&" + ParamKeys.GroupIdName + "=" + SocialGroupId });
+                }
+                else
+                {
+                    sUrl = NavigateUrl(Convert.ToInt32(Request.QueryString["TabId"]), "", new string[] { ParamKeys.ForumId + "=" + ForumId, ParamKeys.TopicId + "=" + TopicId, ParamKeys.ViewType + "=confirmaction", ParamKeys.ConfirmActionId + "=" + ConfirmActions.AlertSent });
+                }
 
                 NotificationType notificationType = NotificationsController.Instance.GetNotificationType("AF-ContentAlert");
-                TopicsController topicController = new TopicsController();
-                DotNetNuke.Modules.ActiveForums.Entities.TopicInfo topic = topicController.Topics_Get(PortalId, ModuleId, TopicId, ForumId, -1, false);
+                DotNetNuke.Modules.ActiveForums.Entities.TopicInfo topic = new TopicsController().Topics_Get(PortalId, ModuleId, TopicId, ForumId, -1, false);
                 string sBody = string.Empty;
                 string authorName = string.Empty;
                 string sSubject = string.Empty;


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
If module doesn't not have any templates defined, default templates should be used.

## Changes made
- Change template logic to load default template if nothing is specified in the database.
- Additional template loading refactoring

## How did you test these updates?  
Tested against copy of @Timo-Breumelhof site as well as a small test site, upgraded from 07.00.12 to 08.00.00.
Before the changes, 'object reference' error:
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/55794cdc-f90f-44b8-bd43-79f2d5446c84)


After changes, topic loads properly:
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/bd6bfe86-de9a-4d46-98ba-d0a03bb1a4d1)


## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #479 