### PR TITLE
ENH: Use non-circle version of chevron for collapsible icon

### DIFF
--- a/Dnn.CommunityForums/class/Injector.cs
+++ b/Dnn.CommunityForums/class/Injector.cs
@@ -30,11 +30,11 @@ namespace DotNetNuke.Modules.ActiveForums
     {
         internal static string InjectCollapsibleOpened(string target, string title)
         {
-            return $"<span class=\"dcf-collapsible dcf-collapsible-opened\" id=\"dcf-collapsible-{target}\" onclick=\"dcf_collapsible_toggle('{target}');\"><i class=\"fa fa-chevron-circle-down\" title=\"{title}\"></i></span>";
+            return $"<span class=\"dcf-collapsible dcf-collapsible-opened\" id=\"dcf-collapsible-{target}\" onclick=\"dcf_collapsible_toggle('{target}');\"><i class=\"fa fa-chevron-down\" title=\"{title}\"></i></span>";
         }
         internal static string InjectCollapsibleClosed(string target, string title)
         {
-            return $"<span class=\"dcf-collapsible dcf-collapsible-closed\" id=\"dcf-collapsible-{target}\" onclick=\"dcf_collapsible_toggle('{target}');\"><i class=\"fa fa-chevron-circle-left\" title=\"{title}\"></i></span>";
+            return $"<span class=\"dcf-collapsible dcf-collapsible-closed\" id=\"dcf-collapsible-{target}\" onclick=\"dcf_collapsible_toggle('{target}');\"><i class=\"fa fa-chevron-left\" title=\"{title}\"></i></span>";
         }
     }
 }

--- a/Dnn.CommunityForums/scripts/afcommon.js
+++ b/Dnn.CommunityForums/scripts/afcommon.js
@@ -368,10 +368,10 @@ function dcf_collapsible_showOrHideTarget(targetName) {
     }
 };
 function dcf_collapsible_getFaCssClassOpened() {
-    return 'fa-chevron-circle-down';
+    return 'fa-chevron-down';
 };
 function dcf_collapsible_getFaCssClassClosed() {
-    return 'fa-chevron-circle-left';
+    return 'fa-chevron-left';
 };
 function dcf_collapsible_getCssClassOpened() {
     return 'dcf-collapsible-opened';


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Change collapsible icon to use chevron without circle


## How did you test these updates?  
Local install. 
Old version:
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/9efb89f1-d1ca-4764-9e70-97cab37cb724)

New version:
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/dab38ef0-b82b-401c-8400-6adcaf78c602)

## PR Template Checklist

- [ ] Fixes Bug
- [ ] Feature solution
- [X] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  

