### PR TITLE
Add "Child" forum resource tokens

### DIFF
--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.de-DE.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.de-DE.resx
@@ -1737,4 +1737,10 @@ Von
   <data name="[RESX:ForumMissingForForumTrackingId]" xml:space="preserve">
     <value>Die Forum-{0} für die {1} der Forum-Tracking-ID wird in der Datenbank nicht gefunden. Sie müssen dies in der Datenbank reparieren oder den Foren-Tracking-Datensatz löschen. Bitte besuchen Sie das Github-Repository der DNN-Community-Foren (https://github.com/DNNCommunity/Dnn.CommunityForums), wo Sie ein Problem posten oder das Wiki für Schritte zur Fehlerbehebung überprüfen können.</value>
   </data>
+  <data name="[RESX:Child].Text" xml:space="preserve">
+    <value>Kind</value>
+  </data>
+  <data name="[RESX:of].Text" xml:space="preserve">
+    <value>von</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.es-ES.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.es-ES.resx
@@ -1740,4 +1740,10 @@ De
   <data name="[RESX:TopicMissingForTopicTrackingId].Text" xml:space="preserve">
     <value>El {0} de tema para el {1} de ID de seguimiento de temas no se encuentra en la base de datos; Deberá reparar esto en la base de datos o eliminar los datos no válidos. Visite el repositorio de Github (https://github.com/DNNCommunity/Dnn.CommunityForums) de los foros de la comunidad DNN, donde puede publicar un problema o revisar la wiki para conocer los pasos de solución de problemas.</value>
   </data>
+  <data name="[RESX:Child].Text" xml:space="preserve">
+    <value>Niño</value>
+  </data>
+  <data name="[RESX:of].Text" xml:space="preserve">
+    <value>de</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.fr-FR.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.fr-FR.resx
@@ -1755,5 +1755,10 @@ De,
   <data name="[RESX:TopicMissingForTopicTrackingId].Text" xml:space="preserve">
     <value>Le {0} de rubrique pour l’ID de suivi de {1} est introuvable dans la base de données ; Vous devrez réparer cela dans la base de données ou supprimer les données invalides. Veuillez visiter le dépôt Github des forums de la communauté DNN (https://github.com/DNNCommunity/Dnn.CommunityForums), où vous pouvez poster un problème ou consulter le wiki pour les étapes de dépannage.</value>
   </data>
-
+  <data name="[RESX:Child].Text" xml:space="preserve">
+    <value>Enfant</value>
+  </data>
+  <data name="[RESX:of].Text" xml:space="preserve">
+    <value>de</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.it-IT.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.it-IT.resx
@@ -1738,5 +1738,10 @@ Da
   <data name="[RESX:TopicMissingForTopicTrackingId].Text" xml:space="preserve">
     <value>Il {0} dell'argomento per l'ID di monitoraggio dell'argomento {1} non viene trovato nel database; Sarà necessario riparare questo nel database o eliminare i dati non validi. Visita il repository Github (https://github.com/DNNCommunity/Dnn.CommunityForums) dei forum della community DNN, dove puoi pubblicare un problema o rivedere il wiki per i passaggi per la risoluzione dei problemi.</value>
   </data>
-
+  <data name="[RESX:Child].Text" xml:space="preserve">
+    <value>Bambino</value>
+  </data>
+  <data name="[RESX:of].Text" xml:space="preserve">
+    <value>di</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.nl-NL.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.nl-NL.resx
@@ -1780,5 +1780,10 @@ Van,
   <data name="[RESX:TopicMissingForTopicTrackingId].Text" xml:space="preserve">
     <value>De Topic {0} voor Topic Tracking Id {1} is niet te vinden in de database. U moet dit in de database herstellen of de ongeldige gegevens verwijderen. Ga naar de Github-repository (https://github.com/DNNCommunity/Dnn.CommunityForums) van de DNN Community Forums, waar u een probleem kunt melden of de wiki kunt bekijken voor stappen voor probleemoplossing.</value>
   </data>
-
+  <data name="[RESX:Child].Text" xml:space="preserve">
+    <value>Kind</value>
+  </data>
+  <data name="[RESX:of].Text" xml:space="preserve">
+    <value>van</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.resx
@@ -1740,4 +1740,10 @@ From,
   <data name="[RESX:TopicMissingForTopicTrackingId].Text" xml:space="preserve">
     <value>The Topic {0} for Topic Tracking Id {1} is not found in the database; you will need to repair this in the database, or delete the invalid data.. Please visit the DNN Community Forums Github repository (https://github.com/DNNCommunity/Dnn.CommunityForums), where you can post an issue or review the wiki for troubleshooting steps.</value>
   </data>
+  <data name="[RESX:Child].Text" xml:space="preserve">
+    <value>Child</value>
+  </data>
+  <data name="[RESX:of].Text" xml:space="preserve">
+    <value>of</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/themes/community-default/templates/ForumView.ascx
+++ b/Dnn.CommunityForums/themes/community-default/templates/ForumView.ascx
@@ -53,19 +53,20 @@
 					</tr>
 
 					[SUBFORUMS]
-					<!-- <tr class="dcf-table-body-row dcf-sub-forums">
-						<td class="dcf-col dcf-col-icon"></td>
-						<td class="dcf-col" colspan="5">
-							<h5 class="dcf-sub-forum-title">Child Forums</h5>
-						</td>
-					</tr> -->
-					
-					<tr class="dcf-table-body-row dcf-sub-forums">
+                    <tr class="dcf-table-body-row dcf-sub-forums">
+                        <td class="dcf-col dcf-col-icon"></td>
+                        <td class="dcf-col" colspan="5">
+                            <h5 class="dcf-sub-forum-title">[RESX:Child] [RESX:FORUMS]</h5>
+                        </td>
+                    </tr>
+
+                    <tr class="dcf-table-body-row dcf-sub-forums">
 
 
 									<td class="dcf-col dcf-col-icon"></td>
 									<td class="dcf-col dcf-col-text">
 												<span class="aftopictitle">[FORUMNAME]</span>
+                                                <span class="aftopictitle">([RESX:Child] [RESX:of] [FORUM:PARENTFORUMNAME])</span>
 												<span class="aftopicsubtitle">[FORUMDESCRIPTION]</span>
 									</td>
 									<td class="dcf-col dcf-col-topics">[TOTALTOPICS]</td>


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Add "Child" forum resource tokens

## Changes made
- Added [RESX:Child] and [RESX:of] resource strings
- Updates community default forum view template to include these as well as [FORUM:PARENTFORUMNAME] token (new in 8.2)

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install as part of 8.2 development.
![image](https://github.com/user-attachments/assets/aed1fd83-d013-466a-b2ed-f95f6c136d1d)
![image](https://github.com/user-attachments/assets/f040e86d-c9a0-487a-80fc-f31221a9b6d2)


## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #470