### PR TITLE
FIX: Show times correctly for daylight savings time

### DIFF
--- a/Dnn.CommunityForums/CustomControls/UserControls/WhatsNewRSS.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/WhatsNewRSS.cs
@@ -227,7 +227,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             // build channel
             var ps = DotNetNuke.Modules.ActiveForums.Utilities.GetPortalSettings();
 
-            var offSet = Convert.ToInt32(PortalSettings.Current.TimeZone.BaseUtcOffset.TotalMinutes);
+            var offSet = Convert.ToInt32(PortalSettings.Current.TimeZone.GetUtcOffset(DateTime.UtcNow).TotalMinutes);
 
             sb.Append(WriteElement("channel", indent));
             sb.Append(WriteElement("title", ps.PortalName, indent));

--- a/Dnn.CommunityForums/DnnCommunityForums.csproj
+++ b/Dnn.CommunityForums/DnnCommunityForums.csproj
@@ -1861,6 +1861,7 @@
     </Compile>
     <Compile Include="controls\af_quickjump.ascx.cs">
       <DependentUpon>af_quickjump.ascx</DependentUpon>
+      <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="controls\af_quickreply.ascx.designer.cs">
       <DependentUpon>af_quickreply.ascx</DependentUpon>

--- a/Dnn.CommunityForums/class/Utilities.cs
+++ b/Dnn.CommunityForums/class/Utilities.cs
@@ -884,13 +884,13 @@ namespace DotNetNuke.Modules.ActiveForums
         {
             CultureInfo userCultureInfo = GetCultureInfoForUser(portalId, userId);
             TimeZoneInfo userTimeZoneInfo = GetTimeZoneInfoForUser(portalId, userId);
-            return GetUserFormattedDateTime(dateTime, userCultureInfo, userTimeZoneInfo.BaseUtcOffset, format);
+            return GetUserFormattedDateTime(dateTime, userCultureInfo, userTimeZoneInfo.GetUtcOffset(dateTime), format);
         }
         public static string GetUserFormattedDateTime(DateTime dateTime, int portalId, int userId)
         {
             CultureInfo userCultureInfo = GetCultureInfoForUser(portalId, userId);
             TimeZoneInfo userTimeZoneInfo = GetTimeZoneInfoForUser(portalId, userId);
-            return GetUserFormattedDateTime(dateTime, userCultureInfo, userTimeZoneInfo.BaseUtcOffset);
+            return GetUserFormattedDateTime(dateTime, userCultureInfo, userTimeZoneInfo.GetUtcOffset(dateTime));
         }
         public static string GetUserFormattedDateTime(DateTime dateTime, CultureInfo userCultureInfo, TimeSpan timeZoneOffset)
         {
@@ -1005,7 +1005,7 @@ namespace DotNetNuke.Modules.ActiveForums
         }
         public static TimeSpan GetTimeZoneOffsetForUser(UserInfo userInfo)
         {
-            return GetTimeZoneInfoForUser(userInfo).BaseUtcOffset;
+            return GetTimeZoneInfoForUser(userInfo).GetUtcOffset(DateTime.UtcNow);
         }
         public static TimeSpan GetTimeZoneOffsetForUser(int PortalId, int UserId)
         {

--- a/Dnn.CommunityForums/feeds.aspx.cs
+++ b/Dnn.CommunityForums/feeds.aspx.cs
@@ -117,7 +117,7 @@ namespace DotNetNuke.Modules.ActiveForums
             DataSet ds = DataProvider.Instance().UI_TopicsView(PortalId, ModuleId, ForumID, ou.UserID, 0, 20, ou.IsSuperUser, SortColumns.ReplyCreated);
             if (ds.Tables.Count > 0)
             {
-                offSet = Convert.ToInt32(ps.TimeZone.BaseUtcOffset.TotalMinutes);
+                offSet = Convert.ToInt32( ps.TimeZone.GetUtcOffset(DateTime.UtcNow).TotalMinutes);
                 if (ds.Tables[0].Rows.Count == 0)
                 {
                     return string.Empty;


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Community Forums was changed in 7.0 to store everything in UTC but display based on user's preferred time zone (see PR #130). However, the display logic used .NET Framework [`TimeZoneInfo.BaseUtcOffset`](https://learn.microsoft.com/en-us/dotnet/api/system.timezoneinfo.baseutcoffset), which doesn't account for Daylight Savings Time. Times displayed in Community Forums are always off during Daylight Savings Time. This has been corrected.

## Changes made
- Use [`TimeZoneInfo.GetUtcOffSet()`](https://learn.microsoft.com/en-us/dotnet/api/system.timezoneinfo.getutcoffset) to calculate the offset rather than using `BaseUtcOffSet`


## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

Record stored in database in UTC
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/29df8f2e-0dd5-4542-9873-e08447195a2d)

Dates are displayed using user's preferred time zone:
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/d8bf744d-735e-4c61-9efc-23763340e869)

Before this change (uses `BaseUtcOffset` so using Eastern Standard Time)
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/8c760c14-4b0c-42b6-b71d-17154943ed0e)

After change (uses `GetUtcOffSet()` to _calculate_ Eastern Daylight Time vs Eastern Standard Time)
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/39197adc-fb08-4949-a885-a7d03651c61d)


## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #678