### PR TITLE
TASK: remove images/ambuttonback.gif 

### DIFF
--- a/Dnn.CommunityForums/08.00.00.txt
+++ b/Dnn.CommunityForums/08.00.00.txt
@@ -3,6 +3,7 @@ DesktopModules/ActiveForums/WhatsNewOptions.ascx
 DesktopModules/ActiveForums/ActiveForumViewer.ascx
 DesktopModules/ActiveForums/ActiveForumViewerSettings.ascx
 DesktopModules/ActiveForumsViewer/ActiveForumsViewerResources.zip.manifest
+DesktopModules/ActiveForums/images/ambuttonback.gif
 DesktopModules/ActiveForums/images/afbuttonback.gif
 DesktopModules/ActiveForums/images/af-logo.png
 DesktopModules/ActiveForums/images/af_logo.gif


### PR DESCRIPTION
TASK: add DesktopModules/ActiveForums/images/ambuttonback.gif to 08.0……0.00.txt cleanup file

<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
images/ambuttonback.gif removed in 08.00.00, and needs to be removed during upgrade since it doesn't get uninstalled.

## Changes made
- add DesktopModules/ActiveForums/images/ambuttonback.gif to 08.00.00.txt cleanup file 

## How did you test these updates?  
On local install, install 07.00.12, upgrade to 08.00.00, uninstall 08.00.00 and verify file is removed.

## PR Template Checklist

- [ ] Fixes Bug
- [ ] Feature solution
- [X] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #562