### PR TITLE
FIX: Search Popup needs z-index

### DIFF
--- a/Dnn.CommunityForums/controls/profile_mypreferences.ascx
+++ b/Dnn.CommunityForums/controls/profile_mypreferences.ascx
@@ -3,7 +3,6 @@
 <%@ Register TagName="label" TagPrefix="dnn" Src="~/controls/labelcontrol.ascx" %>
 <style>
     .afpref{min-width:inherit !important}
-	.dcf-search-popup{z-index:9 !important;}
 </style>
 <h3 class="dcf-heading-3">
     <dnn:label id="lblHeader" cssclass="aftitlelg" runat="server" resourcekey="[RESX:MySettings]" />

--- a/Dnn.CommunityForums/module.css
+++ b/Dnn.CommunityForums/module.css
@@ -1502,3 +1502,8 @@ div.dcf-mod-edit-wrap {
 .dcf-split-checkbox-label {
 	margin-left:3px;
 }
+
+/* need z-index on search popup */
+.dnn-community-forums * .dcf-search-popup {
+	z-index: 9 !important;
+}


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Search popup not overlaying content. 

## Changes made
- Add z-index to module.css
- Removed z-index from profile_mypreferences since now in module.css

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install.
Before:
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/fb75510d-e38a-4525-a605-01dea7390f3d)

After:
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/b9820c32-ec10-4359-b68f-73d03eee323c)



## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #824