### PR TITLE
FIX: prevent duplicate emails when subscribed to forum and topic

### DIFF
--- a/Dnn.CommunityForums/sql/08.00.00.SqlDataProvider
+++ b/Dnn.CommunityForums/sql/08.00.00.SqlDataProvider
@@ -679,3 +679,128 @@ GO
 
 /* issue 420 -  new topic views  */
 
+/* begin -  issue #419 - prevent duplicate emails to users subscribed to both a forum and a specific topic */
+
+IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_Subscriptions_Subscribers]') AND type in (N'P', N'PC'))
+DROP PROCEDURE {databaseOwner}[{objectQualifier}activeforums_Subscriptions_Subscribers]
+GO
+
+CREATE PROCEDURE  {databaseOwner}[{objectQualifier}activeforums_Subscriptions_Subscribers](@PortalId int, @ForumId int, @TopicId int, @SubType int)
+AS
+DECLARE @CanSubscribe nvarchar(255)
+SET @CanSubscribe = (
+					SELECT SUBSTRING(p.CanSubscribe,1,CHARINDEX('|',p.CanSubscribe)-1) as CanSubscribe FROM
+					{databaseOwner}{objectQualifier}activeforums_Forums as f INNER JOIN 
+					{databaseOwner}{objectQualifier}activeforums_Permissions as p on p.PermissionsId = f.PermissionsId
+					WHERE f.ForumId = @ForumId
+					)
+DECLARE @subs TABLE (userid int, username nvarchar(255), firstname nvarchar(255), lastname nvarchar(255), email nvarchar(255), displayname nvarchar(255), topicsubscriber bit)
+
+INSERT INTO @subs 
+	(userid, username, firstname, lastname, email, displayname, topicsubscriber)
+	(SELECT  U.UserID, U.Username, U.FirstName, U.LastName, U.Email, U.DisplayName, 1 AS topicsubscriber  
+FROM         {databaseOwner}{objectQualifier}activeforums_Subscriptions AS S INNER JOIN
+			{databaseOwner}{objectQualifier}activeforums_Forums as F on s.ForumId = f.ForumId INNER JOIN
+                     {databaseOwner}{objectQualifier}Users AS U ON S.UserId = U.UserID INNER JOIN
+                      {databaseOwner}{objectQualifier}UserPortals AS P ON U.UserID = P.UserId INNER JOIN
+                      {databaseOwner}{objectQualifier}UserRoles AS ur ON U.UserID = ur.UserID INNER JOIN
+					  {databaseOwner}{objectQualifier}activeforums_Functions_Split(@CanSubscribe,';')  AS r ON ur.RoleId = r.ID 
+WHERE     (P.PortalId = @PortalId AND P.Authorised = 1 AND P.IsDeleted = 0 AND U.IsDeleted = 0 AND s.Mode = @SubType AND u.IsSuperUser = 0) 
+			AND 
+				(
+						(UR.EffectiveDate IS NULL AND UR.ExpiryDate >= GETDATE()) 
+						OR (UR.EffectiveDate IS NULL AND UR.ExpiryDate IS NULL)
+						OR (UR.EffectiveDate <= GETDATE() AND UR.ExpiryDate IS NULL)
+						OR (UR.EffectiveDate <= GETDATE() AND UR.ExpiryDate >= GETDATE())
+				)
+		
+			AND ((S.TopicId = @TopicId))
+			AND (U.UserID NOT IN (SELECT userid FROM @subs))
+)
+
+INSERT INTO @subs 
+	(userid, username, firstname, lastname, email, displayname, topicsubscriber)
+	(SELECT  U.UserID, U.Username, U.FirstName, U.LastName, U.Email, U.DisplayName, 0 AS topicsubscriber  
+FROM         {databaseOwner}{objectQualifier}activeforums_Subscriptions AS S INNER JOIN
+			{databaseOwner}{objectQualifier}activeforums_Forums as F on s.ForumId = f.ForumId INNER JOIN
+                     {databaseOwner}{objectQualifier}Users AS U ON S.UserId = U.UserID INNER JOIN
+                      {databaseOwner}{objectQualifier}UserPortals AS P ON U.UserID = P.UserId INNER JOIN
+                      {databaseOwner}{objectQualifier}UserRoles AS ur ON U.UserID = ur.UserID INNER JOIN
+					  {databaseOwner}{objectQualifier}activeforums_Functions_Split(@CanSubscribe,';')  AS r ON ur.RoleId = r.ID 
+WHERE     (P.PortalId = @PortalId AND P.Authorised = 1 AND P.IsDeleted = 0 AND U.IsDeleted = 0 AND s.Mode = @SubType AND u.IsSuperUser = 0) 
+			AND 
+				(
+						(UR.EffectiveDate IS NULL AND UR.ExpiryDate >= GETDATE()) 
+						OR (UR.EffectiveDate IS NULL AND UR.ExpiryDate IS NULL)
+						OR (UR.EffectiveDate <= GETDATE() AND UR.ExpiryDate IS NULL)
+						OR (UR.EffectiveDate <= GETDATE() AND UR.ExpiryDate >= GETDATE())
+				)
+		
+			AND ((S.ForumId = @ForumId AND S.TopicId = 0))
+			AND (U.UserID NOT IN (SELECT userid FROM @subs))
+)
+
+INSERT INTO @subs 
+	(userid, username, firstname, lastname, email, displayname, topicsubscriber)
+	(SELECT  U.UserID, U.Username, U.FirstName, U.LastName, U.Email, U.DisplayName, 1 AS topicsubscriber  
+FROM         {databaseOwner}{objectQualifier}activeforums_Subscriptions AS S INNER JOIN
+             {databaseOwner}{objectQualifier}Users AS U ON S.UserId = U.UserID INNER JOIN
+             {databaseOwner}{objectQualifier}UserPortals AS P ON U.UserID = P.UserId
+WHERE s.Mode = @SubType AND u.IsSuperUser = 1
+	AND (P.PortalId = @PortalId AND P.Authorised = 1 AND P.IsDeleted = 0 AND U.IsDeleted = 0 AND (S.TopicId = @TopicId))
+			AND (U.UserID NOT IN (SELECT userid FROM @subs))
+	
+)
+
+INSERT INTO @subs 
+	(userid, username, firstname, lastname, email, displayname, topicsubscriber)
+	(SELECT  U.UserID, U.Username, U.FirstName, U.LastName, U.Email, U.DisplayName,0 AS topicsubscriber  
+FROM         {databaseOwner}{objectQualifier}activeforums_Subscriptions AS S INNER JOIN
+             {databaseOwner}{objectQualifier}Users AS U ON S.UserId = U.UserID INNER JOIN
+             {databaseOwner}{objectQualifier}UserPortals AS P ON U.UserID = P.UserId
+WHERE s.Mode = @SubType AND u.IsSuperUser = 1
+	AND (P.PortalId = @PortalId AND P.Authorised = 1 AND P.IsDeleted = 0 AND U.IsDeleted = 0 AND (S.ForumId = @ForumId AND S.TopicId = 0))
+			AND (U.UserID NOT IN (SELECT userid FROM @subs))
+	
+)
+
+DECLARE @AutoSubscribe bit
+DECLARE @AutoSubscribeRoles nvarchar(255)
+DECLARE @TopicsOnly bit
+DECLARE @IsNewTopic bit
+SET @AutoSubscribe = IsNull((SELECT SettingValue FROM {databaseOwner}{objectQualifier}activeforums_Settings as S INNER JOIN {databaseOwner}{objectQualifier}activeforums_Forums as F ON F.ForumSettingsKey = S.GroupKey  WHERE S.SettingName = 'AUTOSUBSCRIBEENABLED' AND F.ForumId  = @ForumId),0)
+SET @AutoSubscribeRoles = IsNull((SELECT SettingValue FROM {databaseOwner}{objectQualifier}activeforums_Settings as S INNER JOIN {databaseOwner}{objectQualifier}activeforums_Forums as F ON F.ForumSettingsKey = S.GroupKey  WHERE S.SettingName = 'AUTOSUBSCRIBEROLES' AND F.ForumId  = @ForumId),'')
+SET @TopicsOnly = IsNull((SELECT SettingValue FROM {databaseOwner}{objectQualifier}activeforums_Settings as S INNER JOIN {databaseOwner}{objectQualifier}activeforums_Forums as F ON F.ForumSettingsKey = S.GroupKey  WHERE S.SettingName = 'AUTOSUBSCRIBENEWTOPICSONLY' AND F.ForumId  = @ForumId),0)
+SET @IsNewTopic = 0
+IF (SELECT ReplyCount FROM {databaseOwner}{objectQualifier}activeforums_Topics WHERE TopicId = @TopicId) > 0
+	SET @IsNewTopic = 1
+
+If (@TopicsOnly = 1 AND @IsNewTopic = 0) OR (@TopicsOnly = 0)
+	BEGIN
+	IF @AutoSubscribe = 1 AND @AutoSubscribeRoles <> ''
+		BEGIN
+		INSERT INTO @subs 
+		(userid, username, firstname, lastname, email, displayname, topicsubscriber)
+		(SELECT  U.UserID, U.Username, U.FirstName, U.LastName, U.Email, U.DisplayName, 0 /*auto subscribers are never topic-specific subscribers */
+		FROM                 {databaseOwner}{objectQualifier}Users AS U INNER JOIN
+						  {databaseOwner}{objectQualifier}UserPortals AS P ON U.UserID = P.UserId INNER JOIN
+						  {databaseOwner}{objectQualifier}UserRoles AS ur ON U.UserID = ur.UserID INNER JOIN
+						  {databaseOwner}{objectQualifier}activeforums_Functions_Split(@AutoSubscribeRoles,';')  AS r ON ur.RoleId = r.ID 
+		WHERE     (P.PortalId = @PortalId AND P.Authorised = 1 AND P.IsDeleted = 0 AND U.IsDeleted = 0) 
+		
+		AND (
+				(
+					(UR.EffectiveDate IS NULL AND UR.ExpiryDate >= GETDATE()) 
+				 OR (UR.EffectiveDate IS NULL AND UR.ExpiryDate IS NULL)
+				 OR (UR.EffectiveDate <= GETDATE() AND UR.ExpiryDate IS NULL)
+				 OR (UR.EffectiveDate <= GETDATE() AND UR.ExpiryDate >= GETDATE())
+				)
+			AND (U.UserID NOT IN (SELECT userid FROM @subs))
+		
+			))
+		END
+	END
+SELECT DISTINCT * FROM @subs
+GO
+
+/* end -  issue #419 - prevent duplicate emails to users subscribed to both a forum and a specific topic */


### PR DESCRIPTION

<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
If you are subscribed to a forum and a particular topic, you receive two notifications when someone replies.

## Changes made
- update activeforums_Subscriptions_Subscribers stored procedure to only send once if subscribed to forum and topic

## How did you test these updates?  
before and after 

![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/519471e0-2bc4-4212-888a-50bd3b4039ab)


## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #419