### PR TITLE
FIX: Build issues with unit test project after module was renamed

### DIFF
--- a/Dnn.CommunityForums/Properties/AssemblyInfo.cs
+++ b/Dnn.CommunityForums/Properties/AssemblyInfo.cs
@@ -81,5 +81,4 @@ using System.Runtime.CompilerServices;
 [assembly: ComVisibleAttribute(false)]
  
 
-[assembly: InternalsVisibleTo("DnnCommunityForumsTests")] 
-[assembly: InternalsVisibleTo("DotNetNuke.Modules.ActiveForums.Explorables")]
+[assembly: InternalsVisibleTo("DotNetNuke.Modules.ActiveForumsTests")] 

--- a/Dnn.CommunityForumsTests/DnnCommunityForumsTests.csproj
+++ b/Dnn.CommunityForumsTests/DnnCommunityForumsTests.csproj
@@ -14,8 +14,8 @@
     <ProjectGuid>{B268075A-B369-4B84-8AB9-D338AD41C6D6}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ActiveForumsTests</RootNamespace>
-    <AssemblyName>ActiveForumsTests</AssemblyName>
+    <RootNamespace>DotNetNuke.Modules.ActiveForumsTests</RootNamespace>
+    <AssemblyName>DotNetNuke.Modules.ActiveForumsTests</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/Dnn.CommunityForumsTests/Properties/AssemblyInfo.cs
+++ b/Dnn.CommunityForumsTests/Properties/AssemblyInfo.cs
@@ -18,11 +18,6 @@ using System.Security;
 // System
 [assembly: CLSCompliant(false)]
 
-// System.Runtime.CompilerServices
-[assembly: InternalsVisibleTo("Microsoft.Pex, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
-
-
-
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
After module renamed, unit test project stopped working.

## Changes made
- update InternalsVisibleTo attribute to correct name so that unit tests can see `internal` methods
- remove attribute related to Pex; not using since it requires higher VS edition

 
## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #542 