### PR TITLE
ENH: Prevent 'add existing module' / module copying

### DIFF
--- a/Dnn.CommunityForums/DnnCommunityForums.dnn
+++ b/Dnn.CommunityForums/DnnCommunityForums.dnn
@@ -26,6 +26,7 @@
               <supportedFeature type="Searchable" />
               <supportedFeature type="Upgradeable" />
             </supportedFeatures>
+			<shareable>Unsupported</shareable>
             <moduleDefinitions>
               <moduleDefinition>
                 <friendlyName>DNN Community Forums</friendlyName>
@@ -66,7 +67,8 @@
                 </moduleControls>
               </moduleDefinition>
             </moduleDefinitions>
-          </desktopModule>
+          
+	</desktopModule>
           <eventMessage>
             <processorType>DotNetNuke.Entities.Modules.EventMessageProcessor, DotNetNuke</processorType>
             <processorCommand>UpgradeModule</processorCommand>


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Prevent 'add existing module' / module copying

## Changes made
- added 'shareable' is unsupported option to manifest

## How did you test these updates?  
Installed against existing install. Tested 'add existing module':

Prior to change, module can be copied:
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/6ba8af37-4ae4-4740-8b6e-3af6148a3ddc)

After change, module does not show:
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/bce1dabb-6b77-444d-a598-033310768b99)


## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #530 