### PR TITLE
FIX: 'Most liked' incorrect results

### DIFF
--- a/Dnn.CommunityForums/sql/08.01.00.SqlDataProvider
+++ b/Dnn.CommunityForums/sql/08.01.00.SqlDataProvider
@@ -1,75 +1,126 @@
-/* issue 398 : allow user to change topic rating / issue 267 : improve/update database procedures / issue 266 : refactor/modernize entities/controllers (TopicRating) */
+/* begin -- issue 666 - most likes */
 
-/* add index to support retrieval by user id/topic id */
-IF EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}activeforums_Topics_Ratings') AND name = N'IX_{objectQualifier}activeforums_Topics_Ratings_Users')
-DROP INDEX IX_{objectQualifier}activeforums_Topics_Ratings_Users ON {databaseOwner}[{objectQualifier}activeforums_Topics_Ratings] 
-GO
-CREATE NONCLUSTERED INDEX IX_{objectQualifier}activeforums_Topics_Ratings_Users ON {databaseOwner}[{objectQualifier}activeforums_Topics_Ratings]
-	(
-	UserId,
-	TopicId
-	) 
-INCLUDE([Rating]) WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON)
+/*activeforums_UI_MostLiked*/
+IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_UI_MostLiked]') AND type in (N'P', N'PC'))
+DROP PROCEDURE {databaseOwner}[{objectQualifier}activeforums_UI_MostLiked]
 GO
 
-/* add index to support retrieval by topic id/user id */
-IF EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}activeforums_Topics_Ratings') AND name = N'IX_{objectQualifier}activeforums_Topics_Ratings_Topics')
-DROP INDEX IX_{objectQualifier}activeforums_Topics_Ratings_Topics ON {databaseOwner}[{objectQualifier}activeforums_Topics_Ratings] 
-GO
-CREATE NONCLUSTERED INDEX IX_{objectQualifier}activeforums_Topics_Ratings_Topics ON {databaseOwner}[{objectQualifier}activeforums_Topics_Ratings]
-	(
-	TopicId,
-	UserId	
-	) 
-INCLUDE([Rating]) WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON)
-GO
-
-/* no longer needed */
-IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_Topics_AddRating]') AND type in (N'P', N'PC'))
-DROP PROCEDURE {databaseOwner}[{objectQualifier}activeforums_Topics_AddRating]
-GO
-/* no longer needed */
-IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_Topics_GetRating]') AND type in (N'P', N'PC'))
-DROP PROCEDURE {databaseOwner}[{objectQualifier}activeforums_Topics_GetRating]
-GO
-
-/* issue 398 : allow user to change topic rating / issue 267 : improve/update database procedures / issue 266 : refactor/modernize entities/controllers (TopicRating) */
-/* begin - issue 643 - fix friendly urls in search results */
-
-IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_Search_GetSearchItemsFromBegDate]') AND type in (N'P', N'PC'))
-DROP PROCEDURE {databaseOwner}[{objectQualifier}activeforums_Search_GetSearchItemsFromBegDate]
-GO
-
-CREATE PROCEDURE {databaseOwner}{objectQualifier}activeforums_Search_GetSearchItemsFromBegDate(@ModuleId int, @beginDateUtc datetime)
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}activeforums_UI_MostLiked]
+	@PortalId int,
+	@ModuleId int,
+	@UserId int,
+	@RowIndex int = 0,
+	@MaxRows int = 20,
+	@Sort nvarchar(10) = 'DESC',
+	@TimeFrame int,
+	@ForumIds nvarchar(1000)
 AS
-SELECT F.ForumGroupId, FT.ForumId, X.TopicId, X.ReplyId, X.ContentId, X.DateCreated, X.DateUpdated, X.Summary, X.Subject, X.AuthorId, X.Body , X.IsDeleted, X.IsApproved,
-RTRIM(IsNull([dbo].activeforums_Topics_GetTags(X.TopicId),'')) AS Tags, X.TopicURL, F.PrefixURL AS ForumUrlPrefix, G.PrefixURL AS ForumGroupUrlPrefix
-FROM 
-(
-SELECT 
-T.TopicId, -1 AS ReplyId, C.ContentId, C.DateCreated, C.DateUpdated, C.Summary, C.Subject, C.AuthorId, Convert(nvarchar(max),C.Body) as Body, T.IsDeleted, T.IsApproved, T.URL AS TopicUrl
-FROM {databaseOwner}{objectQualifier}activeforums_Topics T
-INNER JOIN {databaseOwner}{objectQualifier}activeforums_Content C ON C.ContentId = T.ContentId 
-WHERE C.DateUpdated BETWEEN @beginDateUtc AND GETUTCDATE() 
-UNION
-SELECT
-R.TopicId, R.ReplyId, C.ContentId, C.DateCreated, C.DateUpdated, C.Summary, C.Subject, C.AuthorId, Convert(nvarchar(max),C.Body) as Body , R.IsDeleted, R.IsApproved, T.URL AS TopicUrl
-FROM {databaseOwner}{objectQualifier}activeforums_Replies R
-INNER JOIN {databaseOwner}{objectQualifier}activeforums_Content C ON C.ContentId = R.ContentId 
-LEFT OUTER JOIN {databaseOwner}{objectQualifier}activeforums_Topics T ON T.TopicId = R.TopicId
-WHERE C.DateUpdated BETWEEN @beginDateUtc AND GETUTCDATE() 
-) X
-INNER JOIN {databaseOwner}{objectQualifier}activeforums_Topics T ON T.TopicId = X.TopicId
-INNER JOIN {databaseOwner}{objectQualifier}activeforums_ForumTopics FT ON FT.TopicId = T.TopicId 
-INNER JOIN {databaseOwner}{objectQualifier}activeforums_Forums F ON F.ForumId = FT.ForumId 
-INNER JOIN {databaseOwner}{objectQualifier}activeforums_Groups G ON G.ForumGroupId  = F.ForumGroupId 
-INNER JOIN {databaseOwner}{objectQualifier}activeforums_settings S ON S.GroupKey = F.ForumSettingsKey AND S.SettingName = 'INDEXCONTENT'
-WHERE F.Active = 1 AND S.SettingValue = 'true' AND F.ModuleId = @ModuleId 
-GO
+	
+	-- Populate our active topics table
+	
+	CREATE TABLE #MostLiked(RowRank int NOT NULL, TopicId int NOT NULL)
+	
+	INSERT INTO #MostLiked(RowRank, TopicId)
+	SELECT ROW_NUMBER() OVER (
+			ORDER BY 
+				CASE 
+					WHEN @Sort = 'DESC' THEN  SUM(COALESCE(LikeCount,0)) END DESC, 
+				CASE  
+					WHEN @Sort = 'ASC' THEN  SUM(COALESCE(LikeCount,0)) END ASC
+					) as RowRank,  TopicId
+	FROM 
+	(SELECT T.TopicId, l.LikeCount
+	FROM {databaseOwner}{objectQualifier}vw_activeforums_TopicsView FT 
+	INNER JOIN {databaseOwner}{objectQualifier}activeforums_Functions_Split(@ForumIds,';') as X ON X.id = FT.ForumId
+	INNER JOIN{databaseOwner}{objectQualifier}activeforums_Topics T ON T.TopicId = FT.TopicId
+	LEFT OUTER JOIN (SELECT l.PostId AS ContentId, COUNT(*) AS LikeCount FROM {databaseOwner}{objectQualifier}activeforums_Likes l WHERE l.Checked = 1 GROUP BY l.PostId) l ON l.ContentId = T.ContentId
+	WHERE FT.PortalId = @PortalId AND FT.ModuleId = @ModuleId AND (COALESCE(l.LikeCount,0) > 0) AND DATEDIFF(mi,FT.LastReplyDate,GETUTCDATE())<= @TimeFrame 
+	UNION 
+	SELECT R.TopicId, l.LikeCount
+	FROM {databaseOwner}{objectQualifier}activeforums_Replies R 
+	INNER JOIN {databaseOwner}{objectQualifier}vw_activeforums_TopicsView FT ON FT.TopicId = R.TopicId
+	INNER JOIN {databaseOwner}{objectQualifier}activeforums_Functions_Split(@ForumIds,';') as X ON X.id = FT.ForumId
+	LEFT OUTER JOIN (SELECT l.PostId AS ContentId, COUNT(*) AS LikeCount FROM{databaseOwner}{objectQualifier}activeforums_Likes l WHERE l.Checked = 1 GROUP BY l.PostId) l ON l.ContentId = R.ContentId
+	WHERE FT.PortalId = @PortalId AND FT.ModuleId = @ModuleId AND (COALESCE(l.LikeCount,0) > 0) AND DATEDIFF(mi,FT.LastReplyDate,GETUTCDATE())<= @TimeFrame 
+	 
+	) x
+	GROUP BY TopicId
 
-/* this is no longer needed */
-IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}activeforums_Search_GetSearchItems') AND type in (N'P', N'PC'))
-DROP PROCEDURE {databaseOwner}{objectQualifier}activeforums_Search_GetSearchItems
-GO
+	-- Get our record count
+	
+	DECLARE @RecordCount int
+	SET @RecordCount = (SELECT COUNT(*) FROM #MostLiked)
 
-/* end - issue 643 - fix friendly urls in search results */
+	-- Return our result set
+
+	SELECT 
+		f.ForumId,
+		f.ForumName,
+		IsNull(f.LastReplyId,0) as LastReplyId,
+		t.TopicId,
+		t.ViewCount,
+		t.ReplyCount,
+		t.IsLocked,
+		t.IsPinned,
+		IsNull(t.TopicIcon,'') as TopicIcon,
+		t.StatusId,
+		t.IsAnnounce,
+		t.AnnounceStart,
+		t.AnnounceEnd,
+		t.TopicType,
+		c.Subject,
+		IsNull(c.Summary,'') as Summary,
+		IsNull(c.AuthorId,-1) as AuthorId,
+		IsNull(c.AuthorName,'') as AuthorName,
+		c.Body,
+		c.DateCreated,
+		IsNull(u.Username,'') as AuthorUserName,
+		IsNull(u.FirstName,'') as AuthorFirstName,
+		IsNull(u.LastName,'') as AuthorLastName,
+		IsNull(u.DisplayName,'') as AuthorDisplayName,
+		CASE WHEN rc.Subject IS NULL THEN c.Subject ELSE rc.Subject END as LastReplySubject,
+		CASE WHEN rc.Summary IS NULL THEN IsNull(c.Summary,'') ELSE rc.Summary END as LastReplySummary,
+		CASE WHEN rc.AuthorId IS NULL THEN c.AuthorId ELSE rc.AuthorId END as LastReplyAuthorId,
+		CASE WHEN rc.AuthorName IS NULL THEN IsNull(c.AuthorName,'') ELSE rc.AuthorName END  as LastReplyAuthorName,
+		CASE WHEN ru.Username IS NULL THEN IsNull(u.UserName,'') ELSE ru.UserName END as LastReplyUserName,
+		CASE WHEN ru.FirstName IS NULL THEN IsNULL(u.FirstName,'') ELSE ru.FirstName END as LastReplyFirstName,
+		CASE WHEN ru.LastName IS NULL THEN IsNull(u.LastName,'') ELSE ru.LastName END as LastReplyLastName,
+		CASE WHEN ru.DisplayName IS NULL THEN IsNull(IsNull(u.DisplayName,rc.AuthorName),'') ELSE ru.DisplayName END as LastReplyDisplayName,
+		CASE WHEN rc.DateCreated IS NULL THEN c.DateCreated ELSE rc.DateCreated END  as LastReplyDate,
+		CASE WHEN TT.LastReplyId < ISNULL(f.LastReplyId,0) THEN TT.LastReplyId ELSE 0 END AS LastReplyRead, 
+		CASE WHEN FT.MaxReplyRead > TT.LastReplyId OR TT.LastReplyID IS NULL THEN ISNULL(FT.MaxReplyRead,0) ELSE TT.LastReplyId END AS UserLastReplyRead, 
+		CASE WHEN FT.MaxTopicRead > TT.TopicId OR TT.TopicId IS NULL THEN ISNULL(FT.MaxTopicRead,0) ELSE TT.TopicId END AS UserLastTopicRead,
+		CASE WHEN ftt.LastReplyID <= tt.LastReplyId OR (ISNULL(ftt.LastReplyId,'') = 0 AND c.AuthorId = @UserId) OR (FT.MaxReplyRead >= ftt.LastReplyId) THEN 1 ELSE 0 END AS IsRead,
+		ftt.LastReplyId as TopicLastReplyId,
+		tr.TopicRating, 
+		@RecordCount as RecordCount,
+		ISNULL(t.URL,'') as  TopicURL,
+		ISNULL(f.PrefixURL,'') as ForumUrl,
+		ISNULL(g.PrefixURL,'') as GroupUrl,
+		g.ForumGroupId,
+		IsNull(S.Mode,0) AS SubscriptionType
+		
+		FROM	#MostLiked as tmp 
+		INNER JOIN {databaseOwner}{objectQualifier}activeforums_Topics as t on t.TopicId = tmp.TopicId 
+		INNER JOIN {databaseOwner}{objectQualifier}activeforums_ForumTopics AS ftt ON ftt.TopicId = t.TopicId 
+		INNER JOIN {databaseOwner}{objectQualifier}activeforums_forums as f ON f.forumId = ftt.ForumId 
+		INNER JOIN {databaseOwner}{objectQualifier}activeforums_Groups as g ON g.ForumGroupId = f.ForumGroupId 
+		INNER JOIN {databaseOwner}{objectQualifier}activeforums_Content as c on c.ContentId = t.ContentId 
+		
+		LEFT OUTER JOIN {databaseOwner}{objectQualifier}vw_activeforums_TopicRatings as tr on tr.TopicId = t.TopicId 
+		LEFT OUTER JOIN {databaseOwner}{objectQualifier}Users as u on u.UserId = c.AuthorId 
+		LEFT OUTER JOIN {databaseOwner}{objectQualifier}activeforums_Replies as r on r.ReplyId = ftt.LastReplyId 
+		LEFT OUTER JOIN (SELECT l.PostId, COUNT(*) AS LikeCount FROM {databaseOwner}{objectQualifier}activeforums_Likes l WHERE l.Checked = 1 GROUP BY l.PostId) tl ON tl.PostId = t.TopicId
+		LEFT OUTER JOIN (SELECT r.TopicId, COUNT(*) AS LikeCount FROM {databaseOwner}{objectQualifier}activeforums_Likes l INNER JOIN {databaseOwner}{objectQualifier}activeforums_Replies r ON r.ReplyId = l.PostId WHERE l.Checked = 1 GROUP BY r.TopicId) rl ON rl.TopicId = t.TopicId 
+		LEFT OUTER JOIN {databaseOwner}{objectQualifier}activeforums_Content as rc on rc.ContentId = r.ContentId 
+		LEFT OUTER JOIN {databaseOwner}{objectQualifier}Users as ru on ru.UserId = rc.AuthorId 
+		LEFT OUTER JOIN {databaseOwner}{objectQualifier}activeforums_Topics_Tracking AS tt ON tt.TopicId = t.TopicId AND tt.UserId = @UserId 
+		LEFT OUTER JOIN {databaseOwner}{objectQualifier}activeforums_Forums_Tracking as ft ON ft.ForumId = f.ForumId AND ft.UserId = @UserId 
+		LEFT OUTER JOIN {databaseOwner}{objectQualifier}activeforums_Subscriptions AS S ON S.ForumId = f.ForumId AND S.TopicId = T.TopicId and S.UserId = @UserId
+				
+	WHERE RowRank > @RowIndex AND RowRank <= (@RowIndex + @MaxRows)
+	ORDER BY RowRank
+
+	DROP TABLE #MostLiked
+GO
+/* end - issue 666 - most likes */


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Incorrect results on 'most liked' page.  In the `activeforums_Likes` table, the column `PostId` is used to track likes. `PostId` needs to be JOINed to `ContentId` (not to `TopicId`) in `activeforums_Content`; also needs to reflect likes from replies.

## Changes made
- Updated `activeforums_UI_MostLiked` stored procedure 

## How did you test these updates?  
Local install

Before:
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/804cb9d3-8afe-414c-ab27-25da07596aa2)

After:
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/748ad6fa-30a5-41d8-8d19-b3eea695d5eb)


## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #666 