### PR TITLE
FIX: copy and then delete (not rename) themes/_default to themes/_legacy

### DIFF
--- a/Dnn.CommunityForums/class/ForumsConfig.cs
+++ b/Dnn.CommunityForums/class/ForumsConfig.cs
@@ -321,14 +321,12 @@ namespace DotNetNuke.Modules.ActiveForums
 				DotNetNuke.Services.Exceptions.Exceptions.LogException(ex);
 			}
 		}
-        internal void Install_Or_Upgrade_RenameDefaultThemeToLegacy()
+        internal void Install_Or_Upgrade_RelocateDefaultThemeToLegacy()
         {
             try
-			{ 
-				if (System.IO.Directory.Exists(HttpContext.Current.Server.MapPath(Globals.ThemesPath + "_default")))
-				{
-					System.IO.Directory.Move(HttpContext.Current.Server.MapPath(Globals.ThemesPath + "_default"), HttpContext.Current.Server.MapPath(Globals.ThemesPath + "_legacy"));
-                }
+			{
+				DotNetNuke.Modules.ActiveForums.Utilities.CopyFolder(new System.IO.DirectoryInfo(HttpContext.Current.Server.MapPath(Globals.ThemesPath + "_default")), new System.IO.DirectoryInfo(HttpContext.Current.Server.MapPath(Globals.ThemesPath + "_legacy")));
+				DotNetNuke.Modules.ActiveForums.Utilities.DeleteFolder(new System.IO.DirectoryInfo(HttpContext.Current.Server.MapPath(Globals.ThemesPath + "_default")));
             }
             catch (Exception ex)
             {

--- a/Dnn.CommunityForums/class/Utilities.cs
+++ b/Dnn.CommunityForums/class/Utilities.cs
@@ -1701,5 +1701,50 @@ namespace DotNetNuke.Modules.ActiveForums
             }
             return moduleId;
         }
+        internal static void CopyFolder(DirectoryInfo source, DirectoryInfo target)
+        {
+            try
+            {
+                if (!target.Exists)
+                {
+                    target.Create();
+                }
+                foreach (var file in source.GetFiles())
+                {
+                    file.CopyTo(System.IO.Path.Combine(target.FullName, file.Name));
+                }
+                foreach (var subDir in source.GetDirectories()) 
+                { 
+                    CopyFolder(subDir, new DirectoryInfo( System.IO.Path.Combine(target.FullName, subDir.Name)));
+                }
+            }
+            catch (Exception ex)
+            {
+                Exceptions.LogException(ex);
+            }
+        }
+        internal static void DeleteFolder(DirectoryInfo dir)
+        {
+            try
+            {
+                if (dir.Exists)
+                {  
+                    foreach (var file in dir.GetFiles())
+                    {
+                            file.Delete();
+                    }
+                    foreach (var subDir in dir.GetDirectories())
+                    {
+                        DeleteFolder(subDir);
+                    }
+                    dir.Delete();
+                }
+              
+            }
+            catch (Exception ex)
+            {
+                Exceptions.LogException(ex);
+            }
+        }
     }
 }

--- a/Dnn.CommunityForums/components/Topics/TopicsController.cs
+++ b/Dnn.CommunityForums/components/Topics/TopicsController.cs
@@ -586,7 +586,7 @@ namespace DotNetNuke.Modules.ActiveForums
                         var fc = new ForumsConfig();
                         fc.Install_Or_Upgrade_MoveTemplates();
                         fc.Install_Or_Upgrade_RenameThemeCssFiles();
-                        fc.Install_Or_Upgrade_RenameDefaultThemeToLegacy();
+                        fc.Install_Or_Upgrade_RelocateDefaultThemeToLegacy();
                         ForumsConfig.FillMissingTopicUrls(); /* for anyone upgrading from 07.00.12-> 08.00.00 */
                     }
                     catch (Exception ex)


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
During an upgrade from pre-8.0 releases, the themes/_default folder is renamed to themes/_legacy. However, there is now updated themes content being installed from the _legacy folder, which causes an exception during the upgrade process. Changes the upgrade logic to move files rather than rename the folder.

## Changes made
- Change logic from folder rename to copy folder contents from `themes/_default` to `themes/_legacy` and then delete `themes/_default` folder.

## How did you test these updates?  
Tested on local 07.00.12 install, upgraded to 08.00.00; verified `themes/_default` folder was removed, files copied from `themes/_default` to `themes/_legacy` and no errors in admin log.

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #554