### PR TITLE
ENH: Show login link on TopicView page if unauthenticated rather than "you are not authorized"

### DIFF
--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.resx
@@ -171,6 +171,9 @@
   <data name="[RESX:NotAuthorized].Text" xml:space="preserve">
     <value>You must be logged in to post a reply.</value>
   </data>
+  <data name="[RESX:NotAuthorizedReplyPleaseLogin].Text" xml:space="preserve">
+    <value>Please &lt;a href="{0}"&gt;login&lt;/a&gt; to post a reply.</value>
+  </data>
   <data name="PostedDate.Text" xml:space="preserve">
     <value>Posted:</value>
   </data>

--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
@@ -48,10 +48,6 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
         #region Private Members
 
-        private string _metaTemplate = "[META][TITLE][TOPICSUBJECT] - [PORTALNAME] - [PAGENAME] - [GROUPNAME] - [FORUMNAME][/TITLE][DESCRIPTION][BODY:255][/DESCRIPTION][KEYWORDS][TAGS][VALUE][/KEYWORDS][/META]";
-        private string _metaTitle = string.Empty;
-        private string _metaDescription = string.Empty;
-        private string _metaKeywords = string.Empty;
         private string _forumName;
         private string _groupName;
         private int _topicTemplateId;
@@ -110,7 +106,6 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
         private int _editInterval;
         private string _tags = string.Empty;
         private string _topicURL = string.Empty;
-        private string _template = string.Empty;
         private string _topicData = string.Empty;
         private bool _useListActions;
 
@@ -118,64 +113,14 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
         #region Public Properties
 
-        public string TopicTemplate
-        {
-            get
-            {
-                return _template;
-            }
-            set
-            {
-                _template = value;
-            }
-        }
+        public string TopicTemplate { get; set; } = string.Empty;
 
         public int OptPageSize { get; set; }
         public string OptDefaultSort { get; set; }
-        public string MetaTemplate
-        {
-            get
-            {
-                return _metaTemplate;
-            }
-            set
-            {
-                _metaTemplate = value;
-            }
-        }
-        public string MetaTitle
-        {
-            get
-            {
-                return _metaTitle;
-            }
-            set
-            {
-                _metaTitle = value;
-            }
-        }
-        public string MetaDescription
-        {
-            get
-            {
-                return _metaDescription;
-            }
-            set
-            {
-                _metaDescription = value;
-            }
-        }
-        public string MetaKeywords
-        {
-            get
-            {
-                return _metaKeywords;
-            }
-            set
-            {
-                _metaKeywords = value;
-            }
-        }
+        public string MetaTemplate { get; set; } = "[META][TITLE][TOPICSUBJECT] - [PORTALNAME] - [PAGENAME] - [GROUPNAME] - [FORUMNAME][/TITLE][DESCRIPTION][BODY:255][/DESCRIPTION][KEYWORDS][TAGS][VALUE][/KEYWORDS][/META]";
+        public string MetaTitle { get; set; } = string.Empty;
+        public string MetaDescription { get; set; } = string.Empty;
+        public string MetaKeywords { get; set; } = string.Empty;
         #endregion
 
         #region Event Handlers
@@ -932,11 +877,19 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 }
                 else
                 {
-                    sbOutput.Replace("[ADDREPLY]", "<span class=\"afnormal\">[RESX:NotAuthorizedReply]</span>");
+                    if (!Request.IsAuthenticated)
+                    { 
+                        DotNetNuke.Abstractions.Portals.IPortalSettings PortalSettings = DotNetNuke.Modules.ActiveForums.Utilities.GetPortalSettings();
+                        string LoginUrl = PortalSettings.LoginTabId > 0 ? Utilities.NavigateURL(PortalSettings.LoginTabId, "", "returnUrl=" + Request.RawUrl) : Utilities.NavigateURL(TabId, "", "ctl=login&returnUrl=" + Request.RawUrl);
+                        sbOutput.Replace("[ADDREPLY]", $"<span class=\"dcf-auth-false-login\">{string.Format(Utilities.GetSharedResource("[RESX:NotAuthorizedReplyPleaseLogin]"), LoginUrl)}</span>");
+                    }
+                    else
+                    {
+                        sbOutput.Replace("[ADDREPLY]", "<span class=\"dcf-auth-false\">[RESX:NotAuthorizedReply]</span>");
+                    }
                     sbOutput.Replace("[QUICKREPLY]", string.Empty);
                 }
 
-                //TODO: Check for owner
             }
 
             if (_bModSplit && (_replyCount > 0))


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Show login link on TopicView page if unauthenticated rather than "you are not authorized"

## Changes made
- If unauthenticated, show link with message to login
- Add string resource to SharedResources: [RESX:NotAuthorizedReplyPleaseLogin]: 
`Please <a href="{0}">login</a> to post a reply.` where {0} is replaced with Portal's login URL.


## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install 
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/d3f1408a-8bd9-4dff-b9c7-1098ed53a6ed)

## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #781