### PR TITLE
ENH: Change default avatar size (250x250 rather than 50x50)

### DIFF
--- a/Dnn.CommunityForums/config/defaultsetup.config
+++ b/Dnn.CommunityForums/config/defaultsetup.config
@@ -18,8 +18,8 @@
     <setting name="ALLOWSUBTYPES" value="0:1:" />
     <setting name="ALLOWAVATARS" value="true" />
     <setting name="ALLOWAVATARLINKS" value="false" />
-    <setting name="AVATARHEIGHT" value="50" />
-    <setting name="AVATARWIDTH" value="50" />
+    <setting name="AVATARHEIGHT" value="250" />
+    <setting name="AVATARWIDTH" value="250" />
     <setting name="ENABLEPOINTS" value="false" />
     <setting name="TOPICPOINTVALUE" value="1" />
     <setting name="REPLYPOINTVALUE" value="1" />


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...

Change default avatar size (250x250 rather than 50x50) for better resolution. 

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #888