### PR TITLE
ENH: changes to subscription options

### DIFF
--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.resx
@@ -657,18 +657,6 @@
   <data name="[RESX:Preview].Text" xml:space="preserve">
     <value>Preview</value>
   </data>
-  <data name="[RESX:ForumSubscribe:FALSE].Text" xml:space="preserve">
-    <value>Subscribe to this forum</value>
-  </data>
-  <data name="[RESX:ForumSubscribe:TRUE].Text" xml:space="preserve">
-    <value>Unsubscribe from forum</value>
-  </data>
-  <data name="[RESX:TopicSubscribe:FALSE].Text" xml:space="preserve">
-    <value>Subscribe to this topic</value>
-  </data>
-  <data name="[RESX:TopicSubscribe:TRUE].Text" xml:space="preserve">
-    <value>Unsubscribe from topic</value>
-  </data>
   <data name="[RESX:Avatar].Text" xml:space="preserve">
     <value>Avatar</value>
   </data>

--- a/Dnn.CommunityForums/CustomControls/UserControls/ForumView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/ForumView.cs
@@ -425,7 +425,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 if (canSubscribe)
                 {
                     bool IsSubscribed = new DotNetNuke.Modules.ActiveForums.Controllers.SubscriptionController().Subscribed(PortalId, ForumModuleId, UserId, ForumId);
-                    string sAlt = "[RESX:ForumSubscribe:" + IsSubscribed.ToString().ToUpper() + "]";
+                    string sAlt = "[RESX:Subscribe]";
                     string sImg = ThemePath + "images/email_unchecked.png";
                     if (IsSubscribed)
                     {
@@ -436,7 +436,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     subControl.DisplayMode = 1;
                     subControl.UserId = CurrentUserId;
                     subControl.ImageURL = sImg;
-                    subControl.Text = "[RESX:ForumSubscribe:" + IsSubscribed.ToString().ToUpper() + "]";
+                    subControl.Text = "[RESX:Subscribe]";
 
                     Template = Template.Replace("[AF:CONTROL:TOGGLESUBSCRIBE]", subControl.Render());
                 }

--- a/Dnn.CommunityForums/CustomControls/UserControls/SubmitForm.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/SubmitForm.cs
@@ -710,18 +710,18 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 bHasOptions = true;
             }
 
-            if (canSubscribe)
+            if (canSubscribe && !UserPrefTopicSubscribe) /* if user has preference set for auto subscribe, no need to show them the subscribe option */
             {
                 if (TopicId > 0)
                 {
                     var subControl = new ToggleSubscribe(ForumModuleId, ForumInfo.ForumID, TopicId, 1);
                     subControl.Checked = (new DotNetNuke.Modules.ActiveForums.Controllers.SubscriptionController().Subscribed(PortalId, ForumModuleId, UserId, ForumInfo.ForumID, TopicId));
-                    subControl.Text = "[RESX:TopicSubscribe:" + (new DotNetNuke.Modules.ActiveForums.Controllers.SubscriptionController().Subscribed(PortalId, ForumModuleId, UserId, ForumInfo.ForumID, TopicId)).ToString().ToUpper() + "]";
+                    subControl.Text = "[RESX:Subscribe]";
                     sb.Append("<tr><td colspan=\"2\">" + subControl.Render() + "</td></tr>");
                 }
                 else
                 {
-                    sb.Append("<tr><td colspan=\"2\"><asp:checkbox id=\"chkSubscribe\" Text=\"[RESX:TopicSubscribe:FALSE]\" TextAlign=\"right\" cssclass=\"afcheckbox\" runat=\"server\" /></td></tr>");
+                    sb.Append("<tr><td colspan=\"2\"><asp:checkbox id=\"chkSubscribe\" Text=\"[RESX:Subscribe]\" TextAlign=\"right\" cssclass=\"afcheckbox\" runat=\"server\" /></td></tr>");
                 }
                 bHasOptions = true;
             }

--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
@@ -888,7 +888,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             {
                 var subControl = new ToggleSubscribe(ForumModuleId, ForumId, TopicId, 1);
                 subControl.Checked = _isSubscribedTopic;
-                subControl.Text = "[RESX:TopicSubscribe:" + _isSubscribedTopic.ToString().ToUpper() + "]";
+                subControl.Text = "[RESX:Subscribe]";
                 sbOutput.Replace("[TOPICSUBSCRIBE]", subControl.Render());
             }
             else

--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicsView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicsView.cs
@@ -523,7 +523,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             {
                 Controls.ToggleSubscribe subControl = new Controls.ToggleSubscribe(ForumModuleId, ForumId, -1, 0);
                 subControl.Checked = IsSubscribedForum;
-                subControl.Text = "[RESX:ForumSubscribe:" + IsSubscribedForum.ToString().ToUpper() + "]";
+                subControl.Text = "[RESX:Subscribe]";
                 sOutput = sOutput.Replace("[FORUMSUBSCRIBE]", subControl.Render());
             }
             else

--- a/Dnn.CommunityForums/controls/af_quickreply.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_quickreply.ascx.cs
@@ -93,11 +93,12 @@ namespace DotNetNuke.Modules.ActiveForums
                 }
                 btnToolBar.Visible = UseFilter;
                 divSubscribe.Visible = AllowSubscribe;
-                if (AllowSubscribe)
+                divSubscribe.Visible = !UserPrefTopicSubscribe; /* if user has preference set for auto subscribe, no need to show them the subscribe option */
+                if (divSubscribe.Visible)
                 {
                     var subControl = new ToggleSubscribe(ForumModuleId, ForumId, TopicId, 1);
                     subControl.Checked = new DotNetNuke.Modules.ActiveForums.Controllers.SubscriptionController().Subscribed(PortalId, ForumModuleId, UserId, ForumId, TopicId);
-                    subControl.Text = "[RESX:TopicSubscribe:" + (new DotNetNuke.Modules.ActiveForums.Controllers.SubscriptionController().Subscribed(PortalId, ForumModuleId, UserId, ForumId, TopicId)).ToString().ToUpper() + "]";
+                    subControl.Text = "[RESX:Subscribe]";
                     divSubscribe.InnerHtml = subControl.Render();
                 }
                 if (Utilities.InputIsValid(Request.Form["txtBody"]) && Request.IsAuthenticated & ((!(string.IsNullOrEmpty(Request.Form["hidReply1"])) && string.IsNullOrEmpty(Request.Form["hidReply2"])) | Request.Browser.IsMobileDevice))

--- a/Dnn.CommunityForums/controls/af_subscribe.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_subscribe.ascx.cs
@@ -46,15 +46,7 @@ namespace DotNetNuke.Modules.ActiveForums
 		{
 			base.OnLoad(e);
 
-            string SubscribeText = null;
-            if (mode == 0)
-            {
-                SubscribeText = GetSharedResource("[RESX:ForumSubscribe:" + IsSubscribed.ToString().ToUpper() + "]");
-            }
-            else
-            {
-                SubscribeText = GetSharedResource("[RESX:TopicSubscribe:" + IsSubscribed.ToString().ToUpper() + "]");
-            }
+            string SubscribeText = GetSharedResource("[RESX:Subscribe]");
             chkSubscribe.Text = SubscribeText;
             chkSubscribe.Checked = IsSubscribed;
             if (UseAjax)
@@ -98,16 +90,8 @@ namespace DotNetNuke.Modules.ActiveForums
                 IsSubscribed = false;
             }
             chkSubscribe.Checked = IsSubscribed;
-            if (mode == 0)
-            {
-                chkSubscribe.Text = GetSharedResource("[RESX:ForumSubscribe:" + IsSubscribed.ToString().ToUpper() + "]");
-            }
-            else
-            {
-                chkSubscribe.Text = GetSharedResource("[RESX:TopicSubscribe:" + IsSubscribed.ToString().ToUpper() + "]");
-            }
-
-
+            chkSubscribe.Text = GetSharedResource("[RESX:Subscribe]");
+            
         }
         #endregion
     }

--- a/Dnn.CommunityForums/scripts/afcommon.js
+++ b/Dnn.CommunityForums/scripts/afcommon.js
@@ -97,8 +97,7 @@ function amaf_topicSubscribe(mid, fid, tid) {
         }).done(function (data) {
             amaf_UpdateTopicSubscriberCount(mid, fid, tid);
             $('input[type=checkbox].amaf-chk-subs')
-                .prop('checked', data)
-                .siblings('label[for=amaf-chk-subs]').html(data ? amaf.resx.TopicSubscribeTrue : amaf.resx.TopicSubscribeFalse);
+                .prop('checked', data);
         }).fail(function (xhr, status) {
             alert('error subscribing to topic');
         });
@@ -134,8 +133,7 @@ function amaf_forumSubscribe(mid, fid) {
     }).done(function (data) {
         amaf_UpdateForumSubscriberCount(mid, fid);
         $('input[type=checkbox].amaf-chk-subs')
-            .prop('checked', data)
-            .siblings('label[for=amaf-chk-subs]').html(data ? amaf.resx.ForumSubscribeTrue : amaf.resx.ForumSubscribeFalse);
+            .prop('checked', data);
         $('img#amaf-sub-' + fid).each(function () {
             var imgSrc = $(this).attr('src');
             if (data) {

--- a/Dnn.CommunityForums/scripts/resx.js
+++ b/Dnn.CommunityForums/scripts/resx.js
@@ -13,11 +13,7 @@ amaf.resx = {
     PinConfirm: '[RESX:Confirm:Pin]',
     UnPinConfim: '[RESX:Confirm:UnPin]',
     LockConfirm: '[RESX:Confirm:Lock]',
-    UnLockConfirm: '[RESX:Confirm:UnLock]',
-    TopicSubscribeTrue: '[RESX:TopicSubscribe:TRUE]',
-    TopicSubscribeFalse: '[RESX:TopicSubscribe:FALSE]',
-    ForumSubscribeTrue: '[RESX:ForumSubscribe:TRUE]',
-    ForumSubscribeFalse: '[RESX:ForumSubscribe:FALSE]'
+    UnLockConfirm: '[RESX:Confirm:UnLock]'
 };
 
 


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Minor UI changes for topic/forum subscriptions

## Changes made
- Changes 'subscribe/unsubscribe' to simply be 'subscribe' as the checkbox itself is the state 
- When a user has "subscribe" user preference checked, hide topic/reply subscription option since user will always be subscribed.

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #753