### PR TITLE
FIX: restore removed code from #527

### DIFF
--- a/Dnn.CommunityForums/class/Templates.cs
+++ b/Dnn.CommunityForums/class/Templates.cs
@@ -212,6 +212,8 @@ namespace DotNetNuke.Modules.ActiveForums
             {
                 using (IDataReader dr = TemplateType == Templates.TemplateTypes.All ? DataProvider.Instance().Templates_List(PortalId, ModuleId, -1) : DataProvider.Instance().Templates_List(PortalId, ModuleId, (int)TemplateType))
                 {
+                    dr.Read();
+                    dr.NextResult();
                     while (dr.Read())
                     {
                         TemplateInfo ti = FillTemplateInfo(dr);


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
PR #527 updated template logic, but removed a couple lines that should not have been removed.
Specifically, the loading of the templates calls a stored procedure which returns multiple resultsets, and the "nextresult" method was removed. This PR restores the missing lines.

![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/3e6c2cce-63cc-462f-8c34-eb1c30d78dd5)


## Changes made
- restore missing lines.

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #539 