### PR TITLE
FIX: Correct forum tracking updates

### DIFF
--- a/Dnn.CommunityForums/Entities/TopicTrackingInfo.cs
+++ b/Dnn.CommunityForums/Entities/TopicTrackingInfo.cs
@@ -38,11 +38,11 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
 
         public int TopicId { get; set; }
 
-        public int LastReplyRead { get; set; } = 0;
-
-        public DateTime DateAdded { get; set; } = DateTime.UtcNow;
+        public int LastReplyId { get; set; } = 0;
 
         public int UserId { get; set; }
+        
+        public DateTime DateAdded { get; set; } = DateTime.UtcNow;
 
         [IgnoreColumn()]
         public DotNetNuke.Modules.ActiveForums.Entities.TopicInfo Topic

--- a/Dnn.CommunityForums/sql/08.02.00.SqlDataProvider
+++ b/Dnn.CommunityForums/sql/08.02.00.SqlDataProvider
@@ -1637,3 +1637,56 @@ GO
 /* issue 1026 end - DAL2 updates for activeforums_ForumTopics  */
 
 /* --------------------- */
+
+/* issue 1032 begin - update forums_tracking */
+
+/*activeforums_Topics_Tracking_UpdateUser*/
+IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_Topics_Tracking_UpdateUser]') AND type in (N'P', N'PC'))
+DROP PROCEDURE {databaseOwner}[{objectQualifier}activeforums_Topics_Tracking_UpdateUser]
+GO
+
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}activeforums_Topics_Tracking_UpdateUser]
+	@ForumId int,
+	@TopicId int,
+	@LastReplyId int,
+	@UserId int
+	
+AS
+IF EXISTS(SELECT TrackingId FROM {databaseOwner}{objectQualifier}activeforums_Topics_Tracking WHERE UserId = @UserId AND ForumId = @ForumId AND TopicId = @TopicId)
+	UPDATE {databaseOwner}{objectQualifier}activeforums_Topics_Tracking
+		SET DateAdded = GETUTCDATE(), LastReplyId = @LastReplyId
+		WHERE UserId = @UserId AND ForumId = @ForumID AND TopicId = @TopicId
+ELSE
+	INSERT INTO {databaseOwner}{objectQualifier}activeforums_Topics_Tracking
+		(ForumId, TopicId, LastReplyId, UserId,DateAdded)
+		VALUES
+		(@ForumId, @TopicId, @LastReplyId, @UserId, GETUTCDATE())
+
+IF EXISTS(SELECT TrackingId FROM {databaseOwner}{objectQualifier}activeforums_Forums_Tracking WHERE UserId = @UserId AND ForumId = @ForumId)
+	UPDATE {databaseOwner}{objectQualifier}activeforums_Forums_Tracking
+    SET LastAccessDate = GETUTCDATE(), MaxTopicRead = CASE WHEN MaxTopicRead > @TopicId THEN MaxTopicRead ELSE @TopicId END, MaxReplyRead = CASE WHEN MaxReplyRead > @LastReplyId THEN MaxReplyRead ELSE @LastReplyId END 
+	WHERE UserId = @UserId AND ForumId = @ForumID AND (MaxTopicRead < @TopicId OR MaxReplyRead < @LastReplyId)
+ELSE
+	INSERT INTO {databaseOwner}{objectQualifier}activeforums_Forums_Tracking
+	(ModuleId, UserId, ForumId, LastAccessDate, MaxTopicRead, MaxReplyRead)
+	SELECT ModuleId, @UserId, @ForumId, GETUTCDATE(), @TopicId, @LastReplyId 
+    FROM {databaseOwner}{objectQualifier}activeforums_Forums 
+    WHERE ForumId = @ForumId
+
+GO
+
+/* backfill missing data */
+UPDATE ft SET MaxReplyRead = COALESCE(tt.LastReplyId,0), MaxTopicRead = COALESCE(tt.MaxTopicId,0)
+FROM {databaseOwner}{objectQualifier}activeforums_Forums_Tracking ft
+LEFT OUTER JOIN (
+	SELECT UserId, ForumId, MAX(TopicId) AS MaxTopicId, MAX(LastReplyId) AS LastReplyId 
+    FROM {databaseOwner}{objectQualifier}activeforums_Topics_Tracking 
+    GROUP BY UserId, ForumId
+	) tt
+	ON tt.UserId = ft.UserId 
+    AND tt.ForumId = ft.forumId 
+
+
+/* issue 1032 end - update forums_tracking */
+
+/* --------------------- */


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
`MaxTopicRead` and `MaxReplyRead` in `activeforums_Forum_Tracking` table not updated 

## Changes made
- update `activeforums_Topics_Tracking_UpdateUser` stored procedure to update `activeforums_Forum_Tracking`
- update existing data
- fix incorrect column mapping in `TopicTrackingInfo`

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

Before:
![image](https://github.com/user-attachments/assets/b36efba6-77f7-469a-ade9-15439dbe56b5)

After:
![image](https://github.com/user-attachments/assets/047ffd8d-7caa-40c8-bbb8-be3a1c0b3678)

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1032