### PR TITLE
FIX: Show graphic in poll in Community themes

### DIFF
--- a/Dnn.CommunityForums/module.css
+++ b/Dnn.CommunityForums/module.css
@@ -1545,3 +1545,13 @@ div.dcf-mod-edit-wrap {
 .dnn-community-forums * .dcf-topic-edit-summary {
 	width: 95% !important;
 }
+
+/* poll graphics removed from module.css and moved to _legacy/theme.css need to be put back */
+
+.afpollbar {
+	background-color: #ff0000;
+}
+
+.afpollresults {
+	border: solid 1px #333;
+}


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
In 08.00.00 release, module.css was cleaned up, and non-module-specific classes were moved to _legacy/theme.css. Two classes related to the poll graph need to remain in module.css--but can be overridden by a theme's CSS if desired.

## Changes made
- Add back CSS to module.css for polls

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/e71d2f49-bd77-41ef-8e8d-e4ba82199b4d)

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #890