### PR TITLE
BUG: Exclude Themes\**\custom\*.css from install package

### DIFF
--- a/Dnn.CommunityForums/BuildScripts/ModulePackage.targets
+++ b/Dnn.CommunityForums/BuildScripts/ModulePackage.targets
@@ -35,7 +35,7 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       <InstallInclude Include="**\*.ascx" Exclude="packages\**;**\node_modules\**;clientApp\**;**\WhatsNew.ascx;**\WhatsNewOptions.ascx;**\ActiveForumViewer.ascx;.git\**;.vs\**;**\ActiveForumViewerSettings.ascx;themes\_legacy\templates\_Master.ascx" />
       <InstallInclude Include="**\*.asmx" Exclude="packages\**;**\node_modules\**;clientApp\**;.git\**;.vs\**" />
       <InstallInclude Include="**\*.ashx" Exclude="packages\**;**\node_modules\**;clientApp\**;.git\**;.vs\**" />
-      <InstallInclude Include="**\*.css" Exclude="packages\**;**\node_modules\**;clientApp\**;.git\**;.vs\**" />
+      <InstallInclude Include="**\*.css" Exclude="packages\**;**\node_modules\**;clientApp\**;.git\**;.vs\**;themes\**\custom\*.css" />
       <InstallInclude Include="**\*.html" Exclude="packages\**;**\node_modules\**;clientApp\**;.git\**;.vs\**" />
       <InstallInclude Include="**\*.htm" Exclude="packages\**;**\node_modules\**;clientApp\**;UpgradeLog*.htm;.git\**;.vs\**" />
       <InstallInclude Include="**\*.resx" Exclude="packages\**;**\node_modules\**;clientApp\**;.git\**;.vs\**" />


### PR DESCRIPTION
With this fix custom.css files will not be overwritten any longer on upgrade

### Description of PR...
Exclude Themes\**\custom\*.css from install package

## How did you test these updates?  
Local install

## PR Template Checklist

- [x] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #729