### PR TITLE
ENH: lmprove user experience when upgrading and then setting quick reply template 

### DIFF
--- a/Dnn.CommunityForums/config/templates/QuickReply.ascx
+++ b/Dnn.CommunityForums/config/templates/QuickReply.ascx
@@ -18,11 +18,11 @@
 						<td valign="top" class="NormalBold">[RESX:Body]:</td>
 						<td width="100%"><div id="btnToolBar" runat="server">
 							<input type="button" class="afButton" accesskey="b" name="afBold" value="[RESX:Bold]" style="font-weight:bold;" onclick="insertCode('[b] [/b]');" onmouseover="window.status='[RESX:BoldDesc]';  return true;" onmouseout="window.status=''; return true;" />
-							<input type="button" class="afButton" accesskey="i" name="afBold" value="[RESX:Italics]"  style="font-weight:bold;" onclick="insertCode('[i] [/i]');" onmouseover="window.status='[RESX:ItalicsDesc]';  return true;" onmouseout="window.status=''; return true;" />
-							<input type="button" class="afButton" accesskey="u" name="afBold" value="[RESX:Underline]" style="font-weight:bold;" onclick="insertCode('[u] [/u]');" onmouseover="window.status='[RESX:UnderlineDesc]';  return true;" onmouseout="window.status=''; return true;" />
-							<input type="button" class="afButton" accesskey="q" name="afBold" value="[RESX:Quote]" style="font-weight:bold;" onclick="insertQuote();" onmouseover="window.status='[RESX:QuoteDesc]';  return true;" onmouseout="window.status=''; return true;" />
-							<input type="button" class="afButton" accesskey="m" name="afBold" value="[RESX:Image]" style="font-weight:bold;" onclick="insertCode('[img] [/img]');" onmouseover="window.status='[RESX:ImageDesc]';  return true;" onmouseout="window.status=''; return true;" />
-							<input type="button" class="afButton" accesskey="c" name="afBold" value="[RESX:Code]" style="font-weight:bold;" onclick="insertCode('[code] [/code]');" onmouseover="window.status='[RESX:CodeDesc]';  return true;" title='[RESX:CodeDesc]' onmouseout="window.status=''; return true;" />
+							<input type="button" class="afButton" accesskey="i" name="afItalics" value="[RESX:Italics]"  style="font-weight:bold;" onclick="insertCode('[i] [/i]');" onmouseover="window.status='[RESX:ItalicsDesc]';  return true;" onmouseout="window.status=''; return true;" />
+							<input type="button" class="afButton" accesskey="u" name="afUnderline" value="[RESX:Underline]" style="font-weight:bold;" onclick="insertCode('[u] [/u]');" onmouseover="window.status='[RESX:UnderlineDesc]';  return true;" onmouseout="window.status=''; return true;" />
+							<input type="button" class="afButton" accesskey="q" name="afQuote" value="[RESX:Quote]" style="font-weight:bold;" onclick="insertQuote();" onmouseover="window.status='[RESX:QuoteDesc]';  return true;" onmouseout="window.status=''; return true;" />
+							<input type="button" class="afButton" accesskey="m" name="afImage" value="[RESX:Image]" style="font-weight:bold;" onclick="insertCode('[img] [/img]');" onmouseover="window.status='[RESX:ImageDesc]';  return true;" onmouseout="window.status=''; return true;" />
+							<input type="button" class="afButton" accesskey="c" name="afCode" value="[RESX:Code]" style="font-weight:bold;" onclick="insertCode('[code] [/code]');" onmouseover="window.status='[RESX:CodeDesc]';  return true;" title='[RESX:CodeDesc]' onmouseout="window.status=''; return true;" />
 							</div>
 							<textarea id="txtBody" name="txtBody" class="aftextbox" style="height:120px" rows="5" cols="250"></textarea></td>
 						<td valign="top">

--- a/Dnn.CommunityForums/sql/08.00.00.SqlDataProvider
+++ b/Dnn.CommunityForums/sql/08.00.00.SqlDataProvider
@@ -956,3 +956,102 @@ GO
 
 
 /* end - issues 537 - move topic should move subscription */
+
+
+/* begin -- issue 617 - create quick reply template record during upgrade */
+
+  
+  	INSERT INTO {databaseOwner}[{objectQualifier}activeforums_Templates]  
+           ([PortalId]
+           ,[ModuleId]
+           ,[TemplateType]
+           ,[IsSystem]
+           ,[Title]
+           ,[Subject]
+           ,[Template]
+           ,[FileName]
+           ,[DateCreated]
+           ,[DateUpdated])
+
+
+	SELECT PortalId, ModuleId, 7, 0, 'QuickReply', 'QuickReply', '<table class="afgrid">
+	<tr>
+		<td class="afgrouprow"><div class="afcontrolheader">[RESX:QuickReply]</div></td>
+		<td class="afgrouprow" align="right" style="text-align:right;padding-right:10px;">[AF:CONTROLS:GROUPTOGGLE]</td>
+	</tr>
+	<tr>
+		<td colspan="2" class="afborder">
+			<div id="groupQR"><asp:PlaceHolder ID="plhMessage" runat="server" />
+				<table width="100%" cellspacing="0" cellpadding="4">	
+					<tr>
+						<td></td>
+						<td class="NormalBold">[RESX:Subject]:</td>
+						<td><input type="text" id="txtSubject" class="aftextbox" readonly="readonly" value="[SUBJECT]" /></td>
+						<td></td>
+					</tr>
+					<tr>
+						<td valign="top"><asp:Label ID="reqBody" runat="server" Visible="false" /></td>
+						<td valign="top" class="NormalBold">[RESX:Body]:</td>
+						<td width="100%"><div id="btnToolBar" runat="server">
+							<input type="button" class="afButton" accesskey="b" name="afBold" value="[RESX:Bold]" style="font-weight:bold;" onclick="insertCode(''[b] [/b]'');" onmouseover="window.status=''[RESX:BoldDesc]'';  return true;" onmouseout="window.status=''''; return true;" />
+							<input type="button" class="afButton" accesskey="i" name="afItalics" value="[RESX:Italics]"  style="font-weight:bold;" onclick="insertCode(''[i] [/i]'');" onmouseover="window.status=''[RESX:ItalicsDesc]'';  return true;" onmouseout="window.status=''''; return true;" />
+							<input type="button" class="afButton" accesskey="u" name="afUnderline" value="[RESX:Underline]" style="font-weight:bold;" onclick="insertCode(''[u] [/u]'');" onmouseover="window.status=''[RESX:UnderlineDesc]'';  return true;" onmouseout="window.status=''''; return true;" />
+							<input type="button" class="afButton" accesskey="q" name="afQuote" value="[RESX:Quote]" style="font-weight:bold;" onclick="insertQuote();" onmouseover="window.status=''[RESX:QuoteDesc]'';  return true;" onmouseout="window.status=''''; return true;" />
+							<input type="button" class="afButton" accesskey="m" name="afImage" value="[RESX:Image]" style="font-weight:bold;" onclick="insertCode(''[img] [/img]'');" onmouseover="window.status=''[RESX:ImageDesc]'';  return true;" onmouseout="window.status=''''; return true;" />
+							<input type="button" class="afButton" accesskey="c" name="afCode" value="[RESX:Code]" style="font-weight:bold;" onclick="insertCode(''[code] [/code]'');" onmouseover="window.status=''[RESX:CodeDesc]'';  return true;" title=''[RESX:CodeDesc]'' onmouseout="window.status=''''; return true;" />
+							</div>
+							<textarea id="txtBody" name="txtBody" class="aftextbox" style="height:120px" rows="5" cols="250"></textarea></td>
+						<td valign="top">
+						</td>
+					</tr>
+				</table>
+				<table width="100%" cellspacing="0" cellpadding="4">	
+				[AF:UI:ANON]
+				<tr>
+					<td style="text-align:left;">[RESX:Username]:[AF:REQ:USERNAME]</td>
+					<td></td>
+				</tr>
+				<tr>
+					<td style="text-align:left;"><div style="width:150px;">[AF:INPUT:USERNAME]</div></td>
+					<td></td>
+				</tr>
+				<tr>
+					<td style="text-align:left;">[RESX:SecurityCode]:[AF:REQ:SECURITYCODE]</td>
+					<td></td>
+				</tr>
+				<tr>
+					<td style="text-align:left;"><div style="width:150px;">[AF:INPUT:CAPTCHA]</div></td>
+					<td></td>
+				</tr>
+				[/AF:UI:ANON]
+				</table>
+				<table width="100%" cellspacing="0" cellpadding="4">	
+					<tr>
+						<td align="right" colspan="4"><div id="divSubscribe" runat="server"></td>
+					</tr>
+				</table>
+				<table width="100%" cellspacing="0" cellpadding="4">	
+					<tr>
+						<td align="center" colspan="3">
+							<div class="amtbwrapper" style="text-align:center;">
+								<div style="margin:0px auto;min-width:50px;max-width:60px;">
+									[AF:BUTTON:SUBMIT]
+								</div>   
+							</div>
+						</td>
+					</tr>
+				</table>
+			</div>
+		</td>
+	</tr>
+</table>', 'QuickReply.ascx', GETUTCDATE(),GETUTCDATE() FROM 
+
+( 
+SELECT DISTINCT PortalId, ModuleId FROM {databaseOwner}[{objectQualifier}activeforums_Templates] 
+EXCEPT 
+SELECT DISTINCT PortalId, ModuleId FROM {databaseOwner}[{objectQualifier}activeforums_Templates] WHERE TemplateType = 7
+) X 
+	
+GO
+	
+/* end -- issue 617 - create quick reply template record during upgrade */


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Forums 08.00.000 adds template support for "quick reply" (PR # 436). When you upgrade from a previous version, existing templates are updated, but a quick reply template (and ability to select one) is not created. 

## Changes made
- Create quick reply template record(s) for existing Forums module instance(s) so they are properly upgraded
- Fix names on input tags in quick reply template html (unrelated but noticed they were incorrect)

## How did you test these updates?  
local install. Install and configure 07.00.12, then upgrade to 08.00.00.

Template file created during upgrade and available for selection:
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/bfc41a4c-e085-40a7-91bb-ce7003823d6b)
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/98281c93-31d2-4bff-a5a2-5282fe7146b9)
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/fc6b9771-c538-4dd8-9e91-0468000b0feb)

## PR Template Checklist

- [X] Fixes Bug
- [X] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #617 