### PR TITLE
Refactoring: Use HttpUtility methods consistently

### DIFF
--- a/Dnn.CommunityForums/Controllers/TokenController.cs
+++ b/Dnn.CommunityForums/Controllers/TokenController.cs
@@ -66,11 +66,11 @@ namespace DotNetNuke.Modules.ActiveForums
                                 tk.TokenTag = xNodeList[i].Attributes["name"].Value;
                                 if (xNodeList[i].Attributes["value"] != null)
                                 {
-                                    tk.TokenReplace = Utilities.HTMLDecode(xNodeList[i].Attributes["value"].Value);
+                                    tk.TokenReplace = HttpUtility.HtmlDecode(xNodeList[i].Attributes["value"].Value);
                                 }
                                 else
                                 {
-                                    tk.TokenReplace = Utilities.HTMLDecode(xNodeList[i].ChildNodes[0].InnerText);
+                                    tk.TokenReplace = HttpUtility.HtmlDecode(xNodeList[i].ChildNodes[0].InnerText);
                                 }
 
                                 li.Add(tk);

--- a/Dnn.CommunityForums/CustomControls/ServerControls/Callback.cs
+++ b/Dnn.CommunityForums/CustomControls/ServerControls/Callback.cs
@@ -342,7 +342,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
         }
         public string XSSFilter(string sText)
         {
-            sText = HttpContext.Current.Server.UrlDecode(sText);
+            sText = HttpUtility.UrlDecode(sText);
             string pattern = "<script.*/*>|</script>|<[a-zA-Z][^>]*=['\"]+javascript:\\w+.*['\"]+>|<\\w+[^>]*\\son\\w+=.*[ /]*>";
             sText = Regex.Replace(sText, pattern, string.Empty, RegexOptions.IgnoreCase);
             sText = sText.Replace("-->", string.Empty);

--- a/Dnn.CommunityForums/CustomControls/UserControls/ForumView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/ForumView.cs
@@ -710,7 +710,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
 
                 }
-                sb.Append("<a href=\"" + sURL + "\">" + Utilities.HTMLEncode(Subject) + "</a>");
+                sb.Append("<a href=\"" + sURL + "\">" + HttpUtility.HtmlEncode(Subject) + "</a>");
             }
             return sb.ToString();
         }

--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
@@ -530,8 +530,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                         {
                             for (var i = 0; i < xNodeList.Count; i++)
                             {
-                                var pName = Utilities.HTMLDecode(xNodeList[i].ChildNodes[0].InnerText);
-                                var pValue = Utilities.HTMLDecode(xNodeList[i].ChildNodes[1].InnerText);
+                                var pName = HttpUtility.HtmlDecode(xNodeList[i].ChildNodes[0].InnerText);
+                                var pValue = HttpUtility.HtmlDecode(xNodeList[i].ChildNodes[1].InnerText);
 
                                 // This builds the replacement text for the properties template
                                 var tmp = sPropTemplate.Replace("[AF:PROPERTY:LABEL]", "[RESX:" + pName + "]");
@@ -1589,7 +1589,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             if (Regex.IsMatch(sBody, "\\[CODE([^>]*)\\]", RegexOptions.IgnoreCase))
             {
                 var objCode = new CodeParser();
-                sBody = CodeParser.ParseCode(Utilities.HTMLDecode(sBody));
+                sBody = CodeParser.ParseCode(HttpUtility.HtmlDecode(sBody));
             }
             sBody = Utilities.StripExecCode(sBody);
             if (MainSettings.AutoLinkEnabled)

--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicsView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicsView.cs
@@ -779,8 +779,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                                 for (i = 0; i < xNodeList.Count; i++)
                                 {
                                     string tmp = sPropTemplate;
-                                    string pName = Utilities.HTMLDecode(xNodeList[i].ChildNodes[0].InnerText);
-                                    string pValue = Utilities.HTMLDecode(xNodeList[i].ChildNodes[1].InnerText);
+                                    string pName = HttpUtility.HtmlDecode(xNodeList[i].ChildNodes[0].InnerText);
+                                    string pValue = HttpUtility.HtmlDecode(xNodeList[i].ChildNodes[1].InnerText);
                                     tmp = tmp.Replace("[AF:PROPERTY:LABEL]", Utilities.GetSharedResource("[RESX:" + pName + "]"));
                                     tmp = tmp.Replace("[AF:PROPERTY:VALUE]", pValue);
                                     sTopicsTemplate = sTopicsTemplate.Replace("[AF:PROPERTY:" + pName + ":LABEL]", Utilities.GetSharedResource("[RESX:" + pName + "]"));

--- a/Dnn.CommunityForums/CustomControls/UserControls/UserProfile.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/UserProfile.cs
@@ -394,7 +394,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     {
                         upi.Signature = Utilities.XSSFilter(txtSignature.Text, true);
                         upi.Signature = Utilities.StripHTMLTag(upi.Signature);
-                        upi.Signature = Utilities.HTMLEncode(upi.Signature);
+                        upi.Signature = HttpUtility.HtmlEncode(upi.Signature);
                     }
                     else if (MainSettings.AllowSignatures == 2)
                     {

--- a/Dnn.CommunityForums/CustomControls/UserControls/WhatsNewRSS.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/WhatsNewRSS.cs
@@ -207,7 +207,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
         private static string CleanXmlString(string xmlString)
         {
-            xmlString = HttpContext.Current.Server.HtmlEncode(xmlString);
+            xmlString = HttpUtility.HtmlEncode(xmlString);
             return xmlString;
         }
 
@@ -233,7 +233,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             sb.Append(WriteElement("channel", indent));
             sb.Append(WriteElement("title", ps.PortalName, indent));
             sb.Append(WriteElement("link", "http://" + HttpContext.Current.Request.Url.Host, indent));
-            sb.Append(WriteElement("description", ps.PortalName, indent));
+            sb.Append(value: WriteElement("description", ps.PortalName, indent));
             sb.Append(WriteElement("generator", "ActiveForums  5.0", indent));
             sb.Append(WriteElement("language", ps.DefaultLanguage, indent));
 
@@ -352,7 +352,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                             }
                         }
                         bodyHtml = bodyHtml.Replace("src=\"/Portals", "src=\"" + Common.Globals.AddHTTP(HttpContext.Current.Request.Url.Host) + "/Portals");
-                        bodyHtml = Utilities.ManageImagePath(bodyHtml, Common.Globals.AddHTTP(HttpContext.Current.Request.Url.Host));
+                        bodyHtml = Utilities.ManageImagePath(bodyHtml, new Uri(Common.Globals.AddHTTP(HttpContext.Current.Request.Url.Host)));
 
                         sb.Append(WriteElement("description", bodyHtml, indent + 1));
                     }

--- a/Dnn.CommunityForums/CustomControls/Views/ForumDisplay.cs
+++ b/Dnn.CommunityForums/CustomControls/Views/ForumDisplay.cs
@@ -294,7 +294,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     sURL = Utilities.NavigateUrl(PageId, "", new[] { ParamKeys.ForumId + "=" + fid, ParamKeys.ViewType + "=" + Views.Topic, ParamKeys.TopicId + "=" + ParentPostID, ParamKeys.ContentJumpId + "=" + PostId });
 
                 }
-                sOut = "<af:link id=\"hypLastPostSubject" + fid + "\" NavigateUrl=\"" + sURL + "\" Text=\"" + Utilities.HTMLEncode(Subject) + "\" runat=\"server\" />";
+                sOut = "<af:link id=\"hypLastPostSubject" + fid + "\" NavigateUrl=\"" + sURL + "\" Text=\"" + System.Web.HttpUtility.HtmlEncode(Subject) + "\" runat=\"server\" />";
             }
             return sOut;
         }

--- a/Dnn.CommunityForums/Deprecated/Utilities.cs
+++ b/Dnn.CommunityForums/Deprecated/Utilities.cs
@@ -31,7 +31,7 @@ namespace DotNetNuke.Modules.ActiveForums
         {
             return ManageImagePath(sHTML, HttpContext.Current.Request.Url);
         }
-        [Obsolete("Deprecated in Community Forums. To be removed in 09.00.00. Use ManageImagePath(string sHTML, Uri hostUri)")]
+        [Obsolete("Deprecated in Community Forums. Removed in 09.00.00. Use ManageImagePath(string sHTML, Uri hostUri)")]
         public static string ManageImagePath(string sHTML, string hostWithScheme)
         {
             return ManageImagePath(sHTML, new Uri(hostWithScheme));

--- a/Dnn.CommunityForums/Deprecated/Utilities.cs
+++ b/Dnn.CommunityForums/Deprecated/Utilities.cs
@@ -31,7 +31,7 @@ namespace DotNetNuke.Modules.ActiveForums
         {
             return ManageImagePath(sHTML, HttpContext.Current.Request.Url);
         }
-        [Obsolete("Deprecated in Community Forums. Removed in 09.00.00. Use ManageImagePath(string sHTML, Uri hostUri)")]
+        [Obsolete("Deprecated in Community Forums. To be removed in 09.00.00. Use ManageImagePath(string sHTML, Uri hostUri)")]
         public static string ManageImagePath(string sHTML, string hostWithScheme)
         {
             return ManageImagePath(sHTML, new Uri(hostWithScheme));
@@ -41,6 +41,96 @@ namespace DotNetNuke.Modules.ActiveForums
         {
             return GetListOfModerators(portalId, -1, forumId);
         }
+
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Use BindEnum(DropDownList pDDL, Type enumType, string pColValue, bool addEmptyValue, bool localize, int excludeIndex)")]
+        public static void BindEnum(System.Web.UI.WebControls.DropDownList pDDL, Type enumType, string pColValue, bool addEmptyValue)
+        {
+            BindEnum(pDDL, enumType, pColValue, addEmptyValue, false, -1);
+        }
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
+        public static string ParsePre(string strMessage)
+        {
+            var objRegEx = new System.Text.RegularExpressions.Regex("<pre>(.*?)</pre>");
+            strMessage = "<code>" + HttpUtility.HtmlDecode(objRegEx.Replace(strMessage, "$1")) + "</code>";
+            return strMessage;
+        }
+
+
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
+        internal static string ParseSecurityTokens(string template, string userRoles)
+        {
+            const string pattern = @"(\[AF:SECURITY:(.+?):(.+?)\])(.|\n)*?(\[/AF:SECURITY:(.+?):(.+?)\])";
+
+            var sKey = string.Empty;
+            var sReplace = string.Empty;
+
+            var regExp = new System.Text.RegularExpressions.Regex(pattern);
+            var matches = regExp.Matches(template);
+            foreach (System.Text.RegularExpressions.Match match in matches)
+            {
+                var sRoles = match.Groups[3].Value;
+                if (Permissions.HasAccess(sRoles, userRoles))
+                {
+                    template = template.Replace(match.Groups[1].Value, string.Empty);
+                    template = template.Replace(match.Groups[5].Value, string.Empty);
+                }
+                else
+                {
+                    template = template.Replace(match.Value, string.Empty);
+                }
+            }
+            return template;
+        }
+
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
+        /// <summary>
+        /// Calculates a friendly display string based on an input timespan
+        /// </summary>
+        public static string HumanFriendlyDate(DateTime displayDate, int ModuleId, int timeZoneOffset)
+        {
+            var newDate = DateTime.Parse(GetDate(displayDate, ModuleId, timeZoneOffset));
+            var ts = new TimeSpan(DateTime.Now.Ticks - newDate.Ticks);
+            var delta = ts.TotalSeconds;
+            if (delta <= 1)
+                return GetSharedResource("[RESX:TimeSpan:SecondAgo]");
+
+            if (delta < 60)
+                return string.Format(GetSharedResource("[RESX:TimeSpan:SecondsAgo]"), ts.Seconds);
+
+            if (delta < 120)
+                return GetSharedResource("[RESX:TimeSpan:MinuteAgo]");
+
+            if (delta < (45 * 60))
+                return string.Format(GetSharedResource("[RESX:TimeSpan:MinutesAgo]"), ts.Minutes);
+
+            if (delta < (90 * 60))
+                return GetSharedResource("[RESX:TimeSpan:HourAgo]");
+
+            if (delta < (24 * 60 * 60))
+                return string.Format(GetSharedResource("[RESX:TimeSpan:HoursAgo]"), ts.Hours);
+
+            if (delta < (48 * 60 * 60))
+                return GetSharedResource("[RESX:TimeSpan:DayAgo]");
+
+            if (delta < (72 * 60 * 60))
+                return string.Format(GetSharedResource("[RESX:TimeSpan:DaysAgo]"), ts.Days);
+
+            if (delta < Convert.ToDouble(new TimeSpan(24 * 32, 0, 0).TotalSeconds))
+                return GetSharedResource("[RESX:TimeSpan:MonthAgo]");
+
+            if (delta < Convert.ToDouble(new TimeSpan(((24 * 30) * 11), 0, 0).TotalSeconds))
+                return string.Format(GetSharedResource("[RESX:TimeSpan:MonthsAgo]"), Math.Ceiling(ts.Days / 30.0));
+
+            if (delta < Convert.ToDouble(new TimeSpan(((24 * 30) * 18), 0, 0).TotalSeconds))
+                return GetSharedResource("[RESX:TimeSpan:YearAgo]");
+
+            return string.Format(GetSharedResource("[RESX:TimeSpan:YearsAgo]"), Math.Ceiling(ts.Days / 365.0));
+
+        }
+        [Obsolete("Deprecated in Community Forums. Removed in 09.00.00. Use HttpUtility.HtmlEncode.")]
+        public static string HtmlEncode(string strMessage = "") => HttpUtility.HtmlEncode(strMessage);
+        [Obsolete("Deprecated in Community Forums. Removed in 09.00.00. Use HttpUtility.HtmlDecode.")]
+        public static string HtmlDecode(string strMessage) => HttpUtility.HtmlDecode(strMessage);
 
     }
 }

--- a/Dnn.CommunityForums/Entities/TopicInfo.cs
+++ b/Dnn.CommunityForums/Entities/TopicInfo.cs
@@ -125,8 +125,8 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                             int i = 0;
                             for (i = 0; i < xNodeList.Count; i++)
                             {
-                                string pName = Utilities.HTMLDecode(xNodeList[i].ChildNodes[0].InnerText);
-                                string pValue = Utilities.HTMLDecode(xNodeList[i].ChildNodes[1].InnerText);
+                                string pName = System.Web.HttpUtility.HtmlDecode(xNodeList[i].ChildNodes[0].InnerText);
+                                string pValue = System.Web.HttpUtility.HtmlDecode(xNodeList[i].ChildNodes[1].InnerText);
                                 int pId = Convert.ToInt32(xNodeList[i].Attributes["id"].Value);
                                 PropertiesInfo p = new PropertiesInfo();
                                 p.Name = pName;

--- a/Dnn.CommunityForums/class/TemplateUtils.cs
+++ b/Dnn.CommunityForums/class/TemplateUtils.cs
@@ -601,11 +601,11 @@ namespace DotNetNuke.Modules.ActiveForums
                     switch (mainSettings.AllowSignatures)
                     {
                         case 1:
-                            sSignature = Utilities.HTMLEncode(sSignature);
+                            sSignature = HttpUtility.HtmlEncode(sSignature);
                             sSignature = sSignature.Replace(System.Environment.NewLine, "<br />");
                             break;
                         case 2:
-                            sSignature = Utilities.HTMLDecode(sSignature);
+                            sSignature = HttpUtility.HtmlDecode(sSignature);
                             break;
                     }
                 }
@@ -680,9 +680,9 @@ namespace DotNetNuke.Modules.ActiveForums
                 result.Replace("[AF:PROFILE:POSTCOUNT]", (up.PostCount == 0) ? string.Empty : up.PostCount.ToString());
                 result.Replace("[AF:PROFILE:USERCAPTION]", up.Profile.UserCaption);
                 result.Replace("[AF:PROFILE:USERID]", up.UserId.ToString());
-                result.Replace("[AF:PROFILE:USERNAME]", Utilities.HTMLEncode(up.UserName).Replace("&amp;#", "&#"));
-                result.Replace("[AF:PROFILE:FIRSTNAME]", Utilities.HTMLEncode(up.FirstName).Replace("&amp;#", "&#"));
-                result.Replace("[AF:PROFILE:LASTNAME]", Utilities.HTMLEncode(up.LastName).Replace("&amp;#", "&#"));
+                result.Replace("[AF:PROFILE:USERNAME]", HttpUtility.HtmlEncode(up.UserName).Replace("&amp;#", "&#"));
+                result.Replace("[AF:PROFILE:FIRSTNAME]", HttpUtility.HtmlEncode(up.FirstName).Replace("&amp;#", "&#"));
+                result.Replace("[AF:PROFILE:LASTNAME]", HttpUtility.HtmlEncode(up.LastName).Replace("&amp;#", "&#"));
                 result.Replace("[AF:PROFILE:DATELASTPOST]", (up.Profile.DateLastPost == DateTime.MinValue) ? string.Empty : Utilities.GetUserFormattedDateTime(up.Profile.DateLastPost, portalId, currentUserId));
                 result.Replace("[AF:PROFILE:TOPICCOUNT]", up.Profile.TopicCount.ToString());
                 result.Replace("[AF:PROFILE:REPLYCOUNT]", up.Profile.ReplyCount.ToString());
@@ -935,7 +935,7 @@ namespace DotNetNuke.Modules.ActiveForums
                         message = message.Replace(m.Value, m.Value.Replace("<br>", System.Environment.NewLine));
                 }
                 var objCode = new CodeParser();
-                template = CodeParser.ParseCode(Utilities.HTMLDecode(template));
+                template = CodeParser.ParseCode(HttpUtility.HtmlDecode(template));
             }
             return template;
         }

--- a/Dnn.CommunityForums/class/TemplateUtils.cs
+++ b/Dnn.CommunityForums/class/TemplateUtils.cs
@@ -200,7 +200,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 }
             }
 
-            body = Utilities.ManageImagePath(body, Common.Globals.AddHTTP(Common.Globals.GetDomainName(HttpContext.Current.Request)));
+            body = Utilities.ManageImagePath(body, new Uri(Common.Globals.AddHTTP(Common.Globals.GetDomainName(HttpContext.Current.Request))));
 
             // load the forum information
             var fi = new ForumController().Forums_Get(portalId: portalID, moduleId: moduleID, forumId: forumID, useCache: true);

--- a/Dnn.CommunityForums/class/Utilities.cs
+++ b/Dnn.CommunityForums/class/Utilities.cs
@@ -42,52 +42,6 @@ namespace DotNetNuke.Modules.ActiveForums
     {
         internal static CultureInfo DateTimeStringCultureInfo = new CultureInfo("en-US", true);
 
-
-        /// <summary>
-        /// Calculates a friendly display string based on an input timespan
-        /// </summary>
-        public static string HumanFriendlyDate(DateTime displayDate, int ModuleId, int timeZoneOffset)
-        {
-            var newDate = DateTime.Parse(GetDate(displayDate, ModuleId, timeZoneOffset));
-            var ts = new TimeSpan(DateTime.Now.Ticks - newDate.Ticks);
-            var delta = ts.TotalSeconds;
-            if (delta <= 1)
-                return GetSharedResource("[RESX:TimeSpan:SecondAgo]");
-
-            if (delta < 60)
-                return string.Format(GetSharedResource("[RESX:TimeSpan:SecondsAgo]"), ts.Seconds);
-
-            if (delta < 120)
-                return GetSharedResource("[RESX:TimeSpan:MinuteAgo]");
-
-            if (delta < (45 * 60))
-                return string.Format(GetSharedResource("[RESX:TimeSpan:MinutesAgo]"), ts.Minutes);
-
-            if (delta < (90 * 60))
-                return GetSharedResource("[RESX:TimeSpan:HourAgo]");
-
-            if (delta < (24 * 60 * 60))
-                return string.Format(GetSharedResource("[RESX:TimeSpan:HoursAgo]"), ts.Hours);
-
-            if (delta < (48 * 60 * 60))
-                return GetSharedResource("[RESX:TimeSpan:DayAgo]");
-
-            if (delta < (72 * 60 * 60))
-                return string.Format(GetSharedResource("[RESX:TimeSpan:DaysAgo]"), ts.Days);
-
-            if (delta < Convert.ToDouble(new TimeSpan(24 * 32, 0, 0).TotalSeconds))
-                return GetSharedResource("[RESX:TimeSpan:MonthAgo]");
-
-            if (delta < Convert.ToDouble(new TimeSpan(((24 * 30) * 11), 0, 0).TotalSeconds))
-                return string.Format(GetSharedResource("[RESX:TimeSpan:MonthsAgo]"), Math.Ceiling(ts.Days / 30.0));
-
-            if (delta < Convert.ToDouble(new TimeSpan(((24 * 30) * 18), 0, 0).TotalSeconds))
-                return GetSharedResource("[RESX:TimeSpan:YearAgo]");
-
-            return string.Format(GetSharedResource("[RESX:TimeSpan:YearsAgo]"), Math.Ceiling(ts.Days / 365.0));
-
-        }
-
         internal static string ParseTokenConfig(int moduleId, string template, string group, ControlsConfig config)
         {
             if (string.IsNullOrEmpty(template))
@@ -117,31 +71,6 @@ namespace DotNetNuke.Modules.ActiveForums
             template = template.Replace("[PORTALID]", config.PortalId.ToString());
             template = template.Replace("[MODULEID]", config.ModuleId.ToString());
 
-            return template;
-        }
-
-        internal static string ParseSecurityTokens(string template, string userRoles)
-        {
-            const string pattern = @"(\[AF:SECURITY:(.+?):(.+?)\])(.|\n)*?(\[/AF:SECURITY:(.+?):(.+?)\])";
-
-            var sKey = string.Empty;
-            var sReplace = string.Empty;
-
-            var regExp = new Regex(pattern);
-            var matches = regExp.Matches(template);
-            foreach (Match match in matches)
-            {
-                var sRoles = match.Groups[3].Value;
-                if (Permissions.HasAccess(sRoles, userRoles))
-                {
-                    template = template.Replace(match.Groups[1].Value, string.Empty);
-                    template = template.Replace(match.Groups[5].Value, string.Empty);
-                }
-                else
-                {
-                    template = template.Replace(match.Value, string.Empty);
-                }
-            }
             return template;
         }
 
@@ -410,12 +339,6 @@ HttpUtility.HtmlEncode(searchUrl), HttpUtility.HtmlEncode(advancedSearchUrl), se
             s = Common.Globals.FriendlyUrl(ti, sURL, pageName, portalSettings);
             return s;
         }
-
-        public static void BindEnum(DropDownList pDDL, Type enumType, string pColValue, bool addEmptyValue)
-        {
-            BindEnum(pDDL, enumType, pColValue, addEmptyValue, false, -1);
-        }
-
         public static void BindEnum(DropDownList pDDL, Type enumType, string pColValue, bool addEmptyValue, bool localize, int excludeIndex)
         {
             pDDL.Items.Clear();
@@ -581,7 +504,7 @@ HttpUtility.HtmlEncode(searchUrl), HttpUtility.HtmlEncode(advancedSearchUrl), se
         private static string CleanTextBox(int portalId, string text, bool allowHTML, bool useFilter, int moduleId, string themePath, bool processEmoticons)
         {
 
-            var strMessage = HTMLEncode(text);
+            var strMessage = HttpUtility.HtmlEncode(text);
 
             if (strMessage != string.Empty)
             {
@@ -603,7 +526,7 @@ HttpUtility.HtmlEncode(searchUrl), HttpUtility.HtmlEncode(advancedSearchUrl), se
                     if (useFilter)
                         strMessage = FilterWords(portalId, moduleId, themePath, strMessage, processEmoticons);
 
-                    strMessage = HTMLEncode(strMessage);
+                    strMessage = HttpUtility.HtmlEncode(strMessage);
                     strMessage = Regex.Replace(strMessage, System.Environment.NewLine, " <br /> ");
 
                     i = 0;
@@ -618,7 +541,7 @@ HttpUtility.HtmlEncode(searchUrl), HttpUtility.HtmlEncode(advancedSearchUrl), se
                     strMessage = Regex.Replace(strMessage, GetCaseInsensitiveSearch("<form"), "&lt;form&gt;");
                     strMessage = Regex.Replace(strMessage, GetCaseInsensitiveSearch("</form>"), "&lt;/form&gt;");
                     if (!allowHTML)
-                        strMessage = HTMLEncode(strMessage);
+                        strMessage = HttpUtility.HtmlEncode(strMessage);
 
                     if (useFilter)
                         strMessage = FilterWords(portalId, moduleId, themePath, strMessage, processEmoticons);
@@ -814,32 +737,6 @@ HttpUtility.HtmlEncode(searchUrl), HttpUtility.HtmlEncode(advancedSearchUrl), se
 
             return !string.IsNullOrEmpty(body.Replace("&nbsp;", string.Empty));
         }
-
-        public static string HTMLEncode(string strMessage = "")
-        {
-            if (strMessage != string.Empty)
-            {
-                strMessage = strMessage.Replace(">", "&gt;");
-                strMessage = strMessage.Replace("<", "&lt;");
-            }
-
-            return strMessage;
-        }
-
-        public static string ParsePre(string strMessage)
-        {
-            var objRegEx = new Regex("<pre>(.*?)</pre>");
-            strMessage = "<code>" + HTMLDecode(objRegEx.Replace(strMessage, "$1")) + "</code>";
-            return strMessage;
-        }
-
-        public static string HTMLDecode(string strMessage)
-        {
-            strMessage = strMessage.Replace("&gt;", ">");
-            strMessage = strMessage.Replace("&lt;", "<");
-            return strMessage;
-        }
-
         public static string StripHTMLTag(string sText)
         {
             if (string.IsNullOrEmpty(sText))
@@ -1265,11 +1162,11 @@ HttpUtility.HtmlEncode(searchUrl), HttpUtility.HtmlEncode(advancedSearchUrl), se
                     if (canRead)
                     {
                         string[] Params = { ParamKeys.ForumId + "=" + forumID, ParamKeys.ViewType + "=" + Views.Topic, ParamKeys.TopicId + "=" + lastPostID, ParamKeys.PageJumpId + "=" + intPages };
-                        sb.AppendFormat("<a href=\"{0}#{1}\" rel=\"nofollow\">{2}</a>", Common.Globals.NavigateURL(tabID, string.Empty, Params), postId, HTMLEncode(subject));
+                        sb.AppendFormat("<a href=\"{0}#{1}\" rel=\"nofollow\">{2}</a>", Common.Globals.NavigateURL(tabID, string.Empty, Params), postId, HttpUtility.HtmlEncode(subject));
                     }
                     else
                     {
-                        sb.Append(HTMLEncode(subject));
+                        sb.Append(HttpUtility.HtmlEncode(subject));
                     }
                 }
                 else
@@ -1277,11 +1174,11 @@ HttpUtility.HtmlEncode(searchUrl), HttpUtility.HtmlEncode(advancedSearchUrl), se
                     if (canRead)
                     {
                         string[] Params = { ParamKeys.ViewType + "=" + Views.Topic, ParamKeys.ForumId + "=" + forumID, ParamKeys.TopicId + "=" + lastPostID };
-                        sb.AppendFormat("<a href=\"{0}#{1}\" rel=\"nofollow\">{2}</a>", Common.Globals.NavigateURL(tabID, string.Empty, Params), postId, HTMLEncode(subject));
+                        sb.AppendFormat("<a href=\"{0}#{1}\" rel=\"nofollow\">{2}</a>", Common.Globals.NavigateURL(tabID, string.Empty, Params), postId, HttpUtility.HtmlEncode(subject));
                     }
                     else
                     {
-                        sb.Append(HTMLEncode(subject));
+                        sb.Append(HttpUtility.HtmlEncode(subject));
                     }
 
                 }

--- a/Dnn.CommunityForums/components/Data/ForumsDB.cs
+++ b/Dnn.CommunityForums/components/Data/ForumsDB.cs
@@ -195,7 +195,7 @@ namespace DotNetNuke.Modules.ActiveForums.Data
 				{
 					forums.Append("<forum groupid=\"" + f.ForumGroupId.ToString() + "\" forumid=\"" + f.ForumID.ToString() + "\"");
 					//forums.Append(" name=""" & HttpUtility.UrlEncode(f.ForumName) & """")
-					//forums.Append(" desc=""" & HttpUtility.UrlEncode(Utilities.HTMLEncode(f.ForumDesc.ToString)) & """")
+					//forums.Append(" desc=""" & HttpUtility.UrlEncode(HttpUtility.HtmlEncode(f.ForumDesc.ToString)) & """")
 					forums.Append(" active=\"" + f.Active.ToString().ToLowerInvariant() + "\"");
 					forums.Append(" hidden=\"" + f.Hidden.ToString().ToLowerInvariant() + "\"");
 					forums.Append(" totaltopics=\"" + f.TotalTopics.ToString() + "\"");

--- a/Dnn.CommunityForums/components/Helpers/Localization.cs
+++ b/Dnn.CommunityForums/components/Helpers/Localization.cs
@@ -131,7 +131,7 @@ namespace DotNetNuke.Modules.ActiveForums
 				xmlDoc.SelectSingleNode("//root").AppendChild(nodeData);
 				node = nodeData.AppendChild(xmlDoc.CreateElement("value"));
 			}
-			node.InnerXml = HttpContext.Current.Server.HtmlEncode(text);
+			node.InnerXml = HttpUtility.HtmlEncode(text);
 
 		}
 	}

--- a/Dnn.CommunityForums/controls/af_post.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_post.ascx.cs
@@ -409,8 +409,8 @@ namespace DotNetNuke.Modules.ActiveForums
                         {
                             for (var i = 0; i < xNodeList.Count; i++)
                             {
-                                var pName = Utilities.HTMLDecode(xNodeList[i].ChildNodes[0].InnerText);
-                                var pValue = Utilities.HTMLDecode(xNodeList[i].ChildNodes[1].InnerText);
+                                var pName = System.Web.HttpUtility.HtmlDecode(xNodeList[i].ChildNodes[0].InnerText);
+                                var pValue = System.Web.HttpUtility.HtmlDecode(xNodeList[i].ChildNodes[1].InnerText);
                                 var xmlAttributeCollection = xNodeList[i].Attributes;
                                 if (xmlAttributeCollection == null)
                                     continue;
@@ -611,7 +611,7 @@ namespace DotNetNuke.Modules.ActiveForums
                         if (body.ToUpper().Contains("<CODE") | body.ToUpper().Contains("[CODE]"))
                         {
                             var objCode = new CodeParser();
-                            body = CodeParser.ParseCode(Utilities.HTMLDecode(body));
+                            body = CodeParser.ParseCode(System.Web.HttpUtility.HtmlDecode(body));
                         }
                     }
                     else
@@ -934,7 +934,7 @@ namespace DotNetNuke.Modules.ActiveForums
             // This HTML decode is used to make Quote functionality work properly even when it appears in Text Box instead of Editor
             if (Request.Params[ParamKeys.QuoteId] != null)
             {
-                body = Utilities.HTMLDecode(body);
+                body = System.Web.HttpUtility.HtmlDecode(body);
             }
             int authorId;
             string authorName;

--- a/Dnn.CommunityForums/controls/af_search.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_search.ascx.cs
@@ -241,10 +241,10 @@ namespace DotNetNuke.Modules.ActiveForums
                     _parameters = new List<string>();
 
                     if (!string.IsNullOrWhiteSpace(SearchText))
-                        _parameters.Add("q=" + Server.UrlEncode(SearchText));
+                        _parameters.Add("q=" + System.Web.HttpUtility.UrlEncode(SearchText));
 
                     if (!string.IsNullOrWhiteSpace(Tags))
-                        _parameters.Add("tg=" + Server.UrlEncode(Tags));
+                        _parameters.Add("tg=" + System.Web.HttpUtility.UrlEncode(Tags));
 
                     if (SearchId > 0)
                         _parameters.Add("sid=" + SearchId);
@@ -268,10 +268,10 @@ namespace DotNetNuke.Modules.ActiveForums
                         _parameters.Add("srt=" + Sort);
 
                     if (!string.IsNullOrWhiteSpace(AuthorUsername))
-                        _parameters.Add("author=" + Server.UrlEncode(AuthorUsername));
+                        _parameters.Add("author=" + System.Web.HttpUtility.UrlEncode(AuthorUsername));
 
                     if (!string.IsNullOrWhiteSpace(Forums))
-                        _parameters.Add("f=" + Server.UrlEncode(Forums));
+                        _parameters.Add("f=" + System.Web.HttpUtility.UrlEncode(Forums));
                 }
 
                 return _parameters;

--- a/Dnn.CommunityForums/controls/af_searchadvanced.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_searchadvanced.ascx.cs
@@ -336,10 +336,10 @@ namespace DotNetNuke.Modules.ActiveForums
             var @params = new List<string> { ParamKeys.ViewType + "=search" };
 
             if(!string.IsNullOrWhiteSpace(searchText))
-                @params.Add("q=" + Server.UrlEncode(searchText));
+                @params.Add("q=" + System.Web.HttpUtility.UrlEncode(searchText));
 
             if (!string.IsNullOrWhiteSpace(tags))
-                @params.Add("tg=" + Server.UrlEncode(tags));
+                @params.Add("tg=" + System.Web.HttpUtility.UrlEncode(tags));
 
             if(searchType > 0)
                 @params.Add("k=" + searchType);
@@ -358,10 +358,10 @@ namespace DotNetNuke.Modules.ActiveForums
 
 
             if(!string.IsNullOrWhiteSpace(authorUsername))
-                @params.Add("author=" + Server.UrlEncode(authorUsername));
+                @params.Add("author=" + System.Web.HttpUtility.UrlEncode(authorUsername));
 
             if(!string.IsNullOrWhiteSpace(forums))
-                @params.Add("f=" + Server.UrlEncode(forums));
+                @params.Add("f=" + System.Web.HttpUtility.UrlEncode(forums));
 
             if (SocialGroupId > 0)
                 @params.Add("GroupId=" + SocialGroupId.ToString());

--- a/Dnn.CommunityForums/controls/profile_mypreferences.ascx.cs
+++ b/Dnn.CommunityForums/controls/profile_mypreferences.ascx.cs
@@ -85,7 +85,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     {
                         upi.Signature = Utilities.XSSFilter(txtSignature.Text, true);
                         upi.Signature = Utilities.StripHTMLTag(upi.Signature);
-                        upi.Signature = Utilities.HTMLEncode(upi.Signature);
+                        upi.Signature = System.Web.HttpUtility.HtmlEncode(upi.Signature);
                     }
                     else if (MainSettings.AllowSignatures == 2)
                     {

--- a/Dnn.CommunityForums/feeds.aspx.cs
+++ b/Dnn.CommunityForums/feeds.aspx.cs
@@ -264,7 +264,7 @@ namespace DotNetNuke.Modules.ActiveForums
             }
              */
             body = body.Replace("src=\"/Portals", "src=\"" + DotNetNuke.Common.Globals.AddHTTP(Request.Url.Host) + "/Portals");
-            body = Utilities.ManageImagePath(body, DotNetNuke.Common.Globals.AddHTTP(Request.Url.Host));
+            body = Utilities.ManageImagePath(body, new Uri(Common.Globals.AddHTTP(Request.Url.Host)));
 
             sb.Append(WriteElement("title", dr["Subject"].ToString(), Indent + 1));
             sb.Append(WriteElement("description", body, Indent + 1));

--- a/Dnn.CommunityForumsTests/class/UtilitiesTests.cs
+++ b/Dnn.CommunityForumsTests/class/UtilitiesTests.cs
@@ -68,42 +68,42 @@ namespace DotNetNuke.Modules.ActiveForumsTests
         }
 
         [Test()]
-        public void HTMLEncodeTestEmptyTag()
+        public void HtmlEncodeTestEmptyTag()
         {
             //Arrange
             //Act
-            string actualResult = Utilities.HTMLEncode(string.Empty);
+            string actualResult = Utilities.HtmlEncode(string.Empty);
             //Assert
             Assert.IsEmpty(actualResult);
         }
         [Test()]
-        public void HTMLEncodeTest()
+        public void HtmlEncodeTest()
         {
             //Arrange
             string tag = "<p>";
             string expectedResult = "&lt;p&gt;";
             //Act
-            string actualResult = Utilities.HTMLEncode(tag);
+            string actualResult = Utilities.HtmlEncode(tag);
             //Assert
             Assert.AreEqual(actualResult, expectedResult);
         }
         [Test()]
-        public void HTMLDecodeTestEmptyTag()
+        public void HtmlDecodeTestEmptyTag()
         {
             //Arrange
             //Act
-            string actualResult = Utilities.HTMLDecode(string.Empty);
+            string actualResult = Utilities.HtmlDecode(string.Empty);
             //Assert
             Assert.IsEmpty(actualResult);
         }
         [Test()]
-        public void HTMLDecodeTest()
+        public void HtmlDecodeTest()
         {
             //Arrange
             string tag = "&lt;p&gt;";
             string expectedResult = "<p>";
             //Act
-            string actualResult = Utilities.HTMLDecode(tag);
+            string actualResult = Utilities.HtmlDecode(tag);
             //Assert
             Assert.AreEqual(actualResult, expectedResult);
         }


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

## Changes made
- Use System.Web.HttpUtility's `HtmlEncode`/`HtmlDecode` & `UrlEncode`/`UrlDecode` methods consistently rather than using roll-your-own and/or relying on HttpContext.
-
## How did you test these updates?  
Local install

## PR Template Checklist

- [ ] Fixes Bug
- [ ] Feature solution
- [X] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->
Part of #264 