### PR TITLE
Delivered default theme now "community-default" rather than "community"

### DIFF
--- a/Dnn.CommunityForums/config/defaultsetup.config
+++ b/Dnn.CommunityForums/config/defaultsetup.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configs>
   <mainsettings>
-    <setting name="THEME" value="community" />
+    <setting name="THEME" value="community-default" />
     <setting name="FORUMTEMPLATEID" value="0" />
     <setting name="PAGESIZE" value="20" /> 
     <setting name="DATEFORMATSTRING" value="dd MMM yyyy" />
@@ -41,13 +41,13 @@
 
   </mainsettings>
 	<templates>
-		<template templateid="" templatetitle="ProfileInfo" templatetype="11" templatesubject="ProfileInfo" templatefile="~/DesktopModules/ActiveForums/themes/community/templates/ProfileInfo.ascx" />
-		<template templateid="" templatetitle="ForumView" templatetype="2" templatesubject="ForumView" templatefile="~/DesktopModules/ActiveForums/themes/community/templates/ForumView.ascx" />
-		<template templateid="" templatetitle="TopicsView" templatetype="4" templatesubject="TopicsView" templatefile="~/DesktopModules/ActiveForums/themes/community/templates/TopicsView.ascx" />
-		<template templateid="" templatetitle="TopicView" templatetype="3" templatesubject="TopicView" templatefile="~/DesktopModules/ActiveForums/themes/community/templates/TopicView.ascx" />
-		<template templateid="" templatetitle="TopicEditor" templatetype="5" templatesubject="TopicEditor" templatefile="~/DesktopModules/ActiveForums/themes/community/templates/TopicEditor.ascx" />
-		<template templateid="" templatetitle="ReplyEditor" templatetype="6" templatesubject="ReplyEditor" templatefile="~/DesktopModules/ActiveForums/themes/community/templates/ReplyEditor.ascx" />
-		<template templateid="" templatetitle="QuickReply" templatetype="7" templatesubject="QuickReply" templatefile="~/DesktopModules/ActiveForums/themes/community/templates/QuickReply.ascx" />
+		<template templateid="" templatetitle="ProfileInfo" templatetype="11" templatesubject="ProfileInfo" templatefile="~/DesktopModules/ActiveForums/themes/community-default/templates/ProfileInfo.ascx" />
+		<template templateid="" templatetitle="ForumView" templatetype="2" templatesubject="ForumView" templatefile="~/DesktopModules/ActiveForums/themes/community-default/templates/ForumView.ascx" />
+		<template templateid="" templatetitle="TopicsView" templatetype="4" templatesubject="TopicsView" templatefile="~/DesktopModules/ActiveForums/themes/community-default/templates/TopicsView.ascx" />
+		<template templateid="" templatetitle="TopicView" templatetype="3" templatesubject="TopicView" templatefile="~/DesktopModules/ActiveForums/themes/community-default/templates/TopicView.ascx" />
+		<template templateid="" templatetitle="TopicEditor" templatetype="5" templatesubject="TopicEditor" templatefile="~/DesktopModules/ActiveForums/themes/community-default/templates/TopicEditor.ascx" />
+		<template templateid="" templatetitle="ReplyEditor" templatetype="6" templatesubject="ReplyEditor" templatefile="~/DesktopModules/ActiveForums/themes/community-default/templates/ReplyEditor.ascx" />
+		<template templateid="" templatetitle="QuickReply" templatetype="7" templatesubject="QuickReply" templatefile="~/DesktopModules/ActiveForums/themes/community-default/templates/QuickReply.ascx" />
 		<template templateid="" templatetitle="SubscribedEmail" templatetype="8" templatesubject="[DISPLAYNAME] [POSTEDORREPLIEDTO] [SUBSCRIBEDFORUMORTOPICSUBJECTFORUMNAME] on [PORTALNAME]" templatefile="~/DesktopModules/ActiveForums/config/templates/SubscribedEmail.ascx" />
 		<template templateid="" templatetitle="PostPending" templatetype="10" templatesubject="[PORTALNAME] Forums - Pending Approval: [SUBJECT]" templatefile="~/DesktopModules/ActiveForums/config/templates/ModEmail.ascx" />
 		<template templateid="" templatetitle="AdminWatchEmail" templatetype="10" templatesubject="[PORTALNAME] Forums - User Activity: [SUBJECT]" templatefile="~/DesktopModules/ActiveForums/config/templates/AdminWatchEmail.ascx" />


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Delivered default theme now "community-default" rather than "community"

## Changes made
- update theme name in initial install
 
## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #