### PR TITLE
FIX: Forum icon not changing when new topic

### DIFF
--- a/Dnn.CommunityForums/Controllers/ForumController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumController.cs
@@ -24,6 +24,7 @@ using System.Reflection;
 using System.Text;
 using System.Xml;
 using DotNetNuke.Data;
+using DotNetNuke.Modules.ActiveForums.API;
 using DotNetNuke.Modules.ActiveForums.Data;
 using Microsoft.ApplicationBlocks.Data;
 
@@ -472,7 +473,19 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
         }
         public static int Forum_GetByTopicId(int TopicId)
         {
-            return new DotNetNuke.Data.SqlDataProvider().ExecuteScalar<int>( "activeforums_ForumGetByTopicId", TopicId);
+            return new DotNetNuke.Data.SqlDataProvider().ExecuteScalar<int>("activeforums_ForumGetByTopicId", TopicId);
+        }
+        public static DateTime Forum_GetLastReadTopicByUser(int ForumId, int UserId)
+        {
+            try
+            {
+                return DataContext.Instance().ExecuteQuery<DateTime>(System.Data.CommandType.Text, "SELECT LastAccessDate FROM {databaseOwner}{objectQualifier}activeforums_Forums_Tracking WHERE ForumId = @0 AND UserId = @1", ForumId, UserId).FirstOrDefault();
+            }
+            catch (Exception ex)
+            {
+                Exceptions.LogException(ex);
+                return DateTime.MinValue;
+            }
         }
         internal static bool RecalculateTopicPointers(int forumId)
         {

--- a/Dnn.CommunityForums/Controllers/ReplyController.cs
+++ b/Dnn.CommunityForums/Controllers/ReplyController.cs
@@ -58,6 +58,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
         {
             var ri = GetById(ReplyId);
             DataProvider.Instance().Reply_Delete(ForumId, TopicId, ReplyId, DelBehavior);
+            DotNetNuke.Modules.ActiveForums.Controllers.ForumController.UpdateForumLastUpdates(ForumId);
+
             DataCache.ContentCacheClear(ri.ModuleId, string.Format(CacheKeys.ForumInfo, ri.ModuleId, ForumId));
             DataCache.CacheClearPrefix(ri.ModuleId, string.Format(CacheKeys.ForumViewPrefix, ri.ModuleId));
             DataCache.CacheClearPrefix(ri.ModuleId, string.Format(CacheKeys.TopicViewPrefix, ri.ModuleId));
@@ -126,7 +128,9 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             DataCache.CacheClearPrefix(ri.ModuleId, string.Format(CacheKeys.ForumViewPrefix, ri.ModuleId));
             DataCache.CacheClearPrefix(ri.ModuleId, string.Format(CacheKeys.TopicViewPrefix, ri.ModuleId));
             DataCache.CacheClearPrefix(ri.ModuleId, string.Format(CacheKeys.TopicsViewPrefix, ri.ModuleId));
-            return Convert.ToInt32(DataProvider.Instance().Reply_Save(PortalId, ri.TopicId, ri.ReplyId, ri.ReplyToId, ri.StatusId, ri.IsApproved, ri.IsDeleted, ri.Content.Subject.Trim(), ri.Content.Body.Trim(), ri.Content.DateCreated, ri.Content.DateUpdated, ri.Content.AuthorId, ri.Content.AuthorName, ri.Content.IPAddress));
+            int replyId = Convert.ToInt32(DataProvider.Instance().Reply_Save(PortalId, ri.TopicId, ri.ReplyId, ri.ReplyToId, ri.StatusId, ri.IsApproved, ri.IsDeleted, ri.Content.Subject.Trim(), ri.Content.Body.Trim(), ri.Content.DateCreated, ri.Content.DateUpdated, ri.Content.AuthorId, ri.Content.AuthorName, ri.Content.IPAddress));
+            DotNetNuke.Modules.ActiveForums.Controllers.ForumController.UpdateForumLastUpdates(ri.ForumId);
+            return replyId;
         }
         public DotNetNuke.Modules.ActiveForums.Entities.ReplyInfo ApproveReply(int PortalId, int TabId, int ModuleId, int ForumId, int TopicId, int ReplyId)
         {
@@ -139,7 +143,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             }
             reply.IsApproved = true;
             rc.Reply_Save(PortalId, ModuleId, reply);
-            DotNetNuke.Modules.ActiveForums.Controllers.TopicController.SaveToForum(ModuleId, ForumId, TopicId, ReplyId);
+            DotNetNuke.Modules.ActiveForums.Controllers.TopicController.SaveToForum(ModuleId, ForumId, TopicId, ReplyId); 
 
             if (forum.ModApproveTemplateId > 0 & reply.Author.AuthorId > 0)
             {

--- a/Dnn.CommunityForums/Controllers/TopicController.cs
+++ b/Dnn.CommunityForums/Controllers/TopicController.cs
@@ -33,6 +33,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Web;
+using System.Web.Http.Controllers;
 using System.Xml.Linq;
 
 namespace DotNetNuke.Modules.ActiveForums.Controllers
@@ -87,6 +88,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             if (topicId > 0)
             {
                 DotNetNuke.Modules.ActiveForums.Controllers.TopicController.SaveToForum(ModuleId, ForumId, topicId, -1);
+
                 if (UserId > 0)
                 {
                     //TODO: update this to be consistent with reply count
@@ -173,14 +175,15 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.TopicViewPrefix, ti.ModuleId));
             DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.TopicsViewPrefix, ti.ModuleId));
         }
-        public static int SaveToForum(int ModuleId, int ForumId, int TopicId, int LastReplyId = -1)
+        public static void SaveToForum(int ModuleId, int ForumId, int TopicId, int LastReplyId = -1)
         {
+            DataProvider.Instance().Topics_SaveToForum(ForumId, TopicId, LastReplyId);
             Utilities.UpdateModuleLastContentModifiedOnDate(ModuleId);
+            DotNetNuke.Modules.ActiveForums.Controllers.ForumController.UpdateForumLastUpdates(ForumId);
             DataCache.ContentCacheClear(ModuleId, string.Format(CacheKeys.ForumInfo, ModuleId, ForumId));
             DataCache.CacheClearPrefix(ModuleId, string.Format(CacheKeys.ForumViewPrefix, ModuleId));
             DataCache.CacheClearPrefix(ModuleId, string.Format(CacheKeys.TopicViewPrefix, ModuleId));
             DataCache.CacheClearPrefix(ModuleId, string.Format(CacheKeys.TopicsViewPrefix, ModuleId));
-            return Convert.ToInt32(DataProvider.Instance().Topics_SaveToForum(ForumId, TopicId, LastReplyId));
         }
         public static int Save(DotNetNuke.Modules.ActiveForums.Entities.TopicInfo ti)
         {

--- a/Dnn.CommunityForums/CustomControls/UserControls/ForumView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/ForumView.cs
@@ -390,7 +390,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             bool canView = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(fi.Security.View, ForumUser.UserRoles);
             bool canSubscribe = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(fi.Security.Subscribe, ForumUser.UserRoles);
             bool canRead = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(fi.Security.Read, ForumUser.UserRoles);
-            string sIcon = TemplateUtils.ShowIcon(canView, fi.ForumID, CurrentUserId, fi.LastPostDateTime, fi.LastRead, fi.LastPostID);
+            string sIcon = TemplateUtils.ShowIcon(canView, fi.ForumID, CurrentUserId, fi.LastPostDateTime, DotNetNuke.Modules.ActiveForums.Controllers.ForumController.Forum_GetLastReadTopicByUser(fi.ForumID, CurrentUserId), fi.LastPostID);
             string sIconImage = "<img alt=\"" + fi.ForumName + "\" src=\"" + ThemePath + "images/" + sIcon + "\" />";
 
             if (Template.Contains("[FORUMICON]"))

--- a/Dnn.CommunityForums/components/Topics/TopicsController.cs
+++ b/Dnn.CommunityForums/components/Topics/TopicsController.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlTypes;
 using System.Linq;
+using System.Runtime.Remoting.Messaging;
 using System.Text.RegularExpressions;
 using DotNetNuke.Common.Controls;
 using DotNetNuke.Entities.Modules;
@@ -48,9 +49,17 @@ namespace DotNetNuke.Modules.ActiveForums
         [Obsolete(message: "Deprecated in Community Forums. Scheduled removal in 10.00.00. Use DotNetNuke.Modules.ActiveForums.Controllers.TopicController.Save(TopicInfo ti)")]
         public int TopicSave(int PortalId, int ModuleId, DotNetNuke.Modules.ActiveForums.Entities.TopicInfo ti) => DotNetNuke.Modules.ActiveForums.Controllers.TopicController.Save(ti);
         [Obsolete(message: "Deprecated in Community Forums. Scheduled removal in 10.00.00. Use DotNetNuke.Modules.ActiveForums.Controllers.TopicController.SaveToForum(int ModuleId, int ForumId, int TopicId, int LastReplyId)")]
-        public int Topics_SaveToForum(int ForumId, int TopicId, int PortalId, int ModuleId) => DotNetNuke.Modules.ActiveForums.Controllers.TopicController.SaveToForum(ModuleId, ForumId, TopicId, -1);
+        public int Topics_SaveToForum(int ForumId, int TopicId, int PortalId, int ModuleId)
+        {
+            DotNetNuke.Modules.ActiveForums.Controllers.TopicController.SaveToForum(ModuleId, ForumId, TopicId, -1);
+            return -1;
+        }
         [Obsolete(message: "Deprecated in Community Forums. Scheduled removal in 10.00.00. Use DotNetNuke.Modules.ActiveForums.Controllers.TopicController.SaveToForum(int ModuleId, int ForumId, int TopicId, int LastReplyId)")]
-        public int Topics_SaveToForum(int ForumId, int TopicId, int PortalId, int ModuleId, int LastReplyId) => DotNetNuke.Modules.ActiveForums.Controllers.TopicController.SaveToForum(ModuleId, ForumId, TopicId, LastReplyId);
+        public int Topics_SaveToForum(int ForumId, int TopicId, int PortalId, int ModuleId, int LastReplyId)
+        {
+            Controllers.TopicController.SaveToForum(ModuleId, ForumId, TopicId, LastReplyId);
+            return -1;
+        }
         [Obsolete("Deprecated in Community Forums. Scheduled removal in 10.00.00. Use DotNetNuke.Modules.ActiveForums.Controllers.TopicController.GetById(int TopicId)")]
         public DotNetNuke.Modules.ActiveForums.Entities.TopicInfo Topics_Get(int PortalId, int ModuleId, int TopicId) => new DotNetNuke.Modules.ActiveForums.Controllers.TopicController().GetById(TopicId);
         [Obsolete("Deprecated in Community Forums. Scheduled removal in 10.00.00. Use DotNetNuke.Modules.ActiveForums.Controllers.TopicController.GetById(int TopicId)")]


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Forum icons not changing color when a new topic is added

## Changes made
- Last topic access date for user is in `activeforums_Forums_Tracking` which has yet been moved to DAL2 and the Forums View didn't have a correct/updated value; added a shim function to retrieve this value until table is used to DAL2 and permanent solution is implemented.
- Updating last forum updated date/topic, etc. was moved to processing queue, so doesn't get updated immediately; logic changed to update the last updated date/topic info for the forum when topic is being saved. Processing queue item will still process but shouldn't update again unless a new topic has appeared. Note: if viewing own topic, there is no concept of it being a "new topic" since you are the user who created it. You have to view it from a different user.

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #973