### PR TITLE
FIX: null value for portalSettings from search crawler

### DIFF
--- a/Dnn.CommunityForums/class/Utilities.cs
+++ b/Dnn.CommunityForums/class/Utilities.cs
@@ -31,11 +31,13 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Web;
 using System.Web.UI.WebControls;
+using DotNetNuke.Abstractions.Portals;
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Tabs;
 using DotNetNuke.Entities.Users;
 using DotNetNuke.Framework;
 using DotNetNuke.Modules.ActiveForums.Controls;
+using DotNetNuke.Modules.ActiveForums.Queue;
 using DotNetNuke.Security.Roles;
 
 namespace DotNetNuke.Modules.ActiveForums
@@ -324,7 +326,13 @@ HttpUtility.HtmlEncode(searchUrl), HttpUtility.HtmlEncode(advancedSearchUrl), se
         }
         public static string NavigateURL(int tabId, string controlKey, params string[] additionalParameters)
         {
-            return new DotNetNuke.Modules.ActiveForums.Services.URLNavigator().NavigateURL(tabId, controlKey, additionalParameters);
+            var ti = DotNetNuke.Entities.Tabs.TabController.Instance.GetTab(tabId, -1, false);
+            DotNetNuke.Abstractions.Portals.IPortalSettings portalSettings = DotNetNuke.Modules.ActiveForums.Utilities.GetPortalSettings(ti.PortalID);
+            return Utilities.NavigateURL(tabId, portalSettings, controlKey, additionalParameters);
+        }
+        public static string NavigateURL(int tabId, DotNetNuke.Abstractions.Portals.IPortalSettings portalSettings, string controlKey, params string[] additionalParameters)
+        {
+            return new DotNetNuke.Modules.ActiveForums.Services.URLNavigator().NavigateURL(tabId, portalSettings, controlKey, additionalParameters);
         }
         public static string NavigateURL(int tabId, string controlKey, string pageName, int portalId, params string[] additionalParameters)
         {

--- a/Dnn.CommunityForums/components/Controls/ControlUtils.cs
+++ b/Dnn.CommunityForums/components/Controls/ControlUtils.cs
@@ -82,7 +82,7 @@ namespace DotNetNuke.Modules.ActiveForums
         public string BuildUrl(int tabId, int moduleId, string groupPrefix, string forumPrefix, int forumGroupId, int forumID, int topicId, string topicURL, int tagId, int categoryId, string otherPrefix, int pageId, int contentId, int socialGroupId)
         {
             var mainSettings = SettingsBase.GetModuleSettings(moduleId);
-
+            DotNetNuke.Abstractions.Portals.IPortalSettings portalSettings = Utilities.GetPortalSettings(DotNetNuke.Entities.Modules.ModuleController.Instance.GetModule(moduleId, tabId, true).PortalID);
             var @params = new List<string>();
 
             if (!mainSettings.URLRewriteEnabled || (((string.IsNullOrEmpty(forumPrefix) && forumID > 0 && string.IsNullOrEmpty(groupPrefix)) || (string.IsNullOrEmpty(forumPrefix) && string.IsNullOrEmpty(groupPrefix) && forumGroupId > 0)) && string.IsNullOrEmpty(otherPrefix)))
@@ -122,7 +122,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
                     @params.Add($"{Literals.GroupId}=" + socialGroupId);
 
-                return Utilities.NavigateURL(tabId, string.Empty, @params.ToArray());
+                return Utilities.NavigateURL(tabId, portalSettings, string.Empty, @params.ToArray());
             }
 
 
@@ -149,12 +149,12 @@ namespace DotNetNuke.Modules.ActiveForums
                 sURL += "/" + mainSettings.PrefixURLOther + "/" + otherPrefix;
 
             if (topicId > 0 && string.IsNullOrEmpty(topicURL))
-                return Utilities.NavigateURL(tabId, string.Empty, ParamKeys.TopicId + "=" + topicId);
+                return Utilities.NavigateURL(tabId, portalSettings, string.Empty, ParamKeys.TopicId + "=" + topicId);
 
             if (pageId > 1)
             {
                 if (string.IsNullOrEmpty(sURL))
-                    return Utilities.NavigateURL(tabId, string.Empty, ParamKeys.PageId + "=" + pageId);
+                    return Utilities.NavigateURL(tabId, portalSettings,string.Empty, ParamKeys.PageId + "=" + pageId);
 
                 sURL += "/" + pageId.ToString();
             }


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Admin log indicating null value for portalSettings from search crawler.

Search crawler runs outside of UI, and internally the DNN navigation manager NavigateURL() API uses PortalController.GetCurrentSettings() if PortalSettings not passed; update to call NavigateURL() with PortalSettings

## Changes made
- added method to internal URL builder to accept PortalSettings
- changed URL builder logic to lookup and pass PortalSettings

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #754