### PR TITLE
FIX: Can't mark reply as correct answer

### DIFF
--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
@@ -1446,7 +1446,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             else
             {
                 // Not Answered
-                if ((UserId == _topicAuthorId && !_bLocked) || _bModEdit)
+                if (replyId > 0 && ((UserId == _topicAuthorId && !_bLocked) || _bModEdit))
                 {
                     // Can mark answer
                     if (_useListActions)

--- a/Dnn.CommunityForums/Services/Controllers/ReplyController.cs
+++ b/Dnn.CommunityForums/Services/Controllers/ReplyController.cs
@@ -32,29 +32,38 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Controllers
     /// </summary>
     public class ReplyController : ControllerBase<ReplyController>
     {
+        public struct ReplyDto
+        {
+            public int ForumId { get; set; }
+            public int TopicId { get; set; }
+            public int ReplyId { get; set; }
+        }
 #pragma warning disable CS1570
+
         /// <summary>
         /// Marks a reply as the answer to a topic
         /// </summary>
-        /// <param name="forumId" type="int"></param>
-        /// <param name="replyId" type="int"></param>
+        /// <param name="dto"></param>
         /// <returns></returns>
-        /// <remarks>https://dnndev.me/API/ActiveForums/Reply/MarkAsAnswer?forumId=xxx&replyId=yyy</remarks>
+        /// <remarks>https://dnndev.me/API/ActiveForums/Reply/MarkAsAnswer</remarks>
 #pragma warning restore CS1570
         [HttpPost]
         [DnnAuthorize]
         [ForumsAuthorize(SecureActions.ModEdit)]
         [ForumsAuthorize(SecureActions.Edit)]
-        public HttpResponseMessage MarkAsAnswer(int forumId, int replyId)
+        public HttpResponseMessage MarkAsAnswer(ReplyDto dto)
         {
-            if (forumId > 0 && replyId > 0)
+            int forumId = dto.ForumId;
+            int topicId = dto.TopicId;
+            int replyId = dto.ReplyId; 
+            if (forumId > 0 && topicId > 0 && replyId > 0)
             {
                 var r = new DotNetNuke.Modules.ActiveForums.Controllers.ReplyController().GetById(replyId);
                 if (r != null)
                 {
-                    if ((UserInfo.UserID == r.Topic.Author.AuthorId && !r.Topic.IsLocked) || DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasAccess(r.Topic.Forum.Security.ModEdit, string.Join(";",UserInfo.Roles)))
+                    if ((UserInfo.UserID == r.Topic.Author.AuthorId && !r.Topic.IsLocked) || DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasAccess(r.Topic.Forum.Security.ModEdit, string.Join(";", DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(ActiveModule.PortalID, UserInfo.Roles))))
                     {
-                        DataProvider.Instance().Reply_UpdateStatus(ActiveModule.PortalID, ForumModuleId, r.TopicId, replyId, UserInfo.UserID, 1,  DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasAccess(r.Topic.Forum.Security.ModEdit, string.Join(";", UserInfo.Roles)));
+                        DataProvider.Instance().Reply_UpdateStatus(ActiveModule.PortalID, ForumModuleId, r.TopicId, replyId, UserInfo.UserID, 1,  DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasAccess(r.Topic.Forum.Security.ModEdit, string.Join(";", DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(ActiveModule.PortalID, UserInfo.Roles))));
                         DataCache.CacheClearPrefix(ForumModuleId, string.Format(CacheKeys.TopicViewPrefix, ForumModuleId));
                         return Request.CreateResponse(HttpStatusCode.OK, string.Empty);
                     }

--- a/Dnn.CommunityForums/Services/Controllers/TopicController.cs
+++ b/Dnn.CommunityForums/Services/Controllers/TopicController.cs
@@ -309,8 +309,8 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Controllers
                     originalTopic.TopicUrl = DotNetNuke.Modules.ActiveForums.Controllers.UrlController.BuildTopicUrl(PortalId: ActiveModule.PortalID, ModuleId: ForumModuleId, TopicId: topicId, subject: subject, forumInfo: originalTopic.Forum);
 
                     if (dto.Topic.IsLocked != originalTopic.IsLocked &&
-                        (DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasAccess(originalTopic.Forum.Security.Lock, string.Join(";", UserInfo.Roles)) ||
-                            DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasAccess(originalTopic.Forum.Security.ModLock, string.Join(";", UserInfo.Roles))
+                        (DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasAccess(originalTopic.Forum.Security.Lock, string.Join(";", DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(ActiveModule.PortalID, UserInfo.Roles))) ||
+                            DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasAccess(originalTopic.Forum.Security.ModLock, string.Join(";", DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(ActiveModule.PortalID, UserInfo.Roles)))
                         )
                         )
                     {
@@ -318,8 +318,8 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Controllers
                     };
 
                     if (dto.Topic.IsPinned != originalTopic.IsPinned &&
-                        (DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasAccess(originalTopic.Forum.Security.Pin, string.Join(";", UserInfo.Roles)) ||
-                            DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasAccess(originalTopic.Forum.Security.ModPin, string.Join(";", UserInfo.Roles))
+                        (DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasAccess(originalTopic.Forum.Security.Pin, string.Join(";", DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(ActiveModule.PortalID, UserInfo.Roles))) ||
+                            DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasAccess(originalTopic.Forum.Security.ModPin, string.Join(";", DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(ActiveModule.PortalID, UserInfo.Roles)))
                         )
                         )
                     {
@@ -359,7 +359,7 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Controllers
                     DotNetNuke.Modules.ActiveForums.Controllers.TopicController.Save(originalTopic);
                     Utilities.UpdateModuleLastContentModifiedOnDate(ForumModuleId);
 
-                    if (DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasAccess(originalTopic.Forum.Security.Tag, string.Join(";", UserInfo.Roles)))
+                    if (DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasAccess(originalTopic.Forum.Security.Tag, string.Join(";", DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(ActiveModule.PortalID, UserInfo.Roles))))
                     {
                         if (!string.IsNullOrEmpty(dto.Topic.Tags))
                         {
@@ -373,7 +373,7 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Controllers
                             }
                         }
                     }
-                    if (DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasAccess(originalTopic.Forum.Security.Categorize, string.Join(";", UserInfo.Roles)))
+                    if (DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasAccess(originalTopic.Forum.Security.Categorize, string.Join(";", DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(ActiveModule.PortalID, UserInfo.Roles))))
                     {
                         if (!string.IsNullOrEmpty(dto.Topic.SelectedCategoriesAsString))
                         {


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Corrects issues with not being able to mark a reply as correct answer.

## Changes made
- Restore code (removed by a github merge) to ReplyController web api method 
- Only show 'mark as answer' on replies not original topic
- When check permissions for web api methods, convert UserInfo.Roles from names to IDs (IDs is used in PermissionController)

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install
![2024-07-02_12-41-56](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/148347c5-70d7-41f7-a82e-ec669ed50550)


## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #945