### PR TITLE
FIX: Correct update of post count for moderated content

### DIFF
--- a/Dnn.CommunityForums/Controllers/TopicController.cs
+++ b/Dnn.CommunityForums/Controllers/TopicController.cs
@@ -84,17 +84,9 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
 
             topicId = DotNetNuke.Modules.ActiveForums.Controllers.TopicController.Save(ti);
 
-
             if (topicId > 0)
             {
                 DotNetNuke.Modules.ActiveForums.Controllers.TopicController.SaveToForum(ModuleId, ForumId, topicId, -1);
-
-                if (UserId > 0)
-                {
-                    //TODO: update this to be consistent with reply count
-                    Data.Profiles uc = new Data.Profiles();
-                    uc.Profile_UpdateTopicCount(PortalId, UserId);
-                }
             }
             return topicId;
         }
@@ -193,18 +185,20 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                 ti.Content.DateCreated = DateTime.UtcNow;
             }
             UserProfileController.Profiles_ClearCache(ti.ModuleId, ti.Content.AuthorId);
-            if (ti.IsApproved && ti.Author.AuthorId > 0)
-            {   //TODO: put this in a better place and make it consistent with reply counter
-                var uc = new Data.Profiles();
-                uc.Profile_UpdateTopicCount(ti.Forum.PortalId, ti.Author.AuthorId);
-            }
+            
             Utilities.UpdateModuleLastContentModifiedOnDate(ti.ModuleId);
             DataCache.ContentCacheClear(ti.ModuleId, string.Format(CacheKeys.ForumInfo, ti.ModuleId, ti.ForumId));
             DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.ForumViewPrefix, ti.ModuleId));
             DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.TopicViewPrefix, ti.ModuleId));
             DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.TopicsViewPrefix, ti.ModuleId));
             //TODO: convert to use DAL2?
-            return Convert.ToInt32(DataProvider.Instance().Topics_Save(ti.Forum.PortalId, ti.TopicId, ti.ViewCount, ti.ReplyCount, ti.IsLocked, ti.IsPinned, ti.TopicIcon, ti.StatusId, ti.IsApproved, ti.IsDeleted, ti.IsAnnounce, ti.IsArchived, ti.AnnounceStart, ti.AnnounceEnd, ti.Content.Subject.Trim(), ti.Content.Body.Trim(), ti.Content.Summary.Trim(), ti.Content.DateCreated, ti.Content.DateUpdated, ti.Content.AuthorId, ti.Content.AuthorName, ti.Content.IPAddress, (int)ti.TopicType, ti.Priority, ti.TopicUrl, ti.TopicData));
+            int topicId = Convert.ToInt32(DataProvider.Instance().Topics_Save(ti.Forum.PortalId, ti.TopicId, ti.ViewCount, ti.ReplyCount, ti.IsLocked, ti.IsPinned, ti.TopicIcon, ti.StatusId, ti.IsApproved, ti.IsDeleted, ti.IsAnnounce, ti.IsArchived, ti.AnnounceStart, ti.AnnounceEnd, ti.Content.Subject.Trim(), ti.Content.Body.Trim(), ti.Content.Summary.Trim(), ti.Content.DateCreated, ti.Content.DateUpdated, ti.Content.AuthorId, ti.Content.AuthorName, ti.Content.IPAddress, (int)ti.TopicType, ti.Priority, ti.TopicUrl, ti.TopicData));
+            if (ti.IsApproved && ti.Author.AuthorId > 0)
+            {   //TODO: put this in a better place and make it consistent with reply counter
+                var uc = new Data.Profiles();
+                uc.Profile_UpdateTopicCount(ti.Forum.PortalId, ti.Author.AuthorId);
+            }
+            return topicId;
         }
         public void DeleteById(int TopicId)
         {

--- a/Dnn.CommunityForums/controls/af_post.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_post.ascx.cs
@@ -743,13 +743,7 @@ namespace DotNetNuke.Modules.ActiveForums
             TopicId = DotNetNuke.Modules.ActiveForums.Controllers.TopicController.Save(ti);
             DotNetNuke.Modules.ActiveForums.Controllers.TopicController.SaveToForum(ForumModuleId, ForumId, TopicId);
             ti = new DotNetNuke.Modules.ActiveForums.Controllers.TopicController().GetById(TopicId);
-
             SaveAttachments(ti.ContentId);
-            if (ti.IsApproved && ti.Author.AuthorId > 0)
-            {//TODO: move this to more appropriate place and make consistent with reply count
-                var uc = new Data.Profiles();
-                uc.Profile_UpdateTopicCount(PortalId, ti.Author.AuthorId);
-            }
 
             if (DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(ForumInfo.Security.Tag, ForumUser.UserRoles))
             {


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Correct update of post count for moderated content

## Changes made
- Move post count update to be after stored procedure is executed
- Remove unnecessary duplicated code

## How did you test these updates?  
Local install

Before moderation:
(should be 2 not 1).
![image](https://github.com/user-attachments/assets/22e7c30f-1ef2-4ee5-b3a5-c4819424d32a)


After moderation (correctly shows 3)
![image](https://github.com/user-attachments/assets/5b91aa8e-d4a8-4c38-91e2-f96c04dce7cc)

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #983