### PR TITLE
ENH: Added subscriber counts to topics / topic view in community-default theme

### DIFF
--- a/Dnn.CommunityForums/themes/community-default/templates/TopicView.ascx
+++ b/Dnn.CommunityForums/themes/community-default/templates/TopicView.ascx
@@ -10,7 +10,7 @@
 				</div>
 			</div>
 		</div>
-		<div class="dcf-breadcrumb">[FORUMMAINLINK] <i class="fa fa-chevron-right"></i> [FORUMLINK]</div>
+		<div class="dcf-breadcrumb">[FORUMMAINLINK] <i class="fa fa-chevron-right"></i> [FORUMGROUPLINK] <i class="fa fa-chevron-right"></i> [FORUMLINK]</div>
 		<div class="dcf-header-content">
 
 			<div class="dcf-cols">
@@ -18,6 +18,9 @@
 					<h1 class="dcf-title dcf-title-1">[AF:CONTROL:STATUSICON]<span class="dcf-topic">[SUBJECT]</span></h1>
 				</div>
 				<div class="dcf-col dcf-col-50-md">
+                    <div class="dcf-forum-subscribers"><i class="fa fa-reply fa-fw fa-grey"></i>&nbsp;[AF:LABEL:ReplyCount] [RESX:REPLIES]</div>
+                    <div class="dcf-forum-subscribers"><i class="fa fa-envelope-o fa-fw fa-grey"></i>&nbsp;<span id="af-topicview-topicsubscribercount">[TOPICSUBSCRIBERCOUNT]</span> [RESX:TOPICSUBSCRIBERCOUNT]</div>
+                    <div class="dcf-forum-subscribers"><i class="fa fa-envelope fa-fw fa-grey"></i>&nbsp;[FORUMSUBSCRIBERCOUNT]&nbsp;[RESX:FORUMSUBSCRIBERCOUNT]</div>
 					<div class="dcf-topic-controls">
 						<span class="dcf-sort">[TRESX:SortPosts]:[SORTDROPDOWN]</span>
 						<div class="dcf-subscribe">[TOPICSUBSCRIBE]</div>

--- a/Dnn.CommunityForums/themes/community-default/templates/TopicsView.ascx
+++ b/Dnn.CommunityForums/themes/community-default/templates/TopicsView.ascx
@@ -10,7 +10,7 @@
 		
 		<div class="dcf-forum-search-subscribe">
 			<div class="dcf-forum-search">[MINISEARCH]</div>
-			<div class="dcf-forum-subscribers"><i class="fa fa-envelope fa-fw fa-grey"></i> [FORUMSUBSCRIBERCOUNT] [RESX:FORUMSUBSCRIBERCOUNT]</div>
+			<div class="dcf-forum-subscribers"><i class="fa fa-envelope fa-fw fa-grey"></i> &nbsp;<span id="af-topicsview-forumsubscribercount">[FORUMSUBSCRIBERCOUNT]</span>&nbsp;[RESX:FORUMSUBSCRIBERCOUNT]</div>
 			<div class="dcf-forum-subscribe">[FORUMSUBSCRIBE]</div>
 		</div>
 		


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
New UI elements for topic/forum subscriber counts were added in 8.0, but still needed to be added to the community-default theme.


## Changes made

Topic view:
- added link to group
- added subscriber count(s)
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/c55f0bd7-f5fd-4590-b5b8-8a15d573045a)

Topics view:
- added subscriber count(s)
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/03f82065-e150-4aa3-9dc8-4278d2584756)



## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  
