### PR TITLE
FIX: move subscriptions when moving topic

### DIFF
--- a/Dnn.CommunityForums/sql/08.00.00.SqlDataProvider
+++ b/Dnn.CommunityForums/sql/08.00.00.SqlDataProvider
@@ -679,3 +679,80 @@ GO
 
 /* issue 420 -  new topic views  */
 
+
+
+/* begin - issues 537 - move topic should move subscription */
+
+IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_Subscriptions_IsSubscribed]') AND type in (N'P', N'PC'))
+DROP PROCEDURE {databaseOwner}[{objectQualifier}activeforums_Subscriptions_IsSubscribed]
+GO
+
+CREATE PROCEDURE {databaseOwner}{objectQualifier}activeforums_Subscriptions_IsSubscribed
+@PortalId int,
+@ModuleId int,
+@ForumId int,
+@TopicId int,
+@Mode int,
+@UserId int
+AS
+DECLARE @SubStatus int 
+SET @SubStatus = 0
+IF @TopicId > 0 
+	BEGIN
+	IF EXISTS(SELECT Id FROM {databaseOwner}{objectQualifier}activeforums_Subscriptions WHERE TopicId = @TopicId AND UserId = @UserId)
+		SET @SubStatus = 1
+	END
+ELSE
+	BEGIN
+	IF EXISTS(SELECT Id FROM {databaseOwner}{objectQualifier}activeforums_Subscriptions WHERE ForumId = @ForumId AND TopicId = 0 AND UserId = @UserId)
+		SET @SubStatus = 1
+	END
+SELECT @SubStatus
+GO
+
+IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_Topics_Move]') AND type in (N'P', N'PC'))
+DROP PROCEDURE {databaseOwner}[{objectQualifier}activeforums_Topics_Move]
+GO
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}activeforums_Topics_Move]
+@PortalId int,
+@ModuleId int,
+@ForumId int,
+@TopicId int
+AS
+DECLARE @OldForumId int
+SELECT @OldForumId = ForumId FROM {databaseOwner}{objectQualifier}activeforums_ForumTopics WHERE TopicId = @TopicId
+If @OldForumId <> @ForumId 
+	BEGIN
+		UPDATE {databaseOwner}{objectQualifier}activeforums_ForumTopics SET ForumId = @ForumId WHERE TopicId = @TopicId AND ForumId = @OldForumId
+		--UPDATE Counts
+		DECLARE @LastPostId int
+		-- New Forum
+		DECLARE @LastReplyId int
+		DECLARE @LastTopicId int
+		SET @LastReplyId = (SELECT MAX(r.ReplyId) FROM {databaseOwner}{objectQualifier}activeforums_Replies as r inner join {databaseOwner}{objectQualifier}activeforums_topics as t on r.topicid = t.topicid inner join {databaseOwner}{objectQualifier}activeforums_ForumTopics as ft on t.topicid = ft.topicid  WHERE r.IsApproved = 1 AND r.IsDeleted = 0 AND ft.forumid = @ForumId)
+		SET @LastTopicId = (SELECT MAX(t.TopicId) FROM {databaseOwner}{objectQualifier}activeforums_Topics as t inner join {databaseOwner}{objectQualifier}activeforums_ForumTopics as ft on t.topicid = ft.topicid  WHERE t.IsApproved = 1 AND t.IsDeleted = 0 AND ft.forumid = @ForumId)
+		UPDATE {databaseOwner}{objectQualifier}activeforums_Forums SET LastReplyId = IsNull(@LastReplyId,0), LastTopicId = ISNULL(@LastTopicId,0) WHERE ForumId = @ForumId
+
+		UPDATE {databaseOwner}{objectQualifier}activeforums_Forums SET LastPostId = ISNULL((CASE WHEN IsNull(@LastReplyId,0) > @LastTopicId THEN @LastReplyId ELSE @LastTopicId END),0), 
+			TotalTopics = ISNULL((SELECT Count(TopicId) FROM {databaseOwner}{objectQualifier}vw_activeforums_TopicsView WHERE ForumId = @ForumId),0),
+			TotalReplies = ISNULL((SELECT Count(ReplyId) FROM {databaseOwner}{objectQualifier}vw_activeforums_ForumReplies WHERE ForumId = @ForumId),0)
+			WHERE ForumId = @ForumId
+		-- Old Forum
+		SET @LastReplyId = (SELECT MAX(r.ReplyId) FROM {databaseOwner}{objectQualifier}activeforums_Replies as r inner join {databaseOwner}{objectQualifier}activeforums_topics as t on r.topicid = t.topicid inner join {databaseOwner}{objectQualifier}activeforums_ForumTopics as ft on t.topicid = ft.topicid  WHERE r.IsApproved = 1 AND r.IsDeleted = 0 AND ft.forumid = @OldForumId )
+		SET @LastTopicId = (SELECT MAX(t.TopicId) FROM {databaseOwner}{objectQualifier}activeforums_Topics as t inner join {databaseOwner}{objectQualifier}activeforums_ForumTopics as ft on t.topicid = ft.topicid  WHERE t.IsApproved = 1 AND t.IsDeleted = 0 AND ft.forumid = @OldForumId )
+		UPDATE {databaseOwner}{objectQualifier}activeforums_Forums SET LastReplyId = IsNull(@LastReplyId,0), LastTopicId = ISNULL(@LastTopicId,0) WHERE ForumId = @OldForumId
+
+		UPDATE {databaseOwner}{objectQualifier}activeforums_Forums SET LastPostId = ISNULL((CASE WHEN IsNull(@LastReplyId,0) > @LastTopicId THEN @LastReplyId ELSE @LastTopicId END),0), 
+			TotalTopics = IsNULL((SELECT Count(TopicId) FROM {databaseOwner}{objectQualifier}vw_activeforums_TopicsView WHERE ForumId = @OldForumId),0),
+			TotalReplies = IsNULL((SELECT Count(ReplyId) FROM {databaseOwner}{objectQualifier}vw_activeforums_ForumReplies WHERE ForumId = @OldForumId),0)
+			WHERE ForumId = @OldForumId
+		DELETE FROM {databaseOwner}{objectQualifier}activeforums_Forums_Tracking WHERE ForumId = @OldForumId AND MaxTopicRead = @TopicId
+		UPDATE {databaseOwner}{objectQualifier}activeforums_Topics_Tracking SET ForumId = @ForumId WHERE TopicId = @TopicId AND ForumId = @OldForumId
+		UPDATE {databaseOwner}{objectQualifier}activeforums_Subscriptions SET ForumId = @ForumId WHERE TopicId = @TopicId AND ForumId = @OldForumId
+		exec {databaseOwner}{objectQualifier}activeforums_Forums_LastUpdates @ForumId
+		exec {databaseOwner}{objectQualifier}activeforums_Forums_LastUpdates @OldForumId
+	END
+GO
+
+
+/* end - issues 537 - move topic should move subscription */


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Topic subscriptions should be moved with topic.

## Changes made
- change stored procedure `activeforums_Topics_Move` to move subscriptions when moving topic
- change stored procedure `activeforums_Subscriptions_IsSubscribed` to look at subscription based on topic without regard to forum (for backward compatibility)

## How did you test these updates?  
1. subscrbed to topic
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/a6fb3764-cb4c-420a-bd34-a0f960b777f8)

2. moved topic
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/f8f81857-a30c-477a-a643-5b8bdc11eea7)

3. subscription stayed
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/3c674482-b4d9-4e5b-af34-0d955e683122)

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #537