### PR TITLE
FIX: What's New should only show selected forums

### DIFF
--- a/Dnn.CommunityForums/Controllers/PermissionController.cs
+++ b/Dnn.CommunityForums/Controllers/PermissionController.cs
@@ -27,6 +27,7 @@ using System.Web.Razor.Parser.SyntaxTree;
 using System.Web.Security;
 using System.Web.UI.WebControls;
 using DotNetNuke.Abstractions.Portals;
+using DotNetNuke.Common.Controls;
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Modules.ActiveForums.API;
 using DotNetNuke.Modules.ActiveForums.DAL2;
@@ -756,11 +757,16 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             string sForums = (string) DataCache.SettingsCacheRetrieve(ModuleId, cacheKey);
             if (string.IsNullOrEmpty(sForums))
             {
-                foreach (DotNetNuke.Modules.ActiveForums.Entities.ForumInfo forum in (ModuleId > 0 ? new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().Get(ModuleId) : new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().Get()))
+                sForums = string.Empty;
+                if (!string.IsNullOrEmpty(ForumIds))
                 {
-                    if (forum.AllowRSS && DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(forum.Security?.View, UserRoles))
+                    foreach (string forumId in ForumIds.Split(":".ToCharArray(),StringSplitOptions.RemoveEmptyEntries))
                     {
-                        sForums += forum.ForumID.ToString() + ":";
+                        DotNetNuke.Modules.ActiveForums.Entities.ForumInfo forum = new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().GetById(Convert.ToInt32(forumId));
+                        if (forum.AllowRSS && DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(forum.Security?.View, UserRoles))
+                        {
+                            sForums += forum.ForumID.ToString() + ":";
+                        }
                     }
                 }
                 DataCache.SettingsCacheStore(ModuleId, cacheKey, sForums);

--- a/Dnn.CommunityForums/WhatsNewOptions.ascx.cs
+++ b/Dnn.CommunityForums/WhatsNewOptions.ascx.cs
@@ -72,7 +72,7 @@ namespace DotNetNuke.Modules.ActiveForums
                             }
                         }
                     }
-                    else
+                    else if (trForums.CheckedNodes.Count > 0)
                     {
                         var sv = trForums.CheckedNodes[0].Value;
                         if (sv.Contains("F:"))


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
What's New should only show selected forums

## Changes made
- Fix forum filtering
- Fix exception when saving What's New module settings without selecting any forums

## How did you test these updates?  
Local install
![2024-07-17_15-19-18](https://github.com/user-attachments/assets/bd3017c7-df71-44f8-a79b-d1296122d8fa)


## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #992 
Close #993