### PR TITLE
FIX: Insert missing security option for social group in module settings

### DIFF
--- a/Dnn.CommunityForums/ForumSettings.ascx.cs
+++ b/Dnn.CommunityForums/ForumSettings.ascx.cs
@@ -69,8 +69,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 			{
 				rdEnableURLRewriter.SelectedIndex = 1;
 				rdEnableURLRewriter.Enabled = false;
-			}
-      var u = DotNetNuke.Entities.Users.UserController.Instance.GetCurrentUserInfo();
+            }
+            var u = DotNetNuke.Entities.Users.UserController.Instance.GetCurrentUserInfo();
       if (u.IsSuperUser & (HttpRuntime.IISVersion.Major >= 7) &!(PortalSettings.PortalAlias.HTTPAlias.Contains("/")))
 			{
 				if (Utilities.IsRewriteLoaded())

--- a/Dnn.CommunityForums/components/Common/ForumSettingsBase.cs
+++ b/Dnn.CommunityForums/components/Common/ForumSettingsBase.cs
@@ -28,22 +28,6 @@ namespace DotNetNuke.Modules.ActiveForums
         /// </summary>
         /// <param name="key"></param>
         /// <param name="newValue"></param>
-        private void UpdateTabModuleSettingCaseSensitive(string key, string newValue)
-        {
-            var oldValue = Settings.GetString(key);
-            if (oldValue != null && oldValue != newValue && oldValue.ToLowerInvariant() == newValue.ToLowerInvariant())
-            {
-                // changed but case-insensitive identical: empty the setting first
-                UpdateTabModuleSettingCaseSensitive(key, "");
-            }
-            DotNetNuke.Entities.Modules.ModuleController.Instance.UpdateTabModuleSetting(TabModuleId, key, newValue);
-        }
-
-        /// <summary>
-        /// This method is only needed because of an issue in DNN as of 8.0.4 where settings don't get updated if they are equal when compared case insensitively
-        /// </summary>
-        /// <param name="key"></param>
-        /// <param name="newValue"></param>
         private void UpdateModuleSettingCaseSensitive(string key, string newValue)
         {
             var oldValue = Settings.GetString(key);
@@ -63,7 +47,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				UpdateTabModuleSettingCaseSensitive(SettingKeys.Mode, value);
+                UpdateModuleSettingCaseSensitive(SettingKeys.Mode, value);
 			}
 		}
 
@@ -415,8 +399,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				//Use Tab Module Setting
-				UpdateTabModuleSettingCaseSensitive("ForumGroupTemplate", value.ToString());
+                UpdateModuleSettingCaseSensitive("ForumGroupTemplate", value.ToString());
 			}
 		}
 
@@ -428,7 +411,7 @@ namespace DotNetNuke.Modules.ActiveForums
 			}
 			set
 			{
-				UpdateTabModuleSettingCaseSensitive("ForumConfig", value);
+                UpdateModuleSettingCaseSensitive("ForumConfig", value);
 			}
 		}
 

--- a/Dnn.CommunityForums/components/Helpers/UpgradeModuleSettings.cs
+++ b/Dnn.CommunityForums/components/Helpers/UpgradeModuleSettings.cs
@@ -18,6 +18,10 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System.Reflection;
+using System.Web.UI;
+using System.Xml;
+using DotNetNuke.Common.Utilities;
 using DotNetNuke.Entities.Modules;
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Instrumentation;
@@ -128,6 +132,50 @@ namespace DotNetNuke.Modules.ActiveForums.Helpers
                     {
                         DotNetNuke.Entities.Modules.ModuleController.Instance.DeleteModuleSetting(module.ModuleID, "TIMEZONEOFFSET");
                         DotNetNuke.Entities.Modules.ModuleController.Instance.DeleteModuleSetting(module.ModuleID, "AMFORUMS");
+                    }
+                }
+            }
+        }
+        internal static void UpgradeSocialGroupForumConfigModuleSettings_080100()
+        {
+            foreach (DotNetNuke.Abstractions.Portals.IPortalInfo portal in DotNetNuke.Entities.Portals.PortalController.Instance.GetPortals())
+            {
+                foreach (ModuleInfo module in DotNetNuke.Entities.Modules.ModuleController.Instance.GetModules(portal.PortalId))
+                {
+                    if (module.DesktopModule.ModuleName.Trim().ToLowerInvariant() == Globals.ModuleName.ToLowerInvariant())
+                    {
+						/*remove four settings previously stored in both TabModuleSettings *and* ModuleSettings -- just store in ModuleSettings */
+                        DotNetNuke.Entities.Modules.ModuleController.Instance.DeleteTabModuleSetting(module.TabModuleID, "ForumConfig");
+                        DotNetNuke.Entities.Modules.ModuleController.Instance.DeleteTabModuleSetting(module.TabModuleID, "ForumGroupTemplate");
+                        DotNetNuke.Entities.Modules.ModuleController.Instance.DeleteTabModuleSetting(module.TabModuleID, "MODE");
+                        DotNetNuke.Entities.Modules.ModuleController.Instance.DeleteTabModuleSetting(module.TabModuleID, "AllowIndex");
+                        DataCache.ClearAllCacheForTabId(module.TabID);
+                        DataCache.ClearAllCache(module.ModuleID);
+                        var ForumConfig = module.ModuleSettings.GetString("ForumConfig", string.Empty);
+						if (!string.IsNullOrEmpty(ForumConfig))
+                        {
+                            var xDoc = new XmlDocument();
+                            xDoc.LoadXml(ForumConfig);
+							if (xDoc != null)
+							{
+								string[] secTypes = { "groupadmin", "groupmember", "registereduser", "anon" };
+								foreach (string secType in secTypes)
+								{
+									string xpath = $"//defaultforums/forum/security[@type='{secType}']";
+
+									if (xDoc.DocumentElement.SelectSingleNode(xpath).ChildNodes.Count == 16)
+									{
+                                        xDoc.DocumentElement.SelectSingleNode(xpath).AddElement("moduser", string.Empty);
+                                        xDoc.DocumentElement.SelectSingleNode(xpath).SelectSingleNode("moduser").AddAttribute("value", "false");
+                                    }
+								}
+								ForumConfig = xDoc.OuterXml;
+                                DotNetNuke.Entities.Modules.ModuleController.Instance.DeleteModuleSetting(module.ModuleID, "ForumConfig");
+                                DotNetNuke.Entities.Modules.ModuleController.Instance.UpdateModuleSetting(module.ModuleID, "ForumConfig", ForumConfig);
+								DataCache.ClearAllCacheForTabId(module.TabID);
+                                DataCache.ClearAllCache(module.ModuleID);
+                            }
+                        }
                     }
                 }
             }

--- a/Dnn.CommunityForums/components/Topics/TopicsController.cs
+++ b/Dnn.CommunityForums/components/Topics/TopicsController.cs
@@ -250,6 +250,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     try
                     {
                         DotNetNuke.Modules.ActiveForums.Helpers.UpgradeModuleSettings.DeleteObsoleteModuleSettings_080100();
+                        DotNetNuke.Modules.ActiveForums.Helpers.UpgradeModuleSettings.UpgradeSocialGroupForumConfigModuleSettings_080100();
                         ForumsConfig.Install_BanUser_NotificationType_080100();
                     }
                     catch (Exception ex)


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Inserts missing security option for social group in module settings.

## Changes made
- Added upgrade code to insert missing option 
- remove TabModuleSettings for 4 settings saved to both TabModuleSettings and ModuleSettings 

Note: module can only be on one tab; we have issue #531 to explore import/export, and #485 (explore Settings repository) if we need to move some settings to TabModuleSettings, but for now there is no need to have them in both.

## How did you test these updates?  
Local install w/ walking thru debugger

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #774