### PR TITLE
FIX: URL prefix (vanity name) not saved for Forum Group in Control Panel

### DIFF
--- a/Dnn.CommunityForums/controls/admin_manageforums_forumeditor.ascx.cs
+++ b/Dnn.CommunityForums/controls/admin_manageforums_forumeditor.ascx.cs
@@ -287,7 +287,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
                         gi.SortOrder = string.IsNullOrWhiteSpace(e.Parameters[7]) ? 0 : Utilities.SafeConvertInt(e.Parameters[7]);
 
-                        gi.PrefixURL = e.Parameters[9];
+                        gi.PrefixURL = e.Parameters[10];
                         if (!(string.IsNullOrEmpty(gi.PrefixURL)))
                         {
                             var db = new Data.Common();


### PR DESCRIPTION
…in control panel; regression from PR #677

<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Fix mismatched query param for URL prefix when changing forum group in control panel; regression from PR #677 when separating group / forum inheritance for security and features

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->

Local install.

Before:
whatever is in vanity name gets changed to 'false':
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/b7cf741a-84ba-4070-848b-b45cee38e053)


After:
correctly saved
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/2bfbe5b8-a7b2-494c-8007-1daba823aa1b)


## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  
