### PR TITLE
ENH: Updates to topic/reply editor UI

### DIFF
--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.resx
@@ -1282,10 +1282,10 @@ From,
   <data name="[RESX:SplitCancelConfirm].Text" xml:space="preserve">
     <value>Cancel split?</value>
   </data>
-	<data name="[RESX:FileName].Text" xml:space="preserve">
+  <data name="[RESX:FileName].Text" xml:space="preserve">
     <value>File Name</value>
   </data>
-	<data name="[RESX:Folder].Text" xml:space="preserve">
+  <data name="[RESX:Folder].Text" xml:space="preserve">
     <value>Folder</value>
   </data>
   <data name="[RESX:FileSize].Text" xml:space="preserve">
@@ -1692,11 +1692,20 @@ From,
   </data>
   <data name="[RESX:Community-Message-Intro].Text" xml:space="preserve">
     <value>We would love to get in touch with you!</value>
-  </data>  
+  </data>
   <data name="[RESX:Community-Message-Connect].Text" xml:space="preserve">
     <value>How to provide feedback / stay up to date</value>
-  </data>  
+  </data>
   <data name="[RESX:Community-Message-Help].Text" xml:space="preserve">
     <value>Module manual / wiki</value>
+  </data>
+  <data name="[RESX:EditingExistingReply].Text" xml:space="preserve">
+    <value>Editing Existing Reply</value>
+  </data>
+  <data name="[RESX:EditingExistingTopic].Text" xml:space="preserve">
+    <value>Editing Existing Topic</value>
+  </data>
+  <data name="[RESX:ReplyToMessage].Text" xml:space="preserve">
+    <value>Reply To Topic</value>
   </data>
 </root>

--- a/Dnn.CommunityForums/config/templates/ReplyEditor.ascx
+++ b/Dnn.CommunityForums/config/templates/ReplyEditor.ascx
@@ -10,10 +10,10 @@
 			<td colspan="2" align="center">			
 				<table cellpadding="0" cellspacing="4" border="0" width="99%">
 					[AF:UI:MESSAGEREPLY]
-					<tr>
-						<td style="text-align:left;">[RESX:ReplyToMessage]:</td>
+					<%--<tr>
+						<td style="text-align:left;">[RESX:ReplyToTopic]:</td>
 						<td></td>
-					</tr>
+					</tr>--%>
 					<tr>
 						<td colspan="2" style="text-align:left;">[AF:LABEL:BODYREPLY]</td>
 					</tr>

--- a/Dnn.CommunityForums/controls/af_post.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_post.ascx.cs
@@ -485,6 +485,10 @@ namespace DotNetNuke.Modules.ActiveForums
         {
 
             string template = TemplateCache.GetCachedTemplate(ForumModuleId, "TopicEditor", _fi.TopicFormId);
+            if (_isEdit)
+            {
+                template = template.Replace("[RESX:CreateNewTopic]", "[RESX:EditingExistingTopic]");
+            }
             
             if (MainSettings.UseSkinBreadCrumb)
             {
@@ -514,7 +518,10 @@ namespace DotNetNuke.Modules.ActiveForums
             ctlForm.EditorMode = Modules.ActiveForums.Controls.SubmitForm.EditorModes.Reply;
 
             string template = TemplateCache.GetCachedTemplate(ForumModuleId, "ReplyEditor", _fi.ReplyFormId);
-            
+            if (_isEdit)
+            {
+                template = template.Replace("[RESX:ReplyToTopic]", "[RESX:EditingExistingReply]");
+            }
             if (MainSettings.UseSkinBreadCrumb)
             {
                 template = template.Replace("<div class=\"afcrumb\">[AF:LINK:FORUMMAIN] > [AF:LINK:FORUMGROUP] > [AF:LINK:FORUMNAME]</div>", string.Empty);

--- a/Dnn.CommunityForums/themes/community-default/templates/ReplyEditor.ascx
+++ b/Dnn.CommunityForums/themes/community-default/templates/ReplyEditor.ascx
@@ -10,10 +10,10 @@
 			<td colspan="2" align="center">			
 				<table cellpadding="0" cellspacing="4" border="0" width="99%">
 					[AF:UI:MESSAGEREPLY]
-					<tr>
-						<td style="text-align:left;">[RESX:ReplyToMessage]:</td>
+					<%--<tr>
+						<td style="text-align:left;">[RESX:ReplyToTopic]:</td>
 						<td></td>
-					</tr>
+					</tr>--%>
 					<tr>
 						<td colspan="2" style="text-align:left;">[AF:LABEL:BODYREPLY]</td>
 					</tr>


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Minor updates to topic/reply editor UI

## Changes made
- Couple of tweaks to topic/reply editor to show "editing existing" topics / replies
- ReplyEditor template referenced [RESX:ReplyToMessage] resource key rather than [RESX:ReplyToTopic]; corrected this in default template, and community-default template. Also added [RESX:ReplyToMessage] as a resource key for any existing templates to show it correctly.
- Removed extra [RESX:ReplyToTopic] in ReplyEditor templates; was in two different places
- Added string resources [RESX:EditingExistingTopic] and  [RESX:EditingExistingReply] 

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #717 