### PR TITLE
FIX: Can't subscribe when adding new topic

### DIFF
--- a/Dnn.CommunityForums/CustomControls/UserControls/SubmitForm.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/SubmitForm.cs
@@ -254,6 +254,11 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 afpolledit.PollQuestion = value;
             }
         }
+        public bool Subscribe
+        {
+            get => chkSubscribe.Checked;
+            set => chkSubscribe.Checked = value;
+        }
         public string PollType
         {
             get
@@ -313,7 +318,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
         protected af_topicstatus aftopicstatus = new af_topicstatus();
         protected CheckBox chkLocked = new CheckBox();
         protected CheckBox chkPinned = new CheckBox();
-        protected CheckBox chkAnnounce = new CheckBox(); 
+        protected CheckBox chkAnnounce = new CheckBox();
+        protected CheckBox chkSubscribe = new CheckBox();
         protected CheckBox chkApproved = new CheckBox();
         protected System.Web.UI.WebControls.RequiredFieldValidator reqSubject = new System.Web.UI.WebControls.RequiredFieldValidator();
         protected Label reqCustomBody = new Label();
@@ -707,10 +713,17 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
             if (canSubscribe)
             {
-                var subControl = new ToggleSubscribe(ForumModuleId, ForumInfo.ForumID, TopicId, 1);
-                subControl.Checked = (Subscriptions.IsSubscribed(PortalId, ForumModuleId, ForumInfo.ForumID, TopicId, SubscriptionTypes.Instant, this.UserId));
-                subControl.Text = "[RESX:TopicSubscribe:" + (Subscriptions.IsSubscribed(PortalId, ForumModuleId, ForumInfo.ForumID, TopicId, SubscriptionTypes.Instant, this.UserId)).ToString().ToUpper() + "]";
-                sb.Append("<tr><td colspan=\"2\">" + subControl.Render() +"</td></tr>");
+                if (TopicId > 0)
+                {
+                    var subControl = new ToggleSubscribe(ForumModuleId, ForumInfo.ForumID, TopicId, 1);
+                    subControl.Checked = (Subscriptions.IsSubscribed(PortalId, ForumModuleId, ForumInfo.ForumID, TopicId, SubscriptionTypes.Instant, this.UserId));
+                    subControl.Text = "[RESX:TopicSubscribe:" + (Subscriptions.IsSubscribed(PortalId, ForumModuleId, ForumInfo.ForumID, TopicId, SubscriptionTypes.Instant, this.UserId)).ToString().ToUpper() + "]";
+                    sb.Append("<tr><td colspan=\"2\">" + subControl.Render() + "</td></tr>");
+                }
+                else
+                {
+                    sb.Append("<tr><td colspan=\"2\"><asp:checkbox id=\"chkSubscribe\" Text=\"[RESX:TopicSubscribe:FALSE]\" TextAlign=\"right\" cssclass=\"afcheckbox\" runat=\"server\" /></td></tr>");
+                }
                 bHasOptions = true;
             }
             if ((EditorMode == EditorModes.NewTopic || EditorMode == EditorModes.EditTopic) && Permissions.HasPerm(ForumInfo.Security.Prioritize, ForumUser.UserRoles))
@@ -1115,6 +1128,9 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                         ctlAttach.ModuleConfiguration = this.ModuleConfiguration;
                         ctlAttach.ModuleId = ModuleId;
                         ctlAttach.ForumInfo = ForumInfo;
+                        break;
+                    case "chkSubscribe":
+                        chkSubscribe = (CheckBox)ctrl;
                         break;
                     case "ctlCaptcha":
                         ctlCaptcha = (DotNetNuke.UI.WebControls.CaptchaControl)ctrl;

--- a/Dnn.CommunityForums/controls/af_post.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_post.ascx.cs
@@ -143,7 +143,6 @@ namespace DotNetNuke.Modules.ActiveForums
             ctlForm.CancelButton.Width = Unit.Pixel(50);
             ctlForm.CancelButton.ConfirmMessage = GetSharedResource("[RESX:ConfirmCancel]");
             ctlForm.ModuleConfiguration = ModuleConfiguration;
-            //ctlForm.Subscribe = UserPrefTopicSubscribe;
             if (_fi.AllowHTML)
             {
                 _allowHTML = IsHtmlPermitted(_fi.EditorPermittedUsers, _userIsTrusted, _canModEdit);
@@ -844,14 +843,13 @@ namespace DotNetNuke.Modules.ActiveForums
 
                 ti = tc.Topics_Get(PortalId, ForumModuleId, TopicId, ForumId, -1, false);
                 ti.TopicType = TopicTypes.Poll;
-                tc.TopicSave(PortalId, ForumModuleId, ti); 
-                if (UserPrefTopicSubscribe)
-                {
-                    new DotNetNuke.Modules.ActiveForums.Controllers.SubscriptionController().Subscribe(PortalId, ForumModuleId, UserId, ForumId, ti.TopicId);
-                }
-                tc.UpdateModuleLastContentModifiedOnDate(ForumModuleId);
+                tc.TopicSave(PortalId, ForumModuleId, ti);
             }
-
+            if ((UserPrefTopicSubscribe && authorId == UserId) || ctlForm.Subscribe)
+            {
+                new DotNetNuke.Modules.ActiveForums.Controllers.SubscriptionController().Subscribe(PortalId, ForumModuleId, UserId, ForumId, ti.TopicId);
+            }
+            tc.UpdateModuleLastContentModifiedOnDate(ForumModuleId);
             try
             {
                 DataCache.ContentCacheClear(ForumModuleId, string.Format(CacheKeys.TopicViewForUser, ForumModuleId, TopicId, authorId));

--- a/Dnn.CommunityForums/scripts/afcommon.js
+++ b/Dnn.CommunityForums/scripts/afcommon.js
@@ -85,22 +85,24 @@ function amaf_topicSubscribe(mid, fid, tid) {
         forumId: fid,
         topicId: tid
     };
-    $.ajax({
-        type: "POST",
-        data: JSON.stringify(params),
-        contentType: "application/json",
-        dataType: "json",
-        url: dnn.getVar("sf_siteRoot", "/") + 'API/ActiveForums/Topic/Subscribe',
-        beforeSend: sf.setModuleHeaders
-    }).done(function (data) {
-        amaf_UpdateTopicSubscriberCount(mid, fid, tid);
-        $('input[type=checkbox].amaf-chk-subs')
-            .prop('checked', data)
-            .siblings('label[for=amaf-chk-subs]').html(data ? amaf.resx.TopicSubscribeTrue : amaf.resx.TopicSubscribeFalse);
-
-    }).fail(function (xhr, status) {
-        alert('error subscribing to topic');
-    });
+    /* can only subscribe using API if existing topic; new topic will be handled in code-behind when saving the topic */
+    if (tid > 0) {
+        $.ajax({
+            type: "POST",
+            data: JSON.stringify(params),
+            contentType: "application/json",
+            dataType: "json",
+            url: dnn.getVar("sf_siteRoot", "/") + 'API/ActiveForums/Topic/Subscribe',
+            beforeSend: sf.setModuleHeaders
+        }).done(function (data) {
+            amaf_UpdateTopicSubscriberCount(mid, fid, tid);
+            $('input[type=checkbox].amaf-chk-subs')
+                .prop('checked', data)
+                .siblings('label[for=amaf-chk-subs]').html(data ? amaf.resx.TopicSubscribeTrue : amaf.resx.TopicSubscribeFalse);
+        }).fail(function (xhr, status) {
+            alert('error subscribing to topic');
+        });
+    }
 };
 function amaf_UpdateTopicSubscriberCount(mid, fid, tid) {
     var u = document.getElementById('af-topicview-topicsubscribercount');


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Subscribing not working when adding a new topic

## Changes made
- Change posting form to use server-side checkbox when adding a new topic
- Change JavaScript to not call subscribe API when adding a new topic

## How did you test these updates?  
Local install; tested adding new topic and replying to existing topics

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #697