### PR TITLE
FIX: default permissions not set correctly after PR 1016

### DIFF
--- a/Dnn.CommunityForums/Controllers/ForumController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumController.cs
@@ -291,7 +291,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                 if (isNew || (fi?.PermissionsId == fg?.PermissionsId)) /* new forum or switching from group security to forum security */
                 {
                     fi.PermissionsId = new DotNetNuke.Modules.ActiveForums.Controllers.PermissionController().CreateAdminPermissions(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetAdministratorsRoleId(portalId).ToString(), fi.ModuleId).PermissionsId;
-                    DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.CreateDefaultSets(portalId, fi.PermissionsId);
+                    DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.CreateDefaultSets(portalId, fi.ModuleId, fi.PermissionsId);
                 }
             }
             fi.ForumSettingsKey = useGroupFeatures ? (fg != null ? fg.GroupSettingsKey : string.Empty) : (fi.ForumID > 0 ? $"F:{fi.ForumID}" : string.Empty);

--- a/Dnn.CommunityForums/Controllers/ForumGroupController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumGroupController.cs
@@ -51,7 +51,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             if (isNew)
             {
                 forumGroupInfo.GroupSettingsKey = $"G:{forumGroupInfo.ForumGroupId}";
-                DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.CreateDefaultSets(portalId, forumGroupInfo.PermissionsId);
+                DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.CreateDefaultSets(portalId, forumGroupInfo.ModuleId, forumGroupInfo.PermissionsId);
                 Settings.SaveSetting(forumGroupInfo.ModuleId, forumGroupInfo.GroupSettingsKey, ForumSettingKeys.TopicsTemplateId, "0");
                 Settings.SaveSetting(forumGroupInfo.ModuleId, forumGroupInfo.GroupSettingsKey, ForumSettingKeys.TopicTemplateId, "0");
                 Settings.SaveSetting(forumGroupInfo.ModuleId, forumGroupInfo.GroupSettingsKey, ForumSettingKeys.TopicFormId, "0");

--- a/Dnn.CommunityForums/Controllers/PermissionController.cs
+++ b/Dnn.CommunityForums/Controllers/PermissionController.cs
@@ -87,20 +87,20 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
         {
             return Utilities.GetPortalSettings(portalId).RegisteredRoleName;
         }
-        internal static void CreateDefaultSets(int PortalId, int PermissionsId)
+        internal static void CreateDefaultSets(int PortalId, int ModuleId, int PermissionsId)
         {
             string[] requestedAccessList = new[] { "View", "Read" };
             string RegisteredUsersRoleId = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRegisteredRoleId(PortalId).ToString();
             foreach (string access in requestedAccessList)
             {
-                DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermissions(PermissionsId, PermissionsId, access, RegisteredUsersRoleId, 0);
-                DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermissions(PermissionsId, PermissionsId, access, DotNetNuke.Common.Globals.glbRoleAllUsers, 0);
-                DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermissions(PermissionsId, PermissionsId, access, DotNetNuke.Common.Globals.glbRoleUnauthUser, 0);
+                DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermissions(ModuleId, PermissionsId, access, RegisteredUsersRoleId, 0);
+                DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermissions(ModuleId, PermissionsId, access, DotNetNuke.Common.Globals.glbRoleAllUsers, 0);
+                DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermissions(ModuleId, PermissionsId, access, DotNetNuke.Common.Globals.glbRoleUnauthUser, 0);
             }
             requestedAccessList = new[] { "Create", "Reply" };
             foreach (string access in requestedAccessList)
             {
-                DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermissions(PermissionsId, PermissionsId, access, RegisteredUsersRoleId, 0);
+                DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermissions(ModuleId, PermissionsId, access, RegisteredUsersRoleId, 0);
             }
         }
         internal DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo CreateAdminPermissions(string adminRole, int moduleId)
@@ -133,10 +133,10 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                 ModPin = adminRoleId,
                 ModuleId = moduleId
             };
-            Insert(permissionInfo);
+            this.Insert(permissionInfo);
             return permissionInfo;
         }
-        internal static DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo GetEmptyPermissions()
+        internal static DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo GetEmptyPermissions(int moduleId)
         {
             return new DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo
             {
@@ -162,7 +162,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                 ModUser = emptyPermissions,
                 ModEdit = emptyPermissions,
                 ModLock = emptyPermissions,
-                ModPin = emptyPermissions
+                ModPin = emptyPermissions,
+                ModuleId = moduleId,
             };
         }
         public static bool HasAccess(string AuthorizedRoles, string UserRoles)

--- a/Dnn.CommunityForums/Entities/ForumGroupInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumGroupInfo.cs
@@ -57,7 +57,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             var security = new DotNetNuke.Modules.ActiveForums.Controllers.PermissionController().GetById(PermissionsId, ModuleId);
             if (security == null)
             {
-                security = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetEmptyPermissions();
+                security = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetEmptyPermissions(ModuleId);
                 var log = new DotNetNuke.Services.Log.EventLog.LogInfo { LogTypeKey = DotNetNuke.Abstractions.Logging.EventLogType.ADMIN_ALERT.ToString() };
                 log.LogProperties.Add(new LogDetailInfo("Module", Globals.ModuleFriendlyName));
                 string message = String.Format(Utilities.GetSharedResource("[RESX:PermissionsMissingForForumGroup]"), PermissionsId, ForumGroupId);

--- a/Dnn.CommunityForums/Entities/ForumInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumInfo.cs
@@ -216,7 +216,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             var security = new DotNetNuke.Modules.ActiveForums.Controllers.PermissionController().GetById(PermissionsId, ModuleId);
             if (security == null)
             {
-                security = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetEmptyPermissions();                
+                security = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetEmptyPermissions(ModuleId);                
                 var log = new DotNetNuke.Services.Log.EventLog.LogInfo { LogTypeKey = DotNetNuke.Abstractions.Logging.EventLogType.ADMIN_ALERT.ToString() };
                 log.LogProperties.Add(new LogDetailInfo("Module", Globals.ModuleFriendlyName));
                 string message = String.Format(Utilities.GetSharedResource("[RESX:PermissionsMissingForForum]"), PermissionsId, ForumID);


### PR DESCRIPTION


<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
FIX: default permissions not set correctly after ModuleId added to activeforums_Permissions in PR#1016

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #726