### PR TITLE
FIX: Issues with executing moderation actions from Activity Feed Notifications

### DIFF
--- a/Dnn.CommunityForums/Services/ModerationService.cs
+++ b/Dnn.CommunityForums/Services/ModerationService.cs
@@ -20,6 +20,7 @@
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Web.Http;
 using DotNetNuke.Modules.ActiveForums.Data;
 using DotNetNuke.Services.Social.Notifications;
 using DotNetNuke.Web.Api;
@@ -41,13 +42,14 @@ namespace DotNetNuke.Modules.ActiveForums
         // In both cases, it must return an 200 "OK" response.
 
         [DnnAuthorize]
+        [HttpPost]
         public HttpResponseMessage ApprovePost(ModerationDTO dto)
         {
             var notify = NotificationsController.Instance.GetNotification(dto.NotificationId);
 
             ParseNotificationContext(notify.Context);
 
-            var fi = new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().GetById(_forumId, ActiveModule.ModuleID);
+            var fi = new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().GetById(_forumId, _moduleId);
             if (fi == null)
                 return Request.CreateResponse(HttpStatusCode.OK, new { Message = "Forum Not Found" });
 
@@ -75,13 +77,14 @@ namespace DotNetNuke.Modules.ActiveForums
         }
 
         [DnnAuthorize]
+        [HttpPost]
         public HttpResponseMessage RejectPost(ModerationDTO dto)
         {
             var notify = NotificationsController.Instance.GetNotification(dto.NotificationId);
 
             ParseNotificationContext(notify.Context);
 
-            var fi = new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().GetById(_forumId, ActiveModule.ModuleID);
+            var fi = new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().GetById(_forumId, _moduleId);
             if (fi == null)
                 return Request.CreateResponse(HttpStatusCode.OK, new { Message = "Forum Not Found" });
 
@@ -137,12 +140,13 @@ namespace DotNetNuke.Modules.ActiveForums
         }
 
         [DnnAuthorize]
+        [HttpPost]
         public HttpResponseMessage DeletePost(ModerationDTO dto)
         {
             var notify = NotificationsController.Instance.GetNotification(dto.NotificationId);
             ParseNotificationContext(notify.Context);
 
-            var fi = new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().GetById(_forumId, ActiveModule.ModuleID);
+            var fi = new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().GetById(_forumId, _moduleId);
             if (fi == null)
                 return Request.CreateResponse(HttpStatusCode.OK, new { Message = "Forum Not Found" });
 
@@ -199,12 +203,13 @@ namespace DotNetNuke.Modules.ActiveForums
         }
 
         [DnnAuthorize]
+        [HttpPost]
         public HttpResponseMessage IgnorePost(ModerationDTO dto)
         {
             var notify = NotificationsController.Instance.GetNotification(dto.NotificationId);
             ParseNotificationContext(notify.Context);
 
-            var fi = new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().GetById(_forumId, ActiveModule.ModuleID);
+            var fi = new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().GetById(_forumId, _moduleId);
             if (fi == null)
                 return Request.CreateResponse(HttpStatusCode.OK, new { Message = "Forum Not Found" });
 
@@ -219,7 +224,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
         private bool IsMod(int forumId)
         {
-            var mods = Utilities.GetListOfModerators(ActiveModule.PortalID, ActiveModule.ModuleID, forumId);
+            var mods = Utilities.GetListOfModerators(ActiveModule.PortalID, _moduleId, forumId);
 
             return mods.Any(i => i.UserID == UserInfo.UserID);
         }


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Moderation actions initiated from an activity feed notification generated an error message.

## Changes made
- Add [HttpPost] to API methods
- use Module ID passed as part of the notification rather than ActiveModule.ModuleID

## How did you test these updates?  
Local install
![2024-05-10_16-35-18](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/6776e160-6f55-442e-96ee-e11df7ffa0c9)

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #798