### PR TITLE
FIX: Template filename Issues when multiple Forums module instances and changing themes

### DIFF
--- a/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.resx
+++ b/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.resx
@@ -381,7 +381,7 @@
   <data name="SecGrid:view.Text" xml:space="preserve">
     <value>View</value>
   </data>
-	<data name="String1" xml:space="preserve">
+  <data name="String1" xml:space="preserve">
     <value />
   </data>
   <data name="UserPermissions.Text" xml:space="preserve">
@@ -483,10 +483,13 @@
   <data name="FullTextNotInstalled.Text" xml:space="preserve">
     <value>Full text search is not installed on the SQL Server.</value>
   </data>
-	<data name="CacheTemplates.Help" xml:space="preserve">
+  <data name="CacheTemplates.Help" xml:space="preserve">
     <value>Should normally be enabled; disable if you are editing templates and want to see immediate results.</value>
   </data>
-	<data name="CacheTemplates.Text" xml:space="preserve">
+  <data name="CacheTemplates.Text" xml:space="preserve">
     <value>Enable Template Caching</value>
+  </data>
+  <data name="ApplicationRestart.Text" xml:space="preserve">
+    <value>Restarting Application after module settings changed</value>
   </data>
 </root>

--- a/Dnn.CommunityForums/ForumSettings.ascx.cs
+++ b/Dnn.CommunityForums/ForumSettings.ascx.cs
@@ -28,6 +28,7 @@ using System.Xml;
 using System.Web;
 using DotNetNuke.Entities.Urls;
 using System.Linq;
+using DotNetNuke.Services.Log.EventLog;
 
 namespace DotNetNuke.Modules.ActiveForums.Controls
 {
@@ -312,7 +313,13 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 // Clear out the cache
                 DataCache.ClearSettingsCache(ModuleId);
 
-			}
+				var log = new DotNetNuke.Services.Log.EventLog.LogInfo { LogTypeKey = DotNetNuke.Abstractions.Logging.EventLogType.APPLICATION_SHUTTING_DOWN.ToString() };
+				log.LogProperties.Add(new LogDetailInfo("ModuleId", ModuleId.ToString()));
+                log.AddProperty("Message", this.LocalizeString("ApplicationRestart"));
+                DotNetNuke.Services.Log.EventLog.LogController.Instance.AddLog(log);
+				DotNetNuke.Common.Utilities.Config.Touch();
+
+            }
 			catch (Exception exc) //Module failed to load
 			{
 				DotNetNuke.Services.Exceptions.Exceptions.ProcessModuleLoadException(this, exc);

--- a/Dnn.CommunityForums/sql/08.01.00.SqlDataProvider
+++ b/Dnn.CommunityForums/sql/08.01.00.SqlDataProvider
@@ -1186,3 +1186,64 @@ GO
 /* issue 660 end - unanswered topics should not include locked topics */
 
 /* --------------------- */
+
+
+/* issue 711 begin - Only append templateId to Filename if template name is duplicated within same module */
+
+/*activeforums_Templates_Save*/
+IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_Templates_Save]') AND type in (N'P', N'PC'))
+DROP PROCEDURE {databaseOwner}[{objectQualifier}activeforums_Templates_Save]
+GO
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}activeforums_Templates_Save]
+	@TemplateId int,
+	@PortalId int,
+	@ModuleId int,
+	@TemplateType int,
+	@IsSystem bit,
+	@Title nvarchar(150),
+	@Subject nvarchar(200),
+	@Template ntext	
+AS
+BEGIN
+IF EXISTS (Select TemplateId FROM {databaseOwner}{objectQualifier}activeforums_Templates WHERE TemplateId = @TemplateID AND PortalId = @PortalId AND ModuleId = @ModuleID) 
+	--UPDATE
+	BEGIN
+		UPDATE {databaseOwner}{objectQualifier}activeforums_Templates
+			SET
+				TemplateType = @TemplateType,
+				IsSystem = @IsSystem,
+				Title = @Title,
+				Subject = @Subject,
+				Template = @Template,
+				DateUpdated = GETUTCDATE()
+			WHERE
+				TemplateId = @TemplateId AND PortalId = @PortalId AND ModuleId = @ModuleId
+	END
+ELSE
+	--INSERT
+	BEGIN
+		INSERT INTO {databaseOwner}{objectQualifier}activeforums_Templates
+			(PortalId, ModuleId, TemplateType, Title, Subject, Template, DateCreated)
+			VALUES
+			(@PortalId, @ModuleId, @TemplateType,@Title,@Subject,@Template, GETUTCDATE())
+		SET @TemplateId = SCOPE_IDENTITY()
+		DECLARE @TemplateTitleCount int
+		SET @TemplateTitleCount = (SELECT COUNT(*) FROM {databaseOwner}{objectQualifier}activeforums_Templates WHERE Title = @Title AND ModuleId = @ModuleId) 
+		IF @TemplateTitleCount <> 1 
+			BEGIN
+				UPDATE {databaseOwner}{objectQualifier}activeforums_Templates SET FileName = CONCAT(RTRIM(Title),'-',LTRIM(STR(TemplateId)),'.ascx') WHERE TemplateId = @TemplateId AND FileName IS NULL
+			END
+			ELSE
+				BEGIN
+					UPDATE {databaseOwner}{objectQualifier}activeforums_Templates SET FileName = CONCAT(RTRIM(Title),'.ascx') WHERE TemplateId = @TemplateId AND FileName IS NULL
+				END 
+	END
+END
+
+SELECT @TemplateId
+GO
+/*activeforums_Templates_Save*/
+
+/* issue 660 end -  Only append templateId to Filename if template name is duplicated within same module */
+
+/* --------------------- */


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Fixes a couple of issues with templates and themes

## Changes made
- When saving a template, only append templateId to filename if duplicated template within same module instance
- Restart application when changing module settings in order to pick up changes to theme, templates

## How did you test these updates?  
Local install

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #711