### PR TITLE
FIX: LastPostId needs to be a calculated property in the ForumInfo entity

### DIFF
--- a/Dnn.CommunityForums/Entities/ForumInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumInfo.cs
@@ -48,8 +48,8 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         public bool Hidden { get; set; }
         public int TotalTopics { get; set; }
         public int TotalReplies { get; set; }
-        [ColumnName("LastPostId")]
-        public int LastPostID { get; set; }
+        [IgnoreColumn]
+        public int LastPostID => LastReplyId == 0 ? LastTopicId : LastReplyId;
         public string ForumSettingsKey { get; set; }
         public DateTime DateCreated { get; set; }
         public DateTime DateUpdated { get; set; }


### PR DESCRIPTION

<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
LastPostId is not updated in the database so needs to be a calculated property in the ForumInfo entity.
This was in the code prior to updating to use DAL2. 

## Changes made
- Change LastPostId to getter only and populate it

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
local install

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  

See related issue #792 to remove LastPostId from the activeforums_Forums table since it is not needed.