### PR TITLE
Remove MAILQUEUE module setting (no longer used)

### DIFF
--- a/Dnn.CommunityForums/ForumSettings.ascx
+++ b/Dnn.CommunityForums/ForumSettings.ascx
@@ -214,13 +214,6 @@
                 <asp:Literal ID="ltrFullTextMessage" runat="server" />
             </span>
 		</div>
-		  <div class="dnnFormItem">
-			<dnn:label ID="lblMailQueue" runat="server" resourcekey="MailQueue" Suffix=":" />
-			<asp:RadioButtonList ID="rdMailQueue" RepeatDirection="Horizontal" runat="server">
-				<asp:ListItem Value="True" resourcekey="Yes" />
-				<asp:ListItem Value="False" resourcekey="No" />
-			</asp:RadioButtonList>
-		</div>  
 		<div class="dnnFormItem">
 			<dnn:label ID="lblCacheTemplates" runat="server" resourcekey="CacheTemplates" Suffix=":" />
 			<asp:RadioButtonList ID="rdCacheTemplates" RepeatDirection="Horizontal" runat="server">

--- a/Dnn.CommunityForums/ForumSettings.ascx.cs
+++ b/Dnn.CommunityForums/ForumSettings.ascx.cs
@@ -145,13 +145,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
                     Utilities.SelectListItemByValue(rdFullTextSearch, FullTextSearch && FullTextStatus == 1); // 1 = Enabled Status
 
-                //rdFullTextSearch.SelectedIndex = FullTextSearch 
-                //    ? rdFullTextSearch.Items.IndexOf(rdFullTextSearch.Items.FindByValue("True"))
-                //    : rdFullTextSearch.Items.IndexOf(rdFullTextSearch.Items.FindByValue("False"));
-
-                Utilities.SelectListItemByValue(rdCacheTemplates, CacheTemplates);
-                Utilities.SelectListItemByValue(rdMailQueue, MailQueue);
-                Utilities.SelectListItemByValue(rdPoints, EnablePoints);
+    				Utilities.SelectListItemByValue(rdCacheTemplates, CacheTemplates);
+	                Utilities.SelectListItemByValue(rdPoints, EnablePoints);
                     Utilities.SelectListItemByValue(rdUsersOnline, EnableUsersOnline);
                     Utilities.SelectListItemByValue(rdUseSkinBreadCrumb, UseSkinBreadCrumb);
 
@@ -231,7 +226,6 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 }
 
                 FullTextSearch = Utilities.SafeConvertBool(rdFullTextSearch.SelectedValue);
-                MailQueue = Utilities.SafeConvertBool(rdMailQueue.SelectedValue);
                 CacheTemplates = Utilities.SafeConvertBool(rdCacheTemplates.SelectedValue);
 
                 MessagingType = Utilities.SafeConvertInt(drpMessagingType.SelectedValue);

--- a/Dnn.CommunityForums/ForumSettings.ascx.designer.cs
+++ b/Dnn.CommunityForums/ForumSettings.ascx.designer.cs
@@ -528,24 +528,6 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
         protected global::System.Web.UI.WebControls.Literal ltrFullTextMessage;
 
         /// <summary>
-        /// lblMailQueue control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.UserControl lblMailQueue;
-
-        /// <summary>
-        /// rdMailQueue control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.WebControls.RadioButtonList rdMailQueue;
-
-        /// <summary>
         /// lblCacheTemplates control.
         /// </summary>
         /// <remarks>

--- a/Dnn.CommunityForums/class/Globals.cs
+++ b/Dnn.CommunityForums/class/Globals.cs
@@ -193,6 +193,7 @@ namespace DotNetNuke.Modules.ActiveForums
 		public const string ForumTemplateId = "FORUMTEMPLATEID";
 		public const string DisableAccountTab = "DISABLEACCOUNTTAB";
 		public const string Theme = "THEME";
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
         public const string MailQueue = "MAILQUEUE";
         public const string FullText = "FULLTEXT";
 		public const string AllowSubTypes = "ALLOWSUBTYPES";

--- a/Dnn.CommunityForums/class/Settings.cs
+++ b/Dnn.CommunityForums/class/Settings.cs
@@ -181,10 +181,8 @@ namespace DotNetNuke.Modules.ActiveForums
         {
             get { return MainSettings.GetString(SettingKeys.AllowSubTypes, string.Empty); }
         }
-        public bool MailQueue
-        {
-            get { return MainSettings.GetBoolean(SettingKeys.MailQueue); }
-        }
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
+        public bool MailQueue => true;
         public bool CacheTemplates
         {
             get { return MainSettings.GetBoolean(SettingKeys.CacheTemplates, defaultValue: true); }

--- a/Dnn.CommunityForums/components/Common/ForumSettingsBase.cs
+++ b/Dnn.CommunityForums/components/Common/ForumSettingsBase.cs
@@ -17,6 +17,7 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 //
+using System;
 using DotNetNuke.Entities.Modules;
 
 namespace DotNetNuke.Modules.ActiveForums
@@ -311,17 +312,8 @@ namespace DotNetNuke.Modules.ActiveForums
             }
 		}
 
-        public bool MailQueue
-        {
-            get
-            {
-                return Settings.GetBoolean(SettingKeys.MailQueue);
-            }
-            set
-            {
-                UpdateModuleSettingCaseSensitive(SettingKeys.MailQueue, value.ToString());
-            }
-        }
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
+        public bool MailQueue => true;
         public bool CacheTemplates
         {
             get

--- a/Dnn.CommunityForums/components/Helpers/UpgradeModuleSettings.cs
+++ b/Dnn.CommunityForums/components/Helpers/UpgradeModuleSettings.cs
@@ -118,7 +118,7 @@ namespace DotNetNuke.Modules.ActiveForums.Helpers
         internal static void DeleteObsoleteModuleSettings_080100()
         {
 
-            /* remove TIMEZONEOFFSET and AMFORUMS */
+            /* remove TIMEZONEOFFSE, AMFORUMS, MAILQUEUE */
 
             foreach (DotNetNuke.Abstractions.Portals.IPortalInfo portal in DotNetNuke.Entities.Portals.PortalController.Instance.GetPortals())
             {
@@ -128,6 +128,7 @@ namespace DotNetNuke.Modules.ActiveForums.Helpers
                     {
                         DotNetNuke.Entities.Modules.ModuleController.Instance.DeleteModuleSetting(module.ModuleID, "TIMEZONEOFFSET");
                         DotNetNuke.Entities.Modules.ModuleController.Instance.DeleteModuleSetting(module.ModuleID, "AMFORUMS");
+                        DotNetNuke.Entities.Modules.ModuleController.Instance.DeleteModuleSetting(module.ModuleID, "MAILQUEUE");
                     }
                 }
             }


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
All email notifications now go through the mail queue, so remove MAILQUEUE module setting (no longer used).

## PR Template Checklist

- [ ] Fixes Bug
- [ ] Feature solution
- [X] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #635