### PR TITLE
FIX: Topic with poll results throws exception

### DIFF
--- a/Dnn.CommunityForums/themes/community-bootstrap/templates/TopicView.ascx
+++ b/Dnn.CommunityForums/themes/community-bootstrap/templates/TopicView.ascx
@@ -76,9 +76,6 @@
 							</header>
 							<section class="dcf-topic-content-main py-4">
 							
-								<div class="dcf-post-poll">
-									[AF:CONTROL:POLL]
-								</div>
 								<div class="dcf-post-body">
 									[BODY]
 								</div>

--- a/Dnn.CommunityForums/themes/community-default/templates/TopicView.ascx
+++ b/Dnn.CommunityForums/themes/community-default/templates/TopicView.ascx
@@ -138,9 +138,6 @@
 							</header>
 							<section class="dcf-topic-content-main">
 							
-								<div class="dcf-post-poll">
-									[AF:CONTROL:POLL]
-								</div>
 								<div class="dcf-post-body">
 									[BODY]
 								</div>


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
The poll control was included in the `[REPLIES]` section of `TopicView.ascx` template and should only be in the `[TOPIC]` section. Since it was in both, the tag was duplicated, resulting in an exception.

## Changes made
- Remove `[AF:CONTROL:POLL]` from `[REPLIES]` section of `TopicView.ascx` template shipped with Community-Default and Community-Bootstrap themes.

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/25c4dfa8-cc6f-405e-8ba4-8b161befcd42)


## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #885