### PR TITLE
FIX: Clicking 'Save' in control panel on forum that is not inheriting group security restores default security

### DIFF
--- a/Dnn.CommunityForums/Controllers/ForumController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumController.cs
@@ -277,7 +277,6 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
         }
         public int Forums_Save(int portalId, DotNetNuke.Modules.ActiveForums.Entities.ForumInfo fi, bool isNew, bool useGroupFeatures, bool useGroupSecurity)
         {
-            var permissionsId = -1;
             var fg = new DotNetNuke.Modules.ActiveForums.Controllers.ForumGroupController().GetById(fi.ForumGroupId, fi.ModuleId);
             if (useGroupSecurity)
             {
@@ -288,10 +287,11 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             }
             else
             {
-                fi.PermissionsId = new DotNetNuke.Modules.ActiveForums.Controllers.PermissionController().CreateAdminPermissions(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetAdministratorsRoleId(portalId).ToString()).PermissionsId;
-                DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.CreateDefaultSets(portalId, fi.PermissionsId); 
-                permissionsId = fi.PermissionsId;
-                isNew = true;
+                if (isNew || (fi?.PermissionsId == fg?.PermissionsId)) /* new forum or switching from group security to forum security */
+                {
+                    fi.PermissionsId = new DotNetNuke.Modules.ActiveForums.Controllers.PermissionController().CreateAdminPermissions(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetAdministratorsRoleId(portalId).ToString()).PermissionsId;
+                    DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.CreateDefaultSets(portalId, fi.PermissionsId);
+                }
             }
             fi.ForumSettingsKey = useGroupFeatures ? (fg != null ? fg.GroupSettingsKey : string.Empty) : (fi.ForumID > 0 ? $"F:{fi.ForumID}" : string.Empty);
 

--- a/Dnn.CommunityForums/DnnCommunityForums.dnn
+++ b/Dnn.CommunityForums/DnnCommunityForums.dnn
@@ -1,6 +1,6 @@
 ﻿<dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="Active Forums" type="Module" version="08.01.01">
+    <package name="Active Forums" type="Module" version="08.01.02">
       <friendlyName>DNN Community Forums</friendlyName>
       <description>DNN Community Forums: The official online forums module for the DNN Community.</description>
       <iconFile>DesktopModules/ActiveForums/images/branding/logo/DNN-Community-Forums-Icon-64px.png</iconFile>
@@ -433,7 +433,7 @@
       </components>
     </package>
 
-    <package name="Active Forums What's New" type="Module" version="08.01.01">
+    <package name="Active Forums What's New" type="Module" version="08.01.02">
 
       <friendlyName>DNN Community Forums What's New</friendlyName>
       <foldername>ActiveForumsWhatsNew</foldername>
@@ -503,7 +503,7 @@
       </components>
     </package>
 
-    <package name="Active Forums Viewer" type="Module" version="08.01.01">
+    <package name="Active Forums Viewer" type="Module" version="08.01.02">
       <friendlyName>DNN Community Forums Forums Viewer</friendlyName>
       <foldername>ActiveForumsViewer</foldername>
       <description>DNN Community Forums: Display any forum topic view on any page within your site.</description>

--- a/Dnn.CommunityForums/DnnCommunityForums_Symbols.dnn
+++ b/Dnn.CommunityForums/DnnCommunityForums_Symbols.dnn
@@ -1,6 +1,6 @@
 ﻿<dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="Active Forums_Symbols" type="Library" version="08.01.01">
+    <package name="Active Forums_Symbols" type="Library" version="08.01.02">
 
       <friendlyName>DNN Community Forums Symbols</friendlyName>
       <description>DNN Community Forums: The official online forums module for the DNN Community.</description>
@@ -16,7 +16,7 @@
       <azureCompatible>True</azureCompatible>
       <dependencies>
 
-        <dependency type="managedPackage" version="8.1.1">Active Forums</dependency>
+        <dependency type="managedPackage" version="8.1.2>Active Forums</dependency>
 
       </dependencies>
       <components>

--- a/Dnn.CommunityForums/Properties/AssemblyInfo.cs
+++ b/Dnn.CommunityForums/Properties/AssemblyInfo.cs
@@ -53,9 +53,9 @@ using System.Runtime.CompilerServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 
-[assembly: AssemblyVersion("08.01.01")]
+[assembly: AssemblyVersion("08.01.02")]
 
-[assembly: AssemblyFileVersion("08.01.01")]
+[assembly: AssemblyFileVersion("08.01.02")]
 
 
 [assembly: WebResource("DotNetNuke.Modules.ActiveForums.CustomControls.Resources.cb.js", "text/javascript")]

--- a/Dnn.CommunityForums/ReleaseNotes.txt
+++ b/Dnn.CommunityForums/ReleaseNotes.txt
@@ -96,45 +96,75 @@
 	<div class="dnnClear">
 		<h2>Release Notes</h2>
 		<hr />
-		<h3>08.01.01<!-- <span class="muy-importante">RELEASE CANDIDATE 1</span>--></h3>
+		<h3>08.01.02<!-- <span class="muy-importante">RELEASE CANDIDATE 1</span>--></h3>
 
-		<!--
-		<p class="muy-importante">
-			<strong>IMPORTANT!!!</strong> This is a release candidate (RC).  Please <strong>DO NOT</strong> use this installation/upgrade package for any production 
-			websites of any kind.  
-		</p>
+<!--
+<p class="muy-importante">
+	<strong>IMPORTANT!!!</strong> This is a release candidate (RC).  Please <strong>DO NOT</strong> use this installation/upgrade package for any production 
+	websites of any kind.  
+</p>
 
-		<p class="muy-importante">This release is <strong>not supported</strong> and is <strong>only provided for testing purposes</strong>, to allow others to test 
-			their websites first, before we deploy an official release.  
-		</p>
-		-->
+<p class="muy-importante">This release is <strong>not supported</strong> and is <strong>only provided for testing purposes</strong>, to allow others to test 
+	their websites first, before we deploy an official release.  
+</p>
+-->
 
-		<h4>New Features &amp; Enhancements</h4>
-		<ul>
-			<li>UPDATE: No Longer Listing Informative Posts as &quot;Unanswered&quot; (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/946">Issue 946</a>, thanks <a href="https://github.com/johnhenley" target="_blank">@johnhenley</a>!)</li>
-			<li>UPDATE: Added Headings to Filtered Topic Overviews (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/949">Issue 949</a>, thanks <a href="https://github.com/johnhenley" target="_blank">@johnhenley</a>!)</li>
-			<li>UPDATE: Added 'Add Reply' Buttons on Top of TopicsView (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/941">Issue 941</a>, thanks <a href="https://github.com/johnhenley" target="_blank">@johnhenley</a>!)</li>
-			<li>UPDATE: Added Alignment for 'Next' in the community-default Forum Theme (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/934">Issue 934</a>, thanks <a href="https://github.com/Timo-Breumelhof" target="_blank">@Timo-Breumelhof</a>!)</li>
-			<!--<li>UPDATE:  (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/">Issue </a>, thanks <a href="https://github.com/" target="_blank">@</a>!)</li>-->
-		</ul>
-		
-		<h4>Bug Fixes</h4>
-		<ul>
-			<li>BUG: [DISPLAYNAME] Not Included in Email Notifications (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/923">Issue 923</a>, thanks <a href="https://github.com/johnhenley" target="_blank">@johnhenley</a>!)</li>
-			<li>BUG: Resolved Alignment Issues in the Active Topics Filtered List (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/948">Issue 948</a>, thanks <a href="https://github.com/johnhenley" target="_blank">@johnhenley</a>!)</li>
-			<li>BUG: Resolved Issue Attempting to Mark Topic as Answered (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/945">Issue 945</a>, thanks <a href="https://github.com/johnhenley" target="_blank">@johnhenley</a>!)</li>
-			<li>BUG: Added Cache Keys to Resolve Topic Paging Issues (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/933">Issue 933</a>, thanks <a href="https://github.com/johnhenley" target="_blank">@johnhenley</a>!)</li>
-			<li>BUG: Moderation Email Not Sent if Disapproving a New Topic (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/938">Issue 938</a>, thanks <a href="https://github.com/johnhenley" target="_blank">@johnhenley</a>!)</li>
-			<!--<li>FIXED:  (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/">Issue </a>, thanks <a href="https://github.com/" target="_blank">@</a>!)</li>-->
-		</ul>
-		
-		<h4>Tasks / Development Updates (and Technical Debt)</h4>
-		<ul>
-			<li>None at this time.</li>
-			<!--<li>TASK:  (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/">Issue </a>, thanks <a href="https://github.com/" target="_blank">@</a>!)</li>-->
-		</ul>
-		<hr /> 
+<h4>New Features &amp; Enhancements</h4>
+<ul>
+	<li>UPDATE: Make sure Filtered Topics dropdown text is visibile on mobile (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/959">Issue 959</a>, thanks <a href="https://github.com/Timo-Breumelhof" target="_blank">@Timo-Breumelhof</a>!)</li>
+	<!--<li>UPDATE:  (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/">Issue </a>, thanks <a href="https://github.com/" target="_blank">@</a>!)</li>-->
+</ul>
 
+<h4>Bug Fixes</h4>
+<ul>
+	<li>BUG: Not redirected to new page after submitting edits to an existing reply (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/963">Issue 963</a>, thanks <a href="https://github.com/johnhenley" target="_blank">@johnhenley</a>!)</li>
+	<li>BUG: Clicking Save in forum control panel restores default security when forum is not inheriting security from group (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/964">Issue 964</a>, thanks <a href="https://github.com/johnhenley" target="_blank">@johnhenley</a>!)</li>
+	<!--<li>FIXED:  (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/">Issue </a>, thanks <a href="https://github.com/" target="_blank">@</a>!)</li>-->
+</ul>
+
+<h4>Tasks / Development Updates (and Technical Debt)</h4>
+<ul>
+	<li>None at this time.</li>
+	<!--<li>TASK:  (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/">Issue </a>, thanks <a href="https://github.com/" target="_blank">@</a>!)</li>-->
+</ul>
+<hr /><h3>08.01.01<!-- <span class="muy-importante">RELEASE CANDIDATE 1</span>--></h3>
+
+<!--
+<p class="muy-importante">
+	<strong>IMPORTANT!!!</strong> This is a release candidate (RC).  Please <strong>DO NOT</strong> use this installation/upgrade package for any production 
+	websites of any kind.  
+</p>
+
+<p class="muy-importante">This release is <strong>not supported</strong> and is <strong>only provided for testing purposes</strong>, to allow others to test 
+	their websites first, before we deploy an official release.  
+</p>
+-->
+
+<h4>New Features &amp; Enhancements</h4>
+<ul>
+	<li>UPDATE: No Longer Listing Informative Posts as &quot;Unanswered&quot; (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/946">Issue 946</a>, thanks <a href="https://github.com/johnhenley" target="_blank">@johnhenley</a>!)</li>
+	<li>UPDATE: Added Headings to Filtered Topic Overviews (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/949">Issue 949</a>, thanks <a href="https://github.com/johnhenley" target="_blank">@johnhenley</a>!)</li>
+	<li>UPDATE: Added 'Add Reply' Buttons on Top of TopicsView (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/941">Issue 941</a>, thanks <a href="https://github.com/johnhenley" target="_blank">@johnhenley</a>!)</li>
+	<li>UPDATE: Added Alignment for 'Next' in the community-default Forum Theme (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/934">Issue 934</a>, thanks <a href="https://github.com/Timo-Breumelhof" target="_blank">@Timo-Breumelhof</a>!)</li>
+	<!--<li>UPDATE:  (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/">Issue </a>, thanks <a href="https://github.com/" target="_blank">@</a>!)</li>-->
+</ul>
+
+<h4>Bug Fixes</h4>
+<ul>
+	<li>BUG: [DISPLAYNAME] Not Included in Email Notifications (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/923">Issue 923</a>, thanks <a href="https://github.com/johnhenley" target="_blank">@johnhenley</a>!)</li>
+	<li>BUG: Resolved Alignment Issues in the Active Topics Filtered List (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/948">Issue 948</a>, thanks <a href="https://github.com/johnhenley" target="_blank">@johnhenley</a>!)</li>
+	<li>BUG: Resolved Issue Attempting to Mark Topic as Answered (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/945">Issue 945</a>, thanks <a href="https://github.com/johnhenley" target="_blank">@johnhenley</a>!)</li>
+	<li>BUG: Added Cache Keys to Resolve Topic Paging Issues (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/933">Issue 933</a>, thanks <a href="https://github.com/johnhenley" target="_blank">@johnhenley</a>!)</li>
+	<li>BUG: Moderation Email Not Sent if Disapproving a New Topic (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/938">Issue 938</a>, thanks <a href="https://github.com/johnhenley" target="_blank">@johnhenley</a>!)</li>
+	<!--<li>FIXED:  (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/">Issue </a>, thanks <a href="https://github.com/" target="_blank">@</a>!)</li>-->
+</ul>
+
+<h4>Tasks / Development Updates (and Technical Debt)</h4>
+<ul>
+	<li>None at this time.</li>
+	<!--<li>TASK:  (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/">Issue </a>, thanks <a href="https://github.com/" target="_blank">@</a>!)</li>-->
+</ul>
+<hr />
 		<h3>08.01.00<!-- <span class="muy-importante">RELEASE CANDIDATE 1</span>--></h3>
 
 		<!--


### PR DESCRIPTION


<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Clicking 'Save' in control panel on forum that is not inheriting group security restores default security

## Changes made
- Default permissions should not be applied unless 1) for a new forum or 2) switching from inheriting group security to not inheriting

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

![2024-07-03_15-19-44](https://github.com/DNNCommunity/Dnn.CommunityForums/assets/9553126/a4e13a86-7ad0-4757-aa38-892dc96ebf39)



## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #964