### PR TITLE
TASK: Update NUnit & Moq for Unit Test Project

### DIFF
--- a/Dnn.CommunityForumsTests/DnnCommunityForumsTests.csproj
+++ b/Dnn.CommunityForumsTests/DnnCommunityForumsTests.csproj
@@ -53,9 +53,8 @@
       <HintPath>..\packages\Microsoft.CodeCoverage.17.4.1\lib\net462\Microsoft.VisualStudio.CodeCoverage.Shim.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Moq, Version=4.18.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.18.4\lib\net462\Moq.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Moq, Version=4.20.70.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.20.70\lib\net462\Moq.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=4.0.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.4.1.0\lib\net462\nunit.framework.dll</HintPath>

--- a/Dnn.CommunityForumsTests/DnnCommunityForumsTests.csproj
+++ b/Dnn.CommunityForumsTests/DnnCommunityForumsTests.csproj
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.NET.Test.Sdk.17.9.0\build\net462\Microsoft.NET.Test.Sdk.props" Condition="Exists('..\packages\Microsoft.NET.Test.Sdk.17.9.0\build\net462\Microsoft.NET.Test.Sdk.props')" />
+  <Import Project="..\packages\Microsoft.CodeCoverage.17.9.0\build\netstandard2.0\Microsoft.CodeCoverage.props" Condition="Exists('..\packages\Microsoft.CodeCoverage.17.9.0\build\netstandard2.0\Microsoft.CodeCoverage.props')" />
   <Import Project="..\packages\NUnit.4.1.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.4.1.0\build\NUnit.props')" />
   <Import Project="..\packages\NUnit3TestAdapter.4.5.0\build\net462\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.4.5.0\build\net462\NUnit3TestAdapter.props')" />
-  <Import Project="..\packages\Microsoft.NET.Test.Sdk.17.4.1\build\net462\Microsoft.NET.Test.Sdk.props" Condition="Exists('..\packages\Microsoft.NET.Test.Sdk.17.4.1\build\net462\Microsoft.NET.Test.Sdk.props')" />
-  <Import Project="..\packages\Microsoft.CodeCoverage.17.4.1\build\netstandard2.0\Microsoft.CodeCoverage.props" Condition="Exists('..\packages\Microsoft.CodeCoverage.17.4.1\build\netstandard2.0\Microsoft.CodeCoverage.props')" />
   <Import Project="..\Dnn.CommunityForums\packages\Microsoft.NET.Test.Sdk.17.4.1\build\net462\Microsoft.NET.Test.Sdk.props" Condition="Exists('..\Dnn.CommunityForums\packages\Microsoft.NET.Test.Sdk.17.4.1\build\net462\Microsoft.NET.Test.Sdk.props')" />
   <Import Project="..\Dnn.CommunityForums\packages\Microsoft.CodeCoverage.17.4.1\build\netstandard2.0\Microsoft.CodeCoverage.props" Condition="Exists('..\Dnn.CommunityForums\packages\Microsoft.CodeCoverage.17.4.1\build\netstandard2.0\Microsoft.CodeCoverage.props')" />
   <Import Project="..\Dnn.CommunityForums\packages\NUnit3TestAdapter.4.3.1\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\Dnn.CommunityForums\packages\NUnit3TestAdapter.4.3.1\build\net35\NUnit3TestAdapter.props')" />
@@ -50,8 +50,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.CodeCoverage.Shim, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeCoverage.17.4.1\lib\net462\Microsoft.VisualStudio.CodeCoverage.Shim.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CodeCoverage.17.9.0\lib\net462\Microsoft.VisualStudio.CodeCoverage.Shim.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.20.70.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.20.70\lib\net462\Moq.dll</HintPath>
@@ -120,15 +119,19 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\Dnn.CommunityForums\packages\Microsoft.CodeCoverage.17.4.1\build\netstandard2.0\Microsoft.CodeCoverage.targets" Condition="Exists('..\Dnn.CommunityForums\packages\Microsoft.CodeCoverage.17.4.1\build\netstandard2.0\Microsoft.CodeCoverage.targets')" />
   <Import Project="..\Dnn.CommunityForums\packages\Microsoft.NET.Test.Sdk.17.4.1\build\net462\Microsoft.NET.Test.Sdk.targets" Condition="Exists('..\Dnn.CommunityForums\packages\Microsoft.NET.Test.Sdk.17.4.1\build\net462\Microsoft.NET.Test.Sdk.targets')" />
-  <Import Project="..\packages\Microsoft.CodeCoverage.17.4.1\build\netstandard2.0\Microsoft.CodeCoverage.targets" Condition="Exists('..\packages\Microsoft.CodeCoverage.17.4.1\build\netstandard2.0\Microsoft.CodeCoverage.targets')" />
-  <Import Project="..\packages\Microsoft.NET.Test.Sdk.17.4.1\build\net462\Microsoft.NET.Test.Sdk.targets" Condition="Exists('..\packages\Microsoft.NET.Test.Sdk.17.4.1\build\net462\Microsoft.NET.Test.Sdk.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\NUnit3TestAdapter.4.5.0\build\net462\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.4.5.0\build\net462\NUnit3TestAdapter.props'))" />
     <Error Condition="!Exists('..\packages\NUnit.4.1.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.4.1.0\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeCoverage.17.9.0\build\netstandard2.0\Microsoft.CodeCoverage.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeCoverage.17.9.0\build\netstandard2.0\Microsoft.CodeCoverage.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeCoverage.17.9.0\build\netstandard2.0\Microsoft.CodeCoverage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeCoverage.17.9.0\build\netstandard2.0\Microsoft.CodeCoverage.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.NET.Test.Sdk.17.9.0\build\net462\Microsoft.NET.Test.Sdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NET.Test.Sdk.17.9.0\build\net462\Microsoft.NET.Test.Sdk.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.NET.Test.Sdk.17.9.0\build\net462\Microsoft.NET.Test.Sdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NET.Test.Sdk.17.9.0\build\net462\Microsoft.NET.Test.Sdk.targets'))" />
   </Target>
+  <Import Project="..\packages\Microsoft.CodeCoverage.17.9.0\build\netstandard2.0\Microsoft.CodeCoverage.targets" Condition="Exists('..\packages\Microsoft.CodeCoverage.17.9.0\build\netstandard2.0\Microsoft.CodeCoverage.targets')" />
+  <Import Project="..\packages\Microsoft.NET.Test.Sdk.17.9.0\build\net462\Microsoft.NET.Test.Sdk.targets" Condition="Exists('..\packages\Microsoft.NET.Test.Sdk.17.9.0\build\net462\Microsoft.NET.Test.Sdk.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Dnn.CommunityForumsTests/DnnCommunityForumsTests.csproj
+++ b/Dnn.CommunityForumsTests/DnnCommunityForumsTests.csproj
@@ -94,6 +94,9 @@
       <Name>DnnCommunityForums</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\NUnit.Analyzers.4.0.1\analyzers\dotnet\cs\nunit.analyzers.dll" />
+  </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>

--- a/Dnn.CommunityForumsTests/DnnCommunityForumsTests.csproj
+++ b/Dnn.CommunityForumsTests/DnnCommunityForumsTests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\NUnit3TestAdapter.4.3.1\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.4.3.1\build\net35\NUnit3TestAdapter.props')" />
-  <Import Project="..\packages\NUnit.3.13.3\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.13.3\build\NUnit.props')" />
+  <Import Project="..\packages\NUnit.4.1.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.4.1.0\build\NUnit.props')" />
+  <Import Project="..\packages\NUnit3TestAdapter.4.5.0\build\net462\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.4.5.0\build\net462\NUnit3TestAdapter.props')" />
   <Import Project="..\packages\Microsoft.NET.Test.Sdk.17.4.1\build\net462\Microsoft.NET.Test.Sdk.props" Condition="Exists('..\packages\Microsoft.NET.Test.Sdk.17.4.1\build\net462\Microsoft.NET.Test.Sdk.props')" />
   <Import Project="..\packages\Microsoft.CodeCoverage.17.4.1\build\netstandard2.0\Microsoft.CodeCoverage.props" Condition="Exists('..\packages\Microsoft.CodeCoverage.17.4.1\build\netstandard2.0\Microsoft.CodeCoverage.props')" />
   <Import Project="..\Dnn.CommunityForums\packages\Microsoft.NET.Test.Sdk.17.4.1\build\net462\Microsoft.NET.Test.Sdk.props" Condition="Exists('..\Dnn.CommunityForums\packages\Microsoft.NET.Test.Sdk.17.4.1\build\net462\Microsoft.NET.Test.Sdk.props')" />
@@ -57,9 +57,11 @@
       <HintPath>..\packages\Moq.4.18.4\lib\net462\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.13.3.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.13.3\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=4.0.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.4.1.0\lib\net462\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework.legacy, Version=4.0.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.4.1.0\lib\net462\nunit.framework.legacy.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -121,6 +123,13 @@
   <Import Project="..\Dnn.CommunityForums\packages\Microsoft.NET.Test.Sdk.17.4.1\build\net462\Microsoft.NET.Test.Sdk.targets" Condition="Exists('..\Dnn.CommunityForums\packages\Microsoft.NET.Test.Sdk.17.4.1\build\net462\Microsoft.NET.Test.Sdk.targets')" />
   <Import Project="..\packages\Microsoft.CodeCoverage.17.4.1\build\netstandard2.0\Microsoft.CodeCoverage.targets" Condition="Exists('..\packages\Microsoft.CodeCoverage.17.4.1\build\netstandard2.0\Microsoft.CodeCoverage.targets')" />
   <Import Project="..\packages\Microsoft.NET.Test.Sdk.17.4.1\build\net462\Microsoft.NET.Test.Sdk.targets" Condition="Exists('..\packages\Microsoft.NET.Test.Sdk.17.4.1\build\net462\Microsoft.NET.Test.Sdk.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.4.5.0\build\net462\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.4.5.0\build\net462\NUnit3TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit.4.1.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.4.1.0\build\NUnit.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Dnn.CommunityForumsTests/app.config
+++ b/Dnn.CommunityForumsTests/app.config
@@ -6,6 +6,18 @@
         <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>-->
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="WebMatrix.Data" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Razor" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/Dnn.CommunityForumsTests/class/UtilitiesTests.cs
+++ b/Dnn.CommunityForumsTests/class/UtilitiesTests.cs
@@ -35,7 +35,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests
             //Act
             var actualResult = Utilities.NullDate();
             //Assert
-            Assert.AreEqual(expectedResult, actualResult);
+            Assert.That(actualResult, Is.EqualTo(expectedResult));
         }
 
         [Test()]
@@ -46,7 +46,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests
             //Act
             string actualResult = Utilities.CleanStringForUrl(input);
             //Assert
-            Assert.AreEqual(expectedResult, actualResult);
+            Assert.That(actualResult, Is.EqualTo(expectedResult));
         }
         [Test()]
         [TestCase(0, 0, false, ExpectedResult = true)] // flood interval disables
@@ -87,7 +87,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests
             //Act
             string actualResult = Utilities.HtmlEncode(tag);
             //Assert
-            Assert.AreEqual(actualResult, expectedResult);
+            Assert.That(expectedResult, Is.EqualTo(actualResult));
         }
         [Test()]
         [Obsolete("Deprecated in Community Forums. Removed in 09.00.00. Use HttpUtility.HtmlDecode.")]
@@ -109,7 +109,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests
             //Act
             string actualResult = Utilities.HtmlDecode(tag);
             //Assert
-            Assert.AreEqual(actualResult, expectedResult);
+            Assert.That(expectedResult, Is.EqualTo(actualResult));
         }
         [Test()]
         [TestCase("", ExpectedResult = false)]

--- a/Dnn.CommunityForumsTests/class/UtilitiesTests.cs
+++ b/Dnn.CommunityForumsTests/class/UtilitiesTests.cs
@@ -24,7 +24,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests
             //Act
             bool isTrusted = Utilities.IsTrusted(0, userTrustLevel, false, 0, userPostCount);
             //Assert
-            Assert.IsFalse(isTrusted);
+            Assert.That(isTrusted, Is.False);
         }
 
         [Test()]
@@ -75,7 +75,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests
             //Act
             string actualResult = Utilities.HtmlEncode(string.Empty);
             //Assert
-            Assert.IsEmpty(actualResult);
+            Assert.That(actualResult, Is.Empty);
         }
         [Test()]
         [Obsolete("Deprecated in Community Forums. Removed in 09.00.00. Use HttpUtility.HtmlEncode.")]
@@ -97,7 +97,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests
             //Act
             string actualResult = Utilities.HtmlDecode(string.Empty);
             //Assert
-            Assert.IsEmpty(actualResult);
+            Assert.That(actualResult, Is.Empty);
         }
         [Test()]
         [Obsolete("Deprecated in Community Forums. Removed in 09.00.00. Use HttpUtility.HtmlDecode.")]

--- a/Dnn.CommunityForumsTests/packages.config
+++ b/Dnn.CommunityForumsTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Castle.Core" version="5.1.1" targetFramework="net472" />
   <package id="Microsoft.CodeCoverage" version="17.4.1" targetFramework="net472" />
   <package id="Microsoft.NET.Test.Sdk" version="17.4.1" targetFramework="net472" />
-  <package id="Moq" version="4.18.4" targetFramework="net472" />
+  <package id="Moq" version="4.20.70" targetFramework="net472" />
   <package id="NUnit" version="4.1.0" targetFramework="net472" />
   <package id="NUnit.Analyzers" version="4.0.1" targetFramework="net472" developmentDependency="true" />
   <package id="NUnit3TestAdapter" version="4.5.0" targetFramework="net472" />

--- a/Dnn.CommunityForumsTests/packages.config
+++ b/Dnn.CommunityForumsTests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="5.1.1" targetFramework="net472" />
-  <package id="Microsoft.CodeCoverage" version="17.4.1" targetFramework="net472" />
-  <package id="Microsoft.NET.Test.Sdk" version="17.4.1" targetFramework="net472" />
+  <package id="Microsoft.CodeCoverage" version="17.9.0" targetFramework="net472" />
+  <package id="Microsoft.NET.Test.Sdk" version="17.9.0" targetFramework="net472" />
   <package id="Moq" version="4.20.70" targetFramework="net472" />
   <package id="NUnit" version="4.1.0" targetFramework="net472" />
   <package id="NUnit.Analyzers" version="4.0.1" targetFramework="net472" developmentDependency="true" />

--- a/Dnn.CommunityForumsTests/packages.config
+++ b/Dnn.CommunityForumsTests/packages.config
@@ -5,6 +5,7 @@
   <package id="Microsoft.NET.Test.Sdk" version="17.4.1" targetFramework="net472" />
   <package id="Moq" version="4.18.4" targetFramework="net472" />
   <package id="NUnit" version="3.13.3" targetFramework="net472" />
+  <package id="NUnit.Analyzers" version="4.0.1" targetFramework="net472" developmentDependency="true" />
   <package id="NUnit3TestAdapter" version="4.3.1" targetFramework="net472" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />

--- a/Dnn.CommunityForumsTests/packages.config
+++ b/Dnn.CommunityForumsTests/packages.config
@@ -4,9 +4,9 @@
   <package id="Microsoft.CodeCoverage" version="17.4.1" targetFramework="net472" />
   <package id="Microsoft.NET.Test.Sdk" version="17.4.1" targetFramework="net472" />
   <package id="Moq" version="4.18.4" targetFramework="net472" />
-  <package id="NUnit" version="3.13.3" targetFramework="net472" />
+  <package id="NUnit" version="4.1.0" targetFramework="net472" />
   <package id="NUnit.Analyzers" version="4.0.1" targetFramework="net472" developmentDependency="true" />
-  <package id="NUnit3TestAdapter" version="4.3.1" targetFramework="net472" />
+  <package id="NUnit3TestAdapter" version="4.5.0" targetFramework="net472" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Update Moq and NUnit versions to latest version to work with Visual Studio 2022 17.4+

## Changes made
- Add NUnit.Analyzers to migrate NUnit3 to NUnit4 for existing tests
- Update NUnit3TestAdapter 4.3.1 to 4.5.0
- Update NUnit 3.13.3 to 4.1.0
- Update NUnit3TestAdapter 4.3.1 to 4.5.0
- Update Moq 4.18.4 to 4.20.70
- Update Microsoft.CodeCoverage 17.4.1 to 17.9.0
- Update Microsoft.NET.Test.Sdk  17.4.1 to 17.9.0
- 
## How did you test these updates?  
Prior to update, tests would not run 
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/38729218-5942-418c-ab91-fe8135c510fd)

Exceptions in output window:
```
NUnit Adapter 4.3.1.0: Test discovery starting
Exception System.TypeInitializationException, Exception thrown discovering tests in E:\source\repos\johnhenley\Dnn.CommunityForums\Dnn.CommunityForumsTests\bin\Debug\DotNetNuke.Modules.ActiveForumsTests.dll
Exception System.TypeInitializationException, Exception thrown discovering tests in E:\source\repos\johnhenley\Dnn.CommunityForums\Dnn.CommunityForums\bin\DotNetNuke.Modules.ActiveForums.dll
The type initializer for 'NUnit.Engine.Services.RuntimeFrameworkService' threw an exception.
The type initializer for 'NUnit.Engine.Services.RuntimeFrameworkService' threw an exception.
   at NUnit.Engine.Services.RuntimeFrameworkService.ApplyImageData(TestPackage package)
   at NUnit.Engine.Services.RuntimeFrameworkService.SelectRuntimeFramework(TestPackage package)
   at NUnit.Engine.Runners.MasterTestRunner.GetEngineRunner()
   at NUnit.Engine.Runners.MasterTestRunner.Explore(TestFilter filter)
   at NUnit.VisualStudio.TestAdapter.NUnitEngine.NUnitEngineAdapter.Explore(TestFilter filter) in D:\repos\NUnit\nunit3-vs-adapter\src\NUnitTestAdapter\NUnitEngine\NUnitEngineAdapter.cs:line 97
   at NUnit.VisualStudio.TestAdapter.NUnit3TestDiscoverer.DiscoverTests(IEnumerable`1 sources, IDiscoveryContext discoveryContext, IMessageLogger messageLogger, ITestCaseDiscoverySink discoverySink) in D:\repos\NUnit\nunit3-vs-adapter\src\NUnitTestAdapter\NUnit3TestDiscoverer.cs:line 82
InnerException: System.ArgumentException: Unknown framework version 8.0
Parameter name: version
   at NUnit.Engine.RuntimeFramework.GetClrVersionForFramework(Version frameworkVersion)
   at NUnit.Engine.RuntimeFramework..ctor(RuntimeType runtime, Version version, String profile)
   at NUnit.Engine.RuntimeFramework.GetNetCoreRuntimesFromDirectoryNames(IEnumerable`1 dirNames)
   at NUnit.Engine.RuntimeFramework.FindDotNetCoreFrameworks()
   at NUnit.Engine.RuntimeFramework.get_AvailableFrameworks()
   at NUnit.Engine.Services.RuntimeFrameworkService..cctor()
   at NUnit.Engine.Services.RuntimeFrameworkService.ApplyImageData(TestPackage package)
   at NUnit.Engine.Services.RuntimeFrameworkService.SelectRuntimeFramework(TestPackage package)
   at NUnit.Engine.Runners.MasterTestRunner.GetEngineRunner()
   at NUnit.Engine.Runners.MasterTestRunner.Explore(TestFilter filter)
   at NUnit.VisualStudio.TestAdapter.NUnitEngine.NUnitEngineAdapter.Explore(TestFilter filter) in D:\repos\NUnit\nunit3-vs-adapter\src\NUnitTestAdapter\NUnitEngine\NUnitEngineAdapter.cs:line 97
   at NUnit.VisualStudio.TestAdapter.NUnit3TestDiscoverer.DiscoverTests(IEnumerable`1 sources, IDiscoveryContext discoveryContext, IMessageLogger messageLogger, ITestCaseDiscoverySink discoverySink) in D:\repos\NUnit\nunit3-vs-adapter\src\NUnitTestAdapter\NUnit3TestDiscoverer.cs:line 82
NUnit Adapter 4.3.1.0: Test discovery complete
InnerException: System.ArgumentException: Unknown framework version 8.0
Parameter name: version
   at NUnit.Engine.RuntimeFramework.GetClrVersionForFramework(Version frameworkVersion)
   at NUnit.Engine.RuntimeFramework..ctor(RuntimeType runtime, Version version, String profile)
   at NUnit.Engine.RuntimeFramework.GetNetCoreRuntimesFromDirectoryNames(IEnumerable`1 dirNames)
   at NUnit.Engine.RuntimeFramework.FindDotNetCoreFrameworks()
   at NUnit.Engine.RuntimeFramework.get_AvailableFrameworks()
   at NUnit.Engine.Services.RuntimeFrameworkService..cctor()
NUnit Adapter 4.3.1.0: Test discovery complete
```

After updates, ran unit tests successfully.
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/56c47dff-6a9e-4360-9166-bbd591eeb2b9)

## PR Template Checklist

- [ ] Fixes Bug
- [ ] Feature solution
- [X] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  

 