### PR TITLE
FIX: Subscribe to all forums displaying resource key rather than text when you click on it

### DIFF
--- a/Dnn.CommunityForums/controls/profile_mysubscriptions.ascx
+++ b/Dnn.CommunityForums/controls/profile_mysubscriptions.ascx
@@ -4,7 +4,7 @@
     <span>[RESX:Subscriptions]</span>
 </h3>
 <div>
-    <asp:label>[RESX:ThreadsTracked]</asp:label>
+    <asp:label ID="lblThreadsTracked" runat="server">[RESX:ThreadsTracked]</asp:label>
     <asp:UpdatePanel ID="upOptions1" UpdateMode="Conditional" runat="server" ChildrenAsTriggers="True" >
         <contenttemplate>
         <asp:GridView ID="dgrdTopicSubs" AutoGenerateColumns="false" AllowPaging="true" PageSize="25"
@@ -33,7 +33,7 @@
             </asp:UpdatePanel>
     </div>
     <div>
-        <asp:label>[RESX:ForumsTracked]</asp:label>
+       <asp:Label ID="lblForumsTracked" runat="server">[RESX:ForumsTracked]</asp:Label>
        <asp:updatepanel id="UpdatePanel2" updatemode="Conditional" runat="server" childrenastriggers="True">
             <contenttemplate>
         <asp:GridView ID="dgrdForumSubs" AutoGenerateColumns="false" AllowPaging="true" PageSize="25"
@@ -58,9 +58,9 @@
                 <div>[RESX:NoSubscriptions]</div>
             </EmptyDataTemplate>
         </asp:GridView>
-        <div style="float: right;">
-            <asp:Button ID="btnSubscribeAll" CssClass="dnnPrimaryAction" runat="server" Text="[RESX:SubscribeAllForums]" />
-        </div>
         </ContentTemplate>
     </asp:UpdatePanel>
+    <div style="float: right;">
+        <asp:Button ID="btnSubscribeAll" CssClass="dnnPrimaryAction" runat="server" Text="[RESX:SubscribeAllForums]" />
+    </div>
 </div>

--- a/Dnn.CommunityForums/controls/profile_mysubscriptions.ascx.designer.cs
+++ b/Dnn.CommunityForums/controls/profile_mysubscriptions.ascx.designer.cs
@@ -15,6 +15,15 @@ namespace DotNetNuke.Modules.ActiveForums
     {
 
         /// <summary>
+        /// lblThreadsTracked control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Label lblThreadsTracked;
+
+        /// <summary>
         /// upOptions1 control.
         /// </summary>
         /// <remarks>
@@ -31,6 +40,15 @@ namespace DotNetNuke.Modules.ActiveForums
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.GridView dgrdTopicSubs;
+
+        /// <summary>
+        /// lblForumsTracked control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Label lblForumsTracked;
 
         /// <summary>
         /// UpdatePanel2 control.


### PR DESCRIPTION

<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
FIX: Subscribe to all forums displaying resource key rather than text when you click on it

## Changes made
- Subscribe button unnecessarily inside an update panel and not translated after AJAX update

## How did you test these updates?  
Local install

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #859