### PR TITLE
ENH: New message resources for token replacement 

### DIFF
--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.de-DE.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.de-DE.resx
@@ -1743,4 +1743,16 @@ Von
   <data name="[RESX:of].Text" xml:space="preserve">
     <value>von</value>
   </data>
+  <data name="[RESX:TopicMissingForTopicTrackingId].Text" xml:space="preserve">
+    <value>Der {0} für die {1} der Themenverfolgungs-ID wird in der Datenbank nicht gefunden. Sie müssen dies in der Datenbank reparieren oder die ungültigen Daten löschen. Bitte besuchen Sie das Github-Repository der DNN-Community-Foren (https://github.com/DNNCommunity/Dnn.CommunityForums), wo Sie ein Problem posten oder das Wiki für Schritte zur Fehlerbehebung überprüfen können.</value>
+  </data>
+  <data name="[RESX:ReplaceObsoleteToken].Text" xml:space="preserve">
+    <value>Vorlagentoken: {0} ist veraltet. Ersetzen durch {1}.</value>
+  </data>
+  <data name="[RESX:RemoveObsoleteToken].Text" xml:space="preserve">
+    <value>Vorlagentoken: {0} ist veraltet und kann nicht ersetzt werden. Aus Vorlage(n) entfernen.</value>
+  </data>
+  <data name="[RESX:RemoveObsoletePrefixedToken].Text" xml:space="preserve">
+    <value>Vorlagentoken, das beginnt mit: {0} ist veraltet und kann nicht ersetzt werden. Aus Vorlage(n) entfernen.</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.es-ES.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.es-ES.resx
@@ -1746,4 +1746,13 @@ De
   <data name="[RESX:of].Text" xml:space="preserve">
     <value>de</value>
   </data>
+  <data name="[RESX:ReplaceObsoleteToken].Text" xml:space="preserve">
+    <value>Token de plantilla: {0} está obsoleto. Reemplace con {1}.</value>
+  </data>
+  <data name="[RESX:RemoveObsoleteToken].Text" xml:space="preserve">
+    <value>Token de plantilla: {0} está obsoleto y no tiene reemplazo. Eliminar de la(s) plantilla(s).</value>
+  </data>
+  <data name="[RESX:RemoveObsoletePrefixedToken].Text" xml:space="preserve">
+    <value>El token de plantilla que comienza con: {0} está obsoleto y no tiene reemplazo. Eliminar de la(s) plantilla(s).</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.fr-FR.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.fr-FR.resx
@@ -1761,4 +1761,13 @@ De,
   <data name="[RESX:of].Text" xml:space="preserve">
     <value>de</value>
   </data>
+  <data name="[RESX:ReplaceObsoleteToken].Text" xml:space="preserve">
+    <value>Template Token : {0} est obsolète. Remplacez par {1}.</value>
+  </data>
+  <data name="[RESX:RemoveObsoleteToken].Text" xml:space="preserve">
+    <value>Jeton de modèle : {0} est obsolète et ne peut pas être remplacé. Supprimer du ou des modèles.</value>
+  </data>
+  <data name="[RESX:RemoveObsoletePrefixedToken].Text" xml:space="preserve">
+    <value>Jeton de modèle commençant par : {0} est obsolète et ne peut pas être remplacé. Supprimer du ou des modèles.</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.it-IT.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.it-IT.resx
@@ -1744,4 +1744,13 @@ Da
   <data name="[RESX:of].Text" xml:space="preserve">
     <value>di</value>
   </data>
+  <data name="[RESX:ReplaceObsoleteToken].Text" xml:space="preserve">
+    <value>Token modello: {0} è obsoleto. Sostituire con {1}.</value>
+  </data>
+  <data name="[RESX:RemoveObsoleteToken].Text" xml:space="preserve">
+    <value>Token modello: {0} è obsoleto e non ha sostituzione. Rimuovi dal/i modello/i.</value>
+  </data>
+  <data name="[RESX:RemoveObsoletePrefixedToken].Text" xml:space="preserve">
+    <value>Template Token che inizia con: {0} è obsoleto e non ha sostituzione. Rimuovi dal/i modello/i.</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.nl-NL.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.nl-NL.resx
@@ -1786,4 +1786,13 @@ Van,
   <data name="[RESX:of].Text" xml:space="preserve">
     <value>van</value>
   </data>
+  <data name="[RESX:ReplaceObsoleteToken].Text" xml:space="preserve">
+    <value>Template Token: {0} is verouderd. Vervang door {1}.</value>
+  </data>
+  <data name="[RESX:RemoveObsoleteToken].Text" xml:space="preserve">
+    <value>Sjabloontoken: {0} is verouderd en kan niet worden vervangen. Verwijderen uit sjabloon(s).</value>
+  </data>
+  <data name="[RESX:RemoveObsoletePrefixedToken].Text" xml:space="preserve">
+    <value>Template Token beginnend met: {0} is verouderd en kan niet worden vervangen. Verwijderen uit sjabloon(s).</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.resx
@@ -1746,4 +1746,13 @@ From,
   <data name="[RESX:of].Text" xml:space="preserve">
     <value>of</value>
   </data>
+  <data name="[RESX:ReplaceObsoleteToken].Text" xml:space="preserve">
+    <value>Template Token: {0} is obsolete. Replace with {1}.</value>
+  </data>
+  <data name="[RESX:RemoveObsoleteToken].Text" xml:space="preserve">
+    <value>Template Token: {0} is obsolete and has no replacement. Remove from template(s).</value>
+  </data>
+  <data name="[RESX:RemoveObsoletePrefixedToken].Text" xml:space="preserve">
+    <value>Template Token starting with: {0} is obsolete and has no replacement. Remove from template(s).</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/class/ForumBase.cs
+++ b/Dnn.CommunityForums/class/ForumBase.cs
@@ -40,8 +40,6 @@ using DotNetNuke.Services.Localization;
         private int? replyId;
         private int? quoteId;
         private int? authorid;
-        private bool? jumpToLastPost;
-        private string templatePath = string.Empty;
         private DotNetNuke.Modules.ActiveForums.Entities.ForumInfo foruminfo;
         private XmlDocument forumData;
 
@@ -382,10 +380,6 @@ using DotNetNuke.Services.Localization;
         }
 
         public int SocialGroupId { get; set; }
-
-        public bool CanRead => this.canRead ?? this.SecurityCheck("read");
-
-        public bool CanView => this.canView ?? this.SecurityCheck("view");
 
         public bool CanCreate
         {

--- a/Dnn.CommunityForums/class/Settings.cs
+++ b/Dnn.CommunityForums/class/Settings.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2024 by DNN Community
+﻿// Copyright (c) 2013-2024 by DNN Community
 //
 // DNN Community licenses this file to you under the MIT license.
 //
@@ -160,21 +160,9 @@ namespace DotNetNuke.Modules.ActiveForums
             }
         }
 
-        public string ThemeLocation
-        {
-            get
-            {
-                return string.Concat(Globals.ThemesPath, "/", this.Theme, "/");
-            }
-        }
+        public string ThemeLocation =>  string.Concat(Globals.ThemesPath, this.Theme, "/");
 
-        public string TemplatePath
-        {
-            get
-            {
-                return this.ThemeLocation + "templates/";
-            }
-        }
+        public string TemplatePath => string.Concat(this.ThemeLocation, "templates/");
 
         public bool FullText
         {


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...

Token replacement is getting an overhaul in 8.2, and "legacy" tokens in existing templates are being remapped to newer tokens either unique to Community Forums [FORUM:*], [FORUMTOPIC:*], [FORUMPOST:*], and [FORUMUSER:*]. Tokens that are generic to DNN are being remapped to their respective counterpart in DNN, e.g. [DISPLAYNAME] -> [USER:DISPLAYNAME].

To support legacy Community Forums users, the replacement of tokens in (customized) templates not shipped with the Forums module, the mapping/replacement will be logged for each token to the admin log. This requires adding new string resources.

This PR is one of many related to token replacement; the logic for using these new string resources will be in another PR.
## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1061