### PR TITLE
FIX: Replace hardcoded "Started by" text with resource string

### DIFF
--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.de-DE.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.de-DE.resx
@@ -1656,7 +1656,7 @@ Von
   <data name="Started.Text" xml:space="preserve">
     <value>Gestartet</value>
   </data>
-  <data name="StartedHeader.Text" xml:space="preserve">
+  <data name="[RESX:StartedHeader].Text" xml:space="preserve">
     <value>Gestartet von</value>
   </data>
   <data name="Stats.LastCreated.Text" xml:space="preserve">

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.es-ES.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.es-ES.resx
@@ -1659,7 +1659,7 @@ De
   <data name="Started.Text" xml:space="preserve">
     <value>Comenzó</value>
   </data>
-  <data name="StartedHeader.Text" xml:space="preserve">
+  <data name="[RESX:StartedHeader].Text" xml:space="preserve">
     <value>Iniciado por</value>
   </data>
   <data name="Stats.LastCreated.Text" xml:space="preserve">

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.fr-FR.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.fr-FR.resx
@@ -1569,7 +1569,7 @@ De,
   <data name="Started.Text" xml:space="preserve" lastModified="2024-06-10 14:06:42">
     <value>Commencé</value>
   </data>
-  <data name="StartedHeader.Text" xml:space="preserve" lastModified="2024-06-10 14:06:42">
+  <data name="[RESX:StartedHeader].Text" xml:space="preserve" lastModified="2024-06-10 14:06:42">
     <value>Commencé par</value>
   </data>
   <data name="Stats.LastCreated.Text" xml:space="preserve" lastModified="2024-06-10 14:06:42">

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.it-IT.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.it-IT.resx
@@ -1654,7 +1654,7 @@ Da
   <data name="Started.Text" xml:space="preserve">
     <value>Avviato</value>
   </data>
-  <data name="StartedHeader.Text" xml:space="preserve">
+  <data name="[RESX:StartedHeader].Text" xml:space="preserve">
     <value>Iniziato da</value>
   </data>
   <data name="Stats.LastCreated.Text" xml:space="preserve">

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.nl-NL.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.nl-NL.resx
@@ -1696,7 +1696,7 @@ Van,
   <data name="Started.Text" xml:space="preserve">
     <value>Begonnen</value>
   </data>
-  <data name="StartedHeader.Text" xml:space="preserve">
+  <data name="[RESX:StartedHeader].Text" xml:space="preserve">
     <value>Gestart op</value>
   </data>
   <data name="Stats.LastCreated.Text" xml:space="preserve">

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.resx
@@ -150,7 +150,7 @@
   <data name="[RESX:Views].Text" xml:space="preserve">
     <value>Views</value>
   </data>
-  <data name="StartedHeader.Text" xml:space="preserve">
+  <data name="[RESX:StartedHeader].Text" xml:space="preserve">
     <value>Started By</value>
   </data>
   <data name="[RESX:SubPages].Text" xml:space="preserve">

--- a/Dnn.CommunityForums/DnnCommunityForums.csproj
+++ b/Dnn.CommunityForums/DnnCommunityForums.csproj
@@ -281,17 +281,23 @@
     <EmbeddedResource Include="App_LocalResources\ControlPanel.ascx.nl-NL.resx" />
     <EmbeddedResource Include="App_LocalResources\ForumSettings.ascx.nl-NL.resx" />
     <EmbeddedResource Include="App_LocalResources\Messages.ascx.nl-NL.resx" />
-    <EmbeddedResource Include="App_LocalResources\SharedResources.nl-NL.resx" />
+    <EmbeddedResource Include="App_LocalResources\SharedResources.nl-NL.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="App_LocalResources\WhatsNew.ascx.nl-NL.resx" />
     <EmbeddedResource Include="App_LocalResources\ControlPanel.ascx.it-IT.resx" />
     <EmbeddedResource Include="App_LocalResources\ForumSettings.ascx.it-IT.resx" />
     <EmbeddedResource Include="App_LocalResources\Messages.ascx.it-IT.resx" />
-    <EmbeddedResource Include="App_LocalResources\SharedResources.it-IT.resx" />
+    <EmbeddedResource Include="App_LocalResources\SharedResources.it-IT.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="App_LocalResources\WhatsNew.ascx.it-IT.resx" />
     <EmbeddedResource Include="App_LocalResources\ControlPanel.ascx.es-ES.resx" />
     <EmbeddedResource Include="App_LocalResources\ForumSettings.ascx.es-ES.resx" />
     <EmbeddedResource Include="App_LocalResources\Messages.ascx.es-ES.resx" />
-    <EmbeddedResource Include="App_LocalResources\SharedResources.es-ES.resx" />
+    <EmbeddedResource Include="App_LocalResources\SharedResources.es-ES.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="App_LocalResources\WhatsNew.ascx.es-ES.resx" />
     <EmbeddedResource Include="App_LocalResources\ControlPanel.ascx.de-DE.resx" />
     <EmbeddedResource Include="App_LocalResources\ForumSettings.ascx.de-DE.resx" />

--- a/Dnn.CommunityForums/config/templates/TopicsView.ascx
+++ b/Dnn.CommunityForums/config/templates/TopicsView.ascx
@@ -97,7 +97,7 @@
 										
 										<span class="afhiddenstats">[REPLIES] [RESX:REPLIESHEADER] and [VIEWS] [RESX:Views] and [TOPICSUBSCRIBERCOUNT] [RESX:SUBSCRIBERS]</span>
 										<span class="aftopictitle"><i class="fa fa-file-o fa-fw fa-grey"></i>&nbsp;[SUBJECTLINK][AF:ICONLINK:LASTREAD]</span> 
-										<span class="aftopicstarted">Started by <i class="fa fa-user fa-fw fa-blue"></i>&nbsp;[STARTEDBY][AF:UI:MINIPAGER]</span>
+										<span class="aftopicstarted">[RESX:StartedHeader] <i class="fa fa-user fa-fw fa-blue"></i>&nbsp;[STARTEDBY][AF:UI:MINIPAGER]</span>
 										
 										
 										<span class="aftopictools">
@@ -173,7 +173,7 @@
 												<i class="fa fa-reply fa-fw fa-grey"></i>&nbsp;[REPLIES]
 												<i class="fa fa-envelope-o fa-fw fa-grey"></i>&nbsp;[TOPICSUBSCRIBERCOUNT]
 											</span>
-											<span class="aftopicstarted">Started by <i class="fa fa-user fa-fw fa-blue"></i>&nbsp;[STARTEDBY][AF:UI:MINIPAGER]</span>
+											<span class="aftopicstarted">[RESX:StartedHeader] <i class="fa fa-user fa-fw fa-blue"></i>&nbsp;[STARTEDBY][AF:UI:MINIPAGER]</span>
 											
 											
 											<span class="aftopictools">

--- a/Dnn.CommunityForums/themes/community-bootstrap/templates/TopicsView.ascx
+++ b/Dnn.CommunityForums/themes/community-bootstrap/templates/TopicsView.ascx
@@ -65,7 +65,7 @@
 								<td class="dcf-col dcf-col-subject w-100" title="[BODYTITLE]">
 									<div class="dcf-subject">
 										<h4 class="dcf-title h5 mt-0 mb-2">[SUBJECTLINK][AF:ICONLINK:LASTREAD]</h4>
-										<div class="dcf-topic-started">Started by
+										<div class="dcf-topic-started">[RESX:StartedHeader]
 											<i class="fa fa-user fa-blue"></i>&nbsp;[STARTEDBY][AF:UI:MINIPAGER]
 										</div>
 										<div class="dcf-forum-description">[BODYTITLE]</div>
@@ -155,7 +155,7 @@
 								<td class="dcf-col dcf-col-subject">
 									<div class="dcf-subject" title="[BODYTITLE]">
 										<h4 class="dcf-title h5 mt-0 mb-2">[SUBJECTLINK][AF:ICONLINK:LASTREAD][ICONPIN][ICONLOCK]</h4>
-										<div class="dcf-topic-started">Started by
+										<div class="dcf-topic-started">[RESX:StartedHeader]
 											<i class="fa fa-user fa-blue"></i>&nbsp;[STARTEDBY][AF:UI:MINIPAGER]
 										</div>
 										<div class="dcf-topic-description">[BODYTITLE]</div>

--- a/Dnn.CommunityForums/themes/community-default/templates/TopicsView.ascx
+++ b/Dnn.CommunityForums/themes/community-default/templates/TopicsView.ascx
@@ -50,7 +50,7 @@
 							<td class="dcf-col dcf-col-subject" title="[BODYTITLE]">
 								<div class="dcf-subject">
 										<h4 class="dcf-title dcf-title-4">[SUBJECTLINK][AF:ICONLINK:LASTREAD]</h4>
-										<div class="dcf-topic-started">Started by <i class="fa fa-user fa-blue"></i>&nbsp;[STARTEDBY][AF:UI:MINIPAGER]</div>
+										<div class="dcf-topic-started">[RESX:StartedHeader] <i class="fa fa-user fa-blue"></i>&nbsp;[STARTEDBY][AF:UI:MINIPAGER]</div>
 
 									<div class="dcf-forum-description">[BODYTITLE]</div>
 
@@ -125,7 +125,7 @@
 
 							<h4 class="dcf-title dcf-title-4">[SUBJECTLINK][AF:ICONLINK:LASTREAD][ICONPIN][ICONLOCK]</h4>
 
-							<div class="dcf-topic-started">Started by <i class="fa fa-user fa-blue"></i>&nbsp;[STARTEDBY][AF:UI:MINIPAGER]</div>
+							<div class="dcf-topic-started">[RESX:StartedHeader] <i class="fa fa-user fa-blue"></i>&nbsp;[STARTEDBY][AF:UI:MINIPAGER]</div>
 
 							<div class="dcf-topic-description">[BODYTITLE]</div>
 


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Replace hardcoded "Started by" with resource string to support localization

## Changes made
- Renamed (unused) "StartedHeader" resource to [RESX:StartedHeader] (consistency)
- Updated templates

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/cd77e18d-e2b1-4396-9cda-290bbef20166)
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/f796dc02-0c61-4db1-b8cc-fa17333cb143)


## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #870