### PR TITLE
FIX: [DISPLAYNAME] not included in email notifications

### DIFF
--- a/Dnn.CommunityForums/CustomControls/HTML/TopicBrowser.cs
+++ b/Dnn.CommunityForums/CustomControls/HTML/TopicBrowser.cs
@@ -394,8 +394,9 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 				if (int.Parse(row["LastAuthorId"].ToString()) == -1)
 				{
 					try
-					{
-						tmp = tmp.Replace("[LASTAUTHOR]", UserProfiles.GetDisplayName(ModuleId, true, ForumUser.Profile.IsMod, ForumUser.IsAdmin || ForumUser.IsSuperUser, -1, auth.Username, auth.FirstName, auth.LastName, auth.DisplayName));
+                    {
+                        DotNetNuke.Entities.Portals.PortalSettings portalSettings = Utilities.GetPortalSettings(PortalId);
+                        tmp = tmp.Replace("[LASTAUTHOR]", UserProfiles.GetDisplayName(portalSettings, ModuleId, true, ForumUser.Profile.IsMod, ForumUser.IsAdmin || ForumUser.IsSuperUser, -1, auth.Username, auth.FirstName, auth.LastName, auth.DisplayName));
 					}
 					catch (Exception ex)
 					{
@@ -404,8 +405,9 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
 				}
 				else
-				{
-                    tmp = tmp.Replace("[LASTAUTHOR]", UserProfiles.GetDisplayName(ModuleId, true, ForumUser.Profile.IsMod, ForumUser.IsAdmin || ForumUser.IsSuperUser, int.Parse(row["LastAuthorId"].ToString()), auth.Username, auth.FirstName, auth.LastName, auth.DisplayName));
+                {
+                    DotNetNuke.Entities.Portals.PortalSettings portalSettings = Utilities.GetPortalSettings(PortalId);
+                    tmp = tmp.Replace("[LASTAUTHOR]", UserProfiles.GetDisplayName(portalSettings, ModuleId, true, ForumUser.Profile.IsMod, ForumUser.IsAdmin || ForumUser.IsSuperUser, int.Parse(row["LastAuthorId"].ToString()), auth.Username, auth.FirstName, auth.LastName, auth.DisplayName));
 				}
 
 				if (_canEdit)

--- a/Dnn.CommunityForums/CustomControls/UserControls/ForumView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/ForumView.cs
@@ -514,7 +514,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     {
                         bool isMod = CurrentUserType == CurrentUserTypes.Admin || CurrentUserType == CurrentUserTypes.ForumMod || CurrentUserType == CurrentUserTypes.SuperUser;
                         bool isAdmin = CurrentUserType == CurrentUserTypes.Admin || CurrentUserType == CurrentUserTypes.SuperUser;
-                        Template = Template.Replace("[DISPLAYNAME]", "<i class=\"fa fa-user fa-fw fa-blue\"></i>&nbsp;" + UserProfiles.GetDisplayName(ForumModuleId, true, isMod, isAdmin, fi.LastPostUserID, fi.LastPostUserName, fi.LastPostFirstName, fi.LastPostLastName, fi.LastPostDisplayName));
+                        Template = Template.Replace("[DISPLAYNAME]", "<i class=\"fa fa-user fa-fw fa-blue\"></i>&nbsp;" + UserProfiles.GetDisplayName(PortalSettings, ForumModuleId, true, isMod, isAdmin, fi.LastPostUserID, fi.LastPostUserName, fi.LastPostFirstName, fi.LastPostLastName, fi.LastPostDisplayName));
                     }
                     DateTime dtLastPostDate = fi.LastPostDateTime;
                     Template = Template.Replace("[LASTPOSTDATE]", Utilities.GetUserFormattedDateTime(dtLastPostDate,PortalId, CurrentUserId));

--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
@@ -991,12 +991,14 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             // View Count
             sbOutput.Replace("[VIEWCOUNT]", _viewCount.ToString());
 
+
+            DotNetNuke.Entities.Portals.PortalSettings portalSettings = Utilities.GetPortalSettings(PortalId);
             // Last Post
             sbOutput.Replace("[AF:LABEL:LastPostDate]", _lastPostDate);
-            sbOutput.Replace("[AF:LABEL:LastPostAuthor]", UserProfiles.GetDisplayName(ForumModuleId, true, _bModApprove, ForumUser.IsAdmin || ForumUser.IsSuperUser, _lastPostAuthor.AuthorId, _lastPostAuthor.Username, _lastPostAuthor.FirstName, _lastPostAuthor.LastName, _lastPostAuthor.DisplayName));
+            sbOutput.Replace("[AF:LABEL:LastPostAuthor]", UserProfiles.GetDisplayName(portalSettings, ForumModuleId, true, _bModApprove, ForumUser.IsAdmin || ForumUser.IsSuperUser, _lastPostAuthor.AuthorId, _lastPostAuthor.Username, _lastPostAuthor.FirstName, _lastPostAuthor.LastName, _lastPostAuthor.DisplayName));
 
             // Topic Info
-            sbOutput.Replace("[AF:LABEL:TopicAuthor]", UserProfiles.GetDisplayName(ForumModuleId, _topicAuthorId, _topicAuthorDisplayName, string.Empty, string.Empty, _topicAuthorDisplayName));
+            sbOutput.Replace("[AF:LABEL:TopicAuthor]", UserProfiles.GetDisplayName(portalSettings, ForumModuleId, false, false, false, _topicAuthorId, _topicAuthorDisplayName, string.Empty, string.Empty, _topicAuthorDisplayName));
             sbOutput.Replace("[AF:LABEL:TopicDateCreated]", _topicDateCreated);
 
 

--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicsView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicsView.cs
@@ -947,7 +947,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     sTopicsTemplate = sTopicsTemplate.Replace("[SUBJECT]", Subject + sPollImage);
                     sTopicsTemplate = sTopicsTemplate.Replace("[SUBJECTLINK]", GetTopic(TabId, ForumId, TopicId, Subject, sBodyTitle, UserId, AuthorId, ReplyCount, -1, sTopicURL) + sPollImage);
 
-                    var displayName = UserProfiles.GetDisplayName(ForumModuleId, true, bModApprove, ForumUser.IsAdmin || ForumUser.IsSuperUser, AuthorId, AuthorUserName, AuthorFirstName, AuthorLastName, AuthorDisplayName).ToString().Replace("&amp;#", "&#");
+                    var displayName = UserProfiles.GetDisplayName(PortalSettings, ForumModuleId, true, bModApprove, ForumUser.IsAdmin || ForumUser.IsSuperUser, AuthorId, AuthorUserName, AuthorFirstName, AuthorLastName, AuthorDisplayName).ToString().Replace("&amp;#", "&#");
                     if (Utilities.StripHTMLTag(displayName) == "Anonymous")
                     {
                         displayName = displayName.Replace("Anonymous", AuthorName);
@@ -1013,7 +1013,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                             //sLastReplyTemp = sLastReplyTemp.Replace("[RESX:BY]", Utilities.GetSharedResource("By.Text"))
                             if (LastReplyAuthorId > 0)
                             {
-                                sLastReplyTemp = sLastReplyTemp.Replace("[LASTPOSTDISPLAYNAME]", UserProfiles.GetDisplayName(ForumModuleId, true, bModApprove, ForumUser.IsAdmin || ForumUser.IsSuperUser, LastReplyAuthorId, LastReplyUserName, LastReplyFirstName, LastReplyLastName, LastReplyDisplayName).ToString().Replace("&amp;#", "&#"));
+                                sLastReplyTemp = sLastReplyTemp.Replace("[LASTPOSTDISPLAYNAME]", UserProfiles.GetDisplayName(PortalSettings, ForumModuleId, true, bModApprove, ForumUser.IsAdmin || ForumUser.IsSuperUser, LastReplyAuthorId, LastReplyUserName, LastReplyFirstName, LastReplyLastName, LastReplyDisplayName).ToString().Replace("&amp;#", "&#"));
                             }
                             else
                             {

--- a/Dnn.CommunityForums/DnnCommunityForums.csproj
+++ b/Dnn.CommunityForums/DnnCommunityForums.csproj
@@ -33,10 +33,14 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <SccProjectName>SAK</SccProjectName>
-    <SccLocalPath>SAK</SccLocalPath>
-    <SccAuxPath>SAK</SccAuxPath>
-    <SccProvider>SAK</SccProvider>
+    <SccProjectName>
+    </SccProjectName>
+    <SccLocalPath>
+    </SccLocalPath>
+    <SccAuxPath>
+    </SccAuxPath>
+    <SccProvider>
+    </SccProvider>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>

--- a/Dnn.CommunityForums/class/TemplateUtils.cs
+++ b/Dnn.CommunityForums/class/TemplateUtils.cs
@@ -279,7 +279,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
             var result = new StringBuilder(sOut);
 
-            result.Replace("[DISPLAYNAME]", UserProfiles.GetDisplayName(moduleID, userId, authorName, sFirstName, sLastName, sDisplayName));
+            result.Replace("[DISPLAYNAME]", UserProfiles.GetDisplayName(portalSettings, moduleID,false,false,false, userId, authorName, sFirstName, sLastName, sDisplayName));
             result.Replace("[USERNAME]", sUsername);
             result.Replace("[USERID]", userId.ToString());
             result.Replace("[FORUMNAME]", fi.ForumName);
@@ -627,7 +627,8 @@ namespace DotNetNuke.Modules.ActiveForums
                 result.Replace("[AF:PROFILE:AVATAR]", sAvatar);
 
                 // Display Name
-                result.Replace("[AF:PROFILE:DISPLAYNAME]", UserProfiles.GetDisplayName(moduleId, true, isMod, isAdmin, up.UserId, up.UserName, up.FirstName, up.LastName, up.DisplayName));
+                DotNetNuke.Entities.Portals.PortalSettings portalSettings = Utilities.GetPortalSettings(portalId);
+                result.Replace("[AF:PROFILE:DISPLAYNAME]", UserProfiles.GetDisplayName(portalSettings, moduleId, true, isMod, isAdmin, up.UserId, up.UserName, up.FirstName, up.LastName, up.DisplayName));
 
                 // These fields are no longer used
                 result.Replace("[AF:PROFILE:LOCATION]", string.Empty);

--- a/Dnn.CommunityForums/class/UserProfiles.cs
+++ b/Dnn.CommunityForums/class/UserProfiles.cs
@@ -20,6 +20,7 @@
 
 using System;
 using System.Linq;
+using System.Reflection;
 using System.Web;
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Users;
@@ -51,17 +52,21 @@ namespace DotNetNuke.Modules.ActiveForums
                 return string.Concat("<img class='af-avatar' src='", string.Format(Common.Globals.UserProfilePicFormattedUrl(), userID, avatarWidth, avatarHeight), "' />");
             }
         }
+        [Obsolete("Deprecated in Community Forums. Removing in 10.00.00. Use method with PortalSettings as a parameter.")]
+        public static string GetDisplayName(int moduleId, int userID, string username, string firstName = "", string lastName = "", string displayName = "", string profileNameClass = "af-profile-name") => GetDisplayName(portalSettings: null, moduleId, linkProfile: false, false, false, userID, username, firstName, lastName, displayName, null, profileNameClass);
+        [Obsolete("Deprecated in Community Forums. Removing in 10.00.00. Use method with PortalSettings as a parameter.")]
+        public static string GetDisplayName(int moduleId, bool linkProfile, bool isMod, bool isAdmin, int userId, string username, string firstName = "", string lastName = "", string displayName = "", string profileLinkClass = "af-profile-link", string profileNameClass = "af-profile-name") => GetDisplayName(null, moduleId, linkProfile, isMod, isAdmin, userId, username, firstName, lastName, displayName, profileLinkClass, profileNameClass);
 
-        public static string GetDisplayName(int moduleId, int userID, string username, string firstName = "", string lastName = "", string displayName = "", string profileNameClass = "af-profile-name")
+        internal static string GetDisplayName(DotNetNuke.Entities.Portals.PortalSettings portalSettings, int moduleId, bool linkProfile, bool isMod, bool isAdmin, int userId, string username, string firstName = "", string lastName = "", string displayName = "", string profileLinkClass = "af-profile-link", string profileNameClass = "af-profile-name")
         {
-            return GetDisplayName(moduleId, false, false, false, userID, username, firstName, lastName, displayName, null, profileNameClass);
-        }
-
-        public static string GetDisplayName(int moduleId, bool linkProfile, bool isMod, bool isAdmin, int userId, string username, string firstName = "", string lastName = "", string displayName = "", string profileLinkClass = "af-profile-link", string profileNameClass = "af-profile-name")
-        {
-            PortalSettings portalSettings = DotNetNuke.Modules.ActiveForums.Utilities.GetPortalSettings();
             if (portalSettings == null)
+            {
+                portalSettings = DotNetNuke.Modules.ActiveForums.Utilities.GetPortalSettings();
+            }
+            if (portalSettings == null)
+            {
                 return null;
+            }
 
             var mainSettings = SettingsBase.GetModuleSettings(moduleId);
 

--- a/Dnn.CommunityForums/class/UsersOnline.cs
+++ b/Dnn.CommunityForums/class/UsersOnline.cs
@@ -20,6 +20,7 @@
 
 using System;
 using System.Text;
+using DotNetNuke.Abstractions.Portals;
 using DotNetNuke.Entities.Portals;
 
 namespace DotNetNuke.Modules.ActiveForums
@@ -38,8 +39,8 @@ namespace DotNetNuke.Modules.ActiveForums
                 {
                     if (sb.Length > 0)
                         sb.Append(", ");
-
-                    sb.Append(UserProfiles.GetDisplayName(moduleId, true, false, isAdmin, dr.GetInt("UserId"), dr.GetString("Username"), dr.GetString("FirstName"), dr.GetString("LastName"), dr.GetString("DisplayName")));
+                    var portalSettings = DotNetNuke.Modules.ActiveForums.Utilities.GetPortalSettings(portalId);
+                    sb.Append(UserProfiles.GetDisplayName(portalSettings, moduleId, true, false, isAdmin, dr.GetInt("UserId"), dr.GetString("Username"), dr.GetString("FirstName"), dr.GetString("LastName"), dr.GetString("DisplayName")));
                 }
 
                 dr.Close();

--- a/Dnn.CommunityForums/controls/af_grid.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_grid.ascx.cs
@@ -387,8 +387,7 @@ namespace DotNetNuke.Modules.ActiveForums
             var firstName = _currentRow["AuthorFirstName"].ToString();
             var lastName = _currentRow["AuthorLastName"].ToString();
             var displayName = _currentRow["AuthorDisplayName"].ToString();
-
-            return UserProfiles.GetDisplayName(ForumModuleId, true, false, ForumUser.IsAdmin, userId, userName, firstName, lastName, displayName);
+            return UserProfiles.GetDisplayName(PortalSettings, ForumModuleId, true, false, ForumUser.IsAdmin, userId, userName, firstName, lastName, displayName);
         }
 
         public string GetLastPostAuthor()
@@ -401,8 +400,7 @@ namespace DotNetNuke.Modules.ActiveForums
             var firstName = _currentRow["LastReplyFirstName"].ToString();
             var lastName = _currentRow["LastReplyLastName"].ToString();
             var displayName = _currentRow["LastReplyDisplayName"].ToString();
-
-            return UserProfiles.GetDisplayName(ForumModuleId, true, false, ForumUser.IsAdmin, userId, userName, firstName, lastName, displayName);
+            return UserProfiles.GetDisplayName(PortalSettings, ForumModuleId, true, false, ForumUser.IsAdmin, userId, userName, firstName, lastName, displayName);
         }
 
         public string GetLastPostTime()

--- a/Dnn.CommunityForums/controls/af_post.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_post.ascx.cs
@@ -563,13 +563,13 @@ namespace DotNetNuke.Modules.ActiveForums
                         if (postId == TopicId)
                         {
                             ci = ti.Content;
-                            sPostedBy = string.Format(sPostedBy, UserProfiles.GetDisplayName(ForumModuleId, true, false, false, ti.Content.AuthorId, ti.Author.Username, ti.Author.FirstName, ti.Author.LastName, ti.Author.DisplayName), Utilities.GetSharedResource("On.Text"), Utilities.GetUserFormattedDateTime(ti.Content.DateCreated, PortalId, UserId));
+                            sPostedBy = string.Format(sPostedBy, UserProfiles.GetDisplayName(PortalSettings, ForumModuleId, true, false, false, ti.Content.AuthorId, ti.Author.Username, ti.Author.FirstName, ti.Author.LastName, ti.Author.DisplayName), Utilities.GetSharedResource("On.Text"), Utilities.GetUserFormattedDateTime(ti.Content.DateCreated, PortalId, UserId));
                         }
                         else
                         {
                             var ri = DotNetNuke.Modules.ActiveForums.Controllers.ReplyController.GetReply(postId);
                             ci = ri.Content;
-                            sPostedBy = string.Format(sPostedBy, UserProfiles.GetDisplayName(ForumModuleId, true, false, false, ri.Content.AuthorId, ri.Author.Username, ri.Author.FirstName, ri.Author.LastName, ri.Author.DisplayName), Utilities.GetSharedResource("On.Text"), Utilities.GetUserFormattedDateTime(ri.Content.DateCreated, PortalId, UserId));
+                            sPostedBy = string.Format(sPostedBy, UserProfiles.GetDisplayName(PortalSettings, ForumModuleId, true, false, false, ri.Content.AuthorId, ri.Author.Username, ri.Author.FirstName, ri.Author.LastName, ri.Author.DisplayName), Utilities.GetSharedResource("On.Text"), Utilities.GetUserFormattedDateTime(ri.Content.DateCreated, PortalId, UserId));
                         }
 
                         if (ci != null)

--- a/Dnn.CommunityForums/controls/af_profile.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_profile.ascx.cs
@@ -41,7 +41,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     DotNetNuke.Entities.Users.UserInfo ui = DotNetNuke.Entities.Users.UserController.Instance.GetUser(PortalId, tUid);
                     if (ui != null)
                     {
-                        sDisplayName = UserProfiles.GetDisplayName(ModuleId, ui.UserID, ui.Username, ui.FirstName, ui.LastName, ui.DisplayName);
+                        sDisplayName = UserProfiles.GetDisplayName(PortalSettings, ModuleId, false,false,false, ui.UserID, ui.Username, ui.FirstName, ui.LastName, ui.DisplayName);
                     }
 
                 }
@@ -50,7 +50,7 @@ namespace DotNetNuke.Modules.ActiveForums
             else
             {
                 tUid = UserId;
-                sDisplayName = UserProfiles.GetDisplayName(ModuleId, UserId, UserInfo.Username, UserInfo.FirstName, UserInfo.LastName, UserInfo.DisplayName);
+                sDisplayName = UserProfiles.GetDisplayName(PortalSettings, ModuleId, false, false, false, UserId, UserInfo.Username, UserInfo.FirstName, UserInfo.LastName, UserInfo.DisplayName);
             }
             lblHeader.Text = string.Format(Utilities.GetSharedResource("[RESX:ProfileForUser]"), sDisplayName);
             if (MainSettings.UseSkinBreadCrumb)

--- a/Dnn.CommunityForums/controls/af_search.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_search.ascx.cs
@@ -536,7 +536,7 @@ namespace DotNetNuke.Modules.ActiveForums
             var lastName = _currentRow["AuthorLastName"].ToString();
             var displayName = _currentRow["AuthorDisplayName"].ToString();
 
-            return UserProfiles.GetDisplayName(ModuleId, true, false, ForumUser.IsAdmin, userId, userName, firstName, lastName, displayName);
+            return UserProfiles.GetDisplayName(PortalSettings, ForumModuleId, true, false, ForumUser.IsAdmin, userId, userName, firstName, lastName, displayName);
         }
 
         public string GetLastPostAuthor()
@@ -550,7 +550,7 @@ namespace DotNetNuke.Modules.ActiveForums
             var lastName = _currentRow["LastReplyLastName"].ToString();
             var displayName = _currentRow["LastReplyDisplayName"].ToString();
 
-            return UserProfiles.GetDisplayName(ModuleId, true, false, ForumUser.IsAdmin, userId, userName, firstName, lastName, displayName);
+            return UserProfiles.GetDisplayName(PortalSettings, ForumModuleId, true, false, ForumUser.IsAdmin, userId, userName, firstName, lastName, displayName);
         }
 
         public string GetLastPostTime()

--- a/Dnn.CommunityForums/controls/af_sendto.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_sendto.ascx.cs
@@ -67,7 +67,7 @@ namespace DotNetNuke.Modules.ActiveForums
                                 sURL = NavigateUrl(TabId, "", new string[] { ParamKeys.TopicId + "=" + TopicId });
                             }
                             MessageDefault = MessageDefault.Replace("[TOPICLINK]", sURL);
-                            MessageDefault = MessageDefault.Replace("[DISPLAYNAME]", UserProfiles.GetDisplayName(ModuleId, UserId, UserInfo.Username, UserInfo.FirstName, UserInfo.LastName, UserInfo.DisplayName));
+                            MessageDefault = MessageDefault.Replace("[DISPLAYNAME]", UserProfiles.GetDisplayName(PortalSettings, ModuleId, false, false, false, UserId, UserInfo.Username, UserInfo.FirstName, UserInfo.LastName, UserInfo.DisplayName));
                             txtMessage.Text = MessageDefault;
                         }
 

--- a/Dnn.CommunityForums/feeds.aspx.cs
+++ b/Dnn.CommunityForums/feeds.aspx.cs
@@ -269,7 +269,7 @@ namespace DotNetNuke.Modules.ActiveForums
             sb.Append(WriteElement("title", dr["Subject"].ToString(), Indent + 1));
             sb.Append(WriteElement("description", body, Indent + 1));
             sb.Append(WriteElement("link", URL, Indent + 1));
-            sb.Append(WriteElement("dc:creator", UserProfiles.GetDisplayName(ModuleID, -1, dr["AuthorUserName"].ToString(), dr["AuthorFirstName"].ToString(), dr["AuthorLastName"].ToString(), dr["AuthorDisplayName"].ToString(), null), Indent + 1));
+            sb.Append(WriteElement("dc:creator", UserProfiles.GetDisplayName(PortalSettings, ModuleID, false, false, false, -1, dr["AuthorUserName"].ToString(), dr["AuthorFirstName"].ToString(), dr["AuthorLastName"].ToString(), dr["AuthorDisplayName"].ToString(), null), Indent + 1));
             sb.Append(WriteElement("pubDate", Convert.ToDateTime(dr["DateCreated"]).AddMinutes(offSet).ToString("r"), Indent + 1));
             sb.Append(WriteElement("guid", URL, Indent + 1));
             sb.Append(WriteElement("slash:comments", dr["ReplyCount"].ToString(), Indent + 1));


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
[DISPLAYNAME] not included in email notifications

## Changes made
- Refactored to always pass PortalSettings to GetUserDisplayName()

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

Before 8.1
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/7c8dac06-a873-4051-984e-4ba5b16a930c)

After 8.1
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/c16dde2f-8b16-431d-a4c0-df24371e289a)

This PR
![image](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/4495d019-8512-4185-8968-91d83a47315b)


## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #923