### PR TITLE
ENH: Moderator notifications when banning user

### DIFF
--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.resx
@@ -1708,4 +1708,13 @@ From,
   <data name="[RESX:ReplyToMessage].Text" xml:space="preserve">
     <value>Reply To Topic</value>
   </data>
+  <data name="RESX:BanAlertBody.Text" xml:space="preserve">
+    <value>&lt;div&gt;[Subject] &lt;br /&gt;&lt;br /&gt;[Post] &lt;br /&gt;&lt;br /&gt;&lt;/div&gt;</value>
+  </data>
+  <data name="RESX:BanAlertSubject.Text" xml:space="preserve">
+    <value>User [Username] has been banned by [BannedBy]</value>
+  </data>
+  <data name="RESX:UserBanned.Text" xml:space="preserve">
+    <value>User: {0} has been banned, and all posts deleted.</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/class/ForumsConfig.cs
+++ b/Dnn.CommunityForums/class/ForumsConfig.cs
@@ -36,6 +36,12 @@ using DotNetNuke.Data;
 using System.Reflection;
 using DotNetNuke.Instrumentation;
 using System.Web.UI;
+using DotNetNuke.Services.Social.Notifications;
+using DotNetNuke.Abstractions.Portals;
+using DotNetNuke.Entities.Users;
+using DotNetNuke.Security.Roles;
+using DotNetNuke.Services.Localization;
+using System.Globalization;
 
 namespace DotNetNuke.Modules.ActiveForums
 {
@@ -64,7 +70,10 @@ namespace DotNetNuke.Modules.ActiveForums
                 // templates are loaded; map new forumview template id
                 UpdateForumViewTemplateId(PortalId, ModuleId);
 
-                return true;
+                // Create "User Banned" core messaging notification type new in 08.01.00
+				ForumsConfig.Install_BanUser_NotificationType_080100();
+                
+				return true;
 			}
 			catch (Exception ex)
 			{
@@ -471,6 +480,18 @@ namespace DotNetNuke.Modules.ActiveForums
                 }
                 dr.Close();
             } 
+		}
+		internal static void Install_BanUser_NotificationType_080100()
+        {
+            string notificationTypeName = "DCF-UserBanned";
+            string notificationTypeDescription = $"{Globals.ModuleFriendlyName} User Banned";
+            int deskModuleId = DesktopModuleController.GetDesktopModuleByFriendlyName(Globals.ModuleFriendlyName).DesktopModuleID;
+
+            NotificationType type = new NotificationType { Name = notificationTypeName, Description = notificationTypeDescription, DesktopModuleId = deskModuleId };
+            if (NotificationsController.Instance.GetNotificationType(notificationTypeName) == null)
+			{
+				NotificationsController.Instance.CreateNotificationType(type);
+			}
 		}
 	}
 }

--- a/Dnn.CommunityForums/class/Globals.cs
+++ b/Dnn.CommunityForums/class/Globals.cs
@@ -140,7 +140,8 @@ namespace DotNetNuke.Modules.ActiveForums
 		}
 
 		public const string ModuleName = "Active Forums";
-		public const string ModulePath = "~/DesktopModules/ActiveForums/";
+		public const string ModuleFriendlyName = "DNN Community Forums";
+        public const string ModulePath = "~/DesktopModules/ActiveForums/";
         public const string ModuleConfigPath = Globals.ModulePath + "config/";
         public const string DefaultTemplatePath = Globals.ModulePath + "config/templates/";
         public const string ModuleImagesPath = Globals.ModulePath + "images/";

--- a/Dnn.CommunityForums/components/Topics/TopicsController.cs
+++ b/Dnn.CommunityForums/components/Topics/TopicsController.cs
@@ -565,6 +565,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     try
                     {
                         DotNetNuke.Modules.ActiveForums.Helpers.UpgradeModuleSettings.DeleteObsoleteModuleSettings_080100();
+                        ForumsConfig.Install_BanUser_NotificationType_080100();
                     }
                     catch (Exception ex)
                     {

--- a/Dnn.CommunityForums/sql/08.01.00.SqlDataProvider
+++ b/Dnn.CommunityForums/sql/08.01.00.SqlDataProvider
@@ -1260,3 +1260,25 @@ GO
 /* issue 660 end -  Only append templateId to Filename if template name is duplicated within same module */
 
 /* --------------------- */
+
+
+/* issue 721 - minor enhancements to banning user */
+
+/* add new notification type  */
+IF NOT EXISTS(SELECT * FROM  {databaseOwner}[{objectQualifier}CoreMessaging_NotificationTypes] WHERE Name = N'DCF-UserBanned') 
+INSERT INTO {databaseOwner}[{objectQualifier}CoreMessaging_NotificationTypes] (
+  [Name],
+  [Description],
+  [TTL],
+  [DesktopModuleID])
+VALUES (
+  N'DCF-UserBanned',
+  N'DCF-UserBanned',
+  -1,
+  NULL)
+GO
+
+/* issue 721 - minor enhancements to banning user */
+
+
+/* --------------------- */

--- a/Dnn.CommunityForums/sql/08.01.00.SqlDataProvider
+++ b/Dnn.CommunityForums/sql/08.01.00.SqlDataProvider
@@ -1260,25 +1260,3 @@ GO
 /* issue 660 end -  Only append templateId to Filename if template name is duplicated within same module */
 
 /* --------------------- */
-
-
-/* issue 721 - minor enhancements to banning user */
-
-/* add new notification type  */
-IF NOT EXISTS(SELECT * FROM  {databaseOwner}[{objectQualifier}CoreMessaging_NotificationTypes] WHERE Name = N'DCF-UserBanned') 
-INSERT INTO {databaseOwner}[{objectQualifier}CoreMessaging_NotificationTypes] (
-  [Name],
-  [Description],
-  [TTL],
-  [DesktopModuleID])
-VALUES (
-  N'DCF-UserBanned',
-  N'DCF-UserBanned',
-  -1,
-  NULL)
-GO
-
-/* issue 721 - minor enhancements to banning user */
-
-
-/* --------------------- */


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Notifications when banning user:
- Adds entry to admin log
- Sends notifications to forum moderators

## Changes made
- New core message notification type DCF-UserBanned
- New resource strings
- Send notifications when banning user

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
local install

Banning user:
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/4e05e047-dc2d-4f59-8b26-1b75f58e39fe)

Notifications sent:
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/50cbfeab-443f-4bcb-a675-dd826b0de13b)

Admin log:
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/a1957e83-440a-483f-8093-e37dd89f9c8d)

## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #721