### PR TITLE
ENH: Reduce whitespace when not using topic properties or post icons

### DIFF
--- a/Dnn.CommunityForums/CustomControls/UserControls/SubmitForm.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/SubmitForm.cs
@@ -25,6 +25,7 @@ using System.Web;
 using System.Web.UI;
 using System.Web.UI.HtmlControls;
 using System.Web.UI.WebControls;
+using DotNetNuke.Modules.ActiveForums.Data;
 
 namespace DotNetNuke.Modules.ActiveForums.Controls
 {
@@ -423,7 +424,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 template = template.Replace("[/AF:UI:SECTION:TAGS]", "</td></tr></table>");
             }
             //Properties
-            if ((EditorMode == EditorModes.EditTopic || EditorMode == EditorModes.NewTopic) & ForumInfo.Properties != null)
+            if ((EditorMode == EditorModes.EditTopic || EditorMode == EditorModes.NewTopic) && (ForumInfo.Properties != null && ForumInfo.Properties.Count > 0))
             {
                 string pTemplate = TemplateUtils.GetTemplateSection(template, "[AF:PROPERTIES]", "[/AF:PROPERTIES]");
                 string propList = string.Empty;
@@ -535,9 +536,15 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     propList += tmp;
                 }
                 template = TemplateUtils.ReplaceSubSection(template, propList, "[AF:PROPERTIES]", "[/AF:PROPERTIES]");
+                /* tokens [AF:UI:SECTION:PROPERTIES][/AF:UI:SECTION:PROPERTIES] can now surround entire properties section to support removing entire section; if using properties, just remove the tokens*/
+                template = template.Replace("[AF:UI:SECTION:PROPERTIES]", string.Empty);
+                template = template.Replace("[/AF:UI:SECTION:PROPERTIES]", string.Empty);
             }
             else
             {
+                /* tokens [AF:UI:SECTION:POSTICONS][/AF:UI:SECTION:POSTICONS] can now surround entire properties section to support removing entire section if not using */
+                template = TemplateUtils.ReplaceSubSection(template, string.Empty, "[AF:UI:SECTION:PROPERTIES]", "[/AF:UI:SECTION:PROPERTIES]");
+                /* leave this for backward compatibility in cases where template doesn't yet have the [AF:UI:SECTION:PROPERTIES][/AF:UI:SECTION:PROPERTIES] tokens */
                 template = TemplateUtils.ReplaceSubSection(template, string.Empty, "[AF:PROPERTIES]", "[/AF:PROPERTIES]");
             }
             if ((EditorMode == EditorModes.EditTopic || EditorMode == EditorModes.NewTopic) && DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(ForumInfo.Security.Categorize, ForumUser.UserRoles))
@@ -572,7 +579,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             }
             else
             {
-                template = TemplateUtils.ReplaceSubSection(template, string.Empty, "[AF:UI:FIELDSET:POLL]", "[/AF:UI:FIELDSET:POLL]");
+                template = TemplateUtils.ReplaceSubSection(template, subTemplate: string.Empty, "[AF:UI:FIELDSET:POLL]", "[/AF:UI:FIELDSET:POLL]");
                 template = template.Replace("[AF:CONTROL:POLL]", string.Empty);
             }
             if (EditorMode == EditorModes.ReplyWithBody)
@@ -638,13 +645,20 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 template = template.Replace("[AF:UI:FIELDSET:POSTICONS]", "<fieldset class=\"affieldset\"><legend>[RESX:PostIcons]</legend><div class=\"affieldsetnote\">[RESX:PostIcons:Note]</div>");
                 template = template.Replace("[AF:CONTROL:POSTICONS]", "<af:posticons id=\"afposticons\" runat=\"server\" Theme=\"" + MainSettings.Theme + "\" />");
                 template = template.Replace("[/AF:UI:FIELDSET:POSTICONS]", "</fieldset>");
+                /* tokens [AF:UI:SECTION:POSTICONS][/AF:UI:SECTION:POSTICONS] can now surround post icons to support removing entire section; if using post icons, just remove the tokens*/
+                template = template.Replace("[AF:UI:SECTION:POSTICONS]", string.Empty);
+                template = template.Replace("[/AF:UI:SECTION:POSTICONS]", string.Empty);
 
             }
             else
             {
+                /* tokens [AF:UI:SECTION:POSTICONS][/AF:UI:SECTION:POSTICONS] can now surround post icons to remove entire section */
+                template = TemplateUtils.ReplaceSubSection(template, subTemplate: string.Empty, "[AF:UI:SECTION:POSTICONS]", "[/AF:UI:SECTION:POSTICONS]");
+                /* leave these 3 lines for backward compatibility in cases where template doesn't yet have the [AF:UI:SECTION:POSTICONS][/AF:UI:SECTION:POSTICONS] tokens */
                 template = template.Replace("[AF:UI:FIELDSET:POSTICONS]", string.Empty);
                 template = template.Replace("[AF:CONTROL:POSTICONS]", string.Empty);
-                template = template.Replace("[/AF:UI:FIELDSET:POSTICONS]", string.Empty);
+                template = template.Replace("[/AF:UI:FIELDSET:POSTICONS]", string.Empty); 
+
             }
             if (template.Contains("[AF:CONTROL:EMOTICONS]") && ForumInfo.AllowEmoticons)
             {
@@ -711,8 +725,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             }
 
             if (canSubscribe && !UserPrefTopicSubscribe) /* if user has preference set for auto subscribe, no need to show them the subscribe option */
-            {
-                if (TopicId > 0)
+                {
+                    if (TopicId > 0)
                 {
                     var subControl = new ToggleSubscribe(ForumModuleId, ForumInfo.ForumID, TopicId, 1);
                     subControl.Checked = (new DotNetNuke.Modules.ActiveForums.Controllers.SubscriptionController().Subscribed(PortalId, ForumModuleId, UserId, ForumInfo.ForumID, TopicId));

--- a/Dnn.CommunityForums/config/templates/TopicEditor.ascx
+++ b/Dnn.CommunityForums/config/templates/TopicEditor.ascx
@@ -43,14 +43,17 @@
 							</table>
 						</td>
 					</tr>
+                    [AF:UI:SECTION:POSTICONS]
 					<tr>
-						<td style="text-align:left;">
+                        <td style="text-align:left;">
 							[AF:UI:FIELDSET:POSTICONS]
 								[AF:CONTROL:POSTICONS]
 							[/AF:UI:FIELDSET:POSTICONS]
-						</td>
-						<td></td>
-					</tr>
+                        </td>
+                        <td></td>
+                    </tr>
+                    [/AF:UI:SECTION:POSTICONS]
+					[AF:UI:SECTION:PROPERTIES]
 					<tr>
 						<td colspan="2">
 							<table class="afprop-table">
@@ -66,6 +69,7 @@
 							</table>
 						</td>
 					</tr>
+                    [/AF:UI:SECTION:PROPERTIES]
 					<tr>
 						<td style="text-align:left;">[RESX:Summary]:</td>
 						<td></td>

--- a/Dnn.CommunityForums/themes/community-bootstrap/templates/TopicEditor.ascx
+++ b/Dnn.CommunityForums/themes/community-bootstrap/templates/TopicEditor.ascx
@@ -43,14 +43,17 @@
 							</table>
 						</td>
 					</tr>
+                    [AF:UI:SECTION:POSTICONS]
 					<tr>
-						<td style="text-align:left;">
+                        <td style="text-align:left;">
 							[AF:UI:FIELDSET:POSTICONS]
 								[AF:CONTROL:POSTICONS]
 							[/AF:UI:FIELDSET:POSTICONS]
-						</td>
-						<td></td>
-					</tr>
+                        </td>
+                        <td></td>
+                    </tr>
+                    [/AF:UI:SECTION:POSTICONS]
+					[AF:UI:SECTION:PROPERTIES]
 					<tr>
 						<td colspan="2">
 							<table class="afprop-table">
@@ -66,6 +69,7 @@
 							</table>
 						</td>
 					</tr>
+                    [/AF:UI:SECTION:PROPERTIES]
 					<tr>
 						<td style="text-align:left;">[RESX:Summary]:</td>
 						<td></td>

--- a/Dnn.CommunityForums/themes/community-default/templates/TopicEditor.ascx
+++ b/Dnn.CommunityForums/themes/community-default/templates/TopicEditor.ascx
@@ -43,6 +43,7 @@
 							</table>
 						</td>
 					</tr>
+                    [AF:UI:SECTION:POSTICONS]
 					<tr>
 						<td style="text-align:left;">
 							[AF:UI:FIELDSET:POSTICONS]
@@ -51,6 +52,8 @@
 						</td>
 						<td></td>
 					</tr>
+                    [/AF:UI:SECTION:POSTICONS]
+					[AF:UI:SECTION:PROPERTIES]
 					<tr>
 						<td colspan="2">
 							<table class="afprop-table">
@@ -66,6 +69,7 @@
 							</table>
 						</td>
 					</tr>
+                    [/AF:UI:SECTION:PROPERTIES]
 					<tr>
 						<td style="text-align:left;">[RESX:Summary]:</td>
 						<td></td>


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Extra whitespace is shown in topic editor when not using topic properties or topic/post icons.
This PR adds two new token pairs, updates shipping templates, and adds logic to reduce the whitespace

## Changes made
- Add tokens `[AF:UI:SECTION:POSTICONS]`, `[/AF:UI:SECTION:POSTICONS]`, `[AF:UI:SECTION:PROPERTIES]`, `[/AF:UI:SECTION:PROPERTIES]`
- Update TopicEditor.ascx templates in all themes shipped with Community Forums
- Add logic to remove sections when post icons or topic properties features are not used

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

Before:
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/431aafa5-fa75-4daf-8f3f-e0e6f4a4d0e5)

After:
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/e05b3ad5-eadc-48b6-a57c-5f961f57c549)

## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  
