### PR TITLE
ENH: Implements TokenReplace & IPropertyAccess for primary Forums entites

### DIFF
--- a/Dnn.CommunityForums/Controllers/ForumController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumController.cs
@@ -48,6 +48,9 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                     forum.LoadSubForums();
                     forum.LoadProperties();
                     forum.LoadSettings();
+                    forum.LoadPortalSettings();
+                    forum.LoadMainSettings();
+                    forum.LoadModuleInfo();
                     forum.LoadSecurity();
                 }
 
@@ -69,6 +72,9 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                     forum.LoadSubForums();
                     forum.LoadProperties();
                     forum.LoadSettings();
+                    forum.LoadPortalSettings();
+                    forum.LoadMainSettings();
+                    forum.LoadModuleInfo();
                     forum.LoadSecurity();
                     forums.Add(forum);
                 }
@@ -90,6 +96,9 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                     forum.LoadForumGroup();
                     forum.LoadProperties();
                     forum.LoadSettings();
+                    forum.LoadPortalSettings();
+                    forum.LoadMainSettings();
+                    forum.LoadModuleInfo();
                     forum.LoadSecurity();
                     forums.Add(forum);
                 }

--- a/Dnn.CommunityForums/Controllers/ForumUserController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumUserController.cs
@@ -68,9 +68,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                     user = this.Find("WHERE UserId = @0", userId).FirstOrDefault();
                     if (user != null)
                     {
-                        user.UserInfo =
-                            DotNetNuke.Entities.Users.UserController.GetUserById(portalId: user.PortalId,
-                                userId: userId);
+                        user.UserInfo = DotNetNuke.Entities.Users.UserController.GetUserById(portalId: user.PortalId, userId: userId);
                     }
                     else
                     {

--- a/Dnn.CommunityForums/Controllers/ReplyController.cs
+++ b/Dnn.CommunityForums/Controllers/ReplyController.cs
@@ -48,7 +48,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                 ri.GetTopic();
                 ri.Topic.GetForum();
                 ri.GetContent();
-                ri.GetAuthor();
+                ri.Author = ri.GetAuthor(ri.PortalId, ri.ModuleId, ri.Content.AuthorId);
             }
 
             return ri;

--- a/Dnn.CommunityForums/CustomControls/HTML/TopicBrowser.cs
+++ b/Dnn.CommunityForums/CustomControls/HTML/TopicBrowser.cs
@@ -194,7 +194,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     try
                     {
                         DotNetNuke.Entities.Portals.PortalSettings portalSettings = Utilities.GetPortalSettings(this.PortalId);
-                        tmp = tmp.Replace("[LASTAUTHOR]", DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetDisplayName(portalSettings, this.ModuleId, true, this.ForumUser.GetIsMod(this.ModuleId), this.ForumUser.IsAdmin || this.ForumUser.IsSuperUser, -1, auth.Username, auth.FirstName, auth.LastName, auth.DisplayName));
+                        tmp = tmp.Replace("[LASTAUTHOR]", DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetDisplayName(portalSettings, this._mainSettings, this.ForumUser.GetIsMod(this.ModuleId), this.ForumUser.IsAdmin || this.ForumUser.IsSuperUser, -1, auth.Username, auth.FirstName, auth.LastName, auth.DisplayName));
                     }
                     catch (Exception ex)
                     {
@@ -204,7 +204,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 else
                 {
                     DotNetNuke.Entities.Portals.PortalSettings portalSettings = Utilities.GetPortalSettings(this.PortalId);
-                    tmp = tmp.Replace("[LASTAUTHOR]", DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetDisplayName(portalSettings, this.ModuleId, true, this.ForumUser.GetIsMod(this.ModuleId), this.ForumUser.IsAdmin || this.ForumUser.IsSuperUser, int.Parse(row["LastAuthorId"].ToString()), auth.Username, auth.FirstName, auth.LastName, auth.DisplayName));
+                    tmp = tmp.Replace("[LASTAUTHOR]", DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetDisplayName(portalSettings, this._mainSettings, this.ForumUser.GetIsMod(this.ModuleId), this.ForumUser.IsAdmin || this.ForumUser.IsSuperUser, int.Parse(row["LastAuthorId"].ToString()), auth.Username, auth.FirstName, auth.LastName, auth.DisplayName));
                 }
 
                 if (this._canEdit)

--- a/Dnn.CommunityForums/CustomControls/Views/ForumDisplay.cs
+++ b/Dnn.CommunityForums/CustomControls/Views/ForumDisplay.cs
@@ -227,11 +227,6 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 sForum = sForum.Replace("[LASTPOSTDATE]", lastpostdate);
             }
 
-            // TODO: Properly check "canview"
-            string sIcon = TemplateUtils.ShowIcon(true, fid, this.UserId, DateTime.Parse(lastpostdate), lastReadDate, lastreplyid);
-            string sIconImage = "<img alt=\"" + forumname + "\" src=\"" + this.ThemePath + "images/" + sIcon + "\" />";
-
-            // sForum = sForum.Replace("[FORUMICON]", sIconImage);
             sForum = sForum.Replace("[FORUMICON]", "<div style=\"height:30px;margin=right:10px;\"><i class=\"fa fa-folder fa-2x fa-blue\"></i></div>");
             sForum = sForum.Replace("[CSS:FORUMICON]", "affoldernorm");
             sForum = sForum.Replace("[CSS:FORUMICONSM]", "affoldersmnorm");

--- a/Dnn.CommunityForums/DnnCommunityForums.csproj
+++ b/Dnn.CommunityForums/DnnCommunityForums.csproj
@@ -1462,6 +1462,8 @@
     <Compile Include="Services\Controllers\LikeController.cs" />
     <Compile Include="Services\ForumAuthorizeAttribute.cs" />
     <Compile Include="Services\ServicesHelper.cs" />
+    <Compile Include="Services\Tokens\ResourceStringTokenReplacer.cs" />
+    <Compile Include="Services\Tokens\TokenReplacer.cs" />
     <Compile Include="Services\URLNavigator.cs">
       <SubType>ASPXCodeBehind</SubType>
     </Compile>

--- a/Dnn.CommunityForums/Entities/AuthorInfo.cs
+++ b/Dnn.CommunityForums/Entities/AuthorInfo.cs
@@ -1,7 +1,8 @@
-﻿//
-// Community Forums
-// Copyright (c) 2013-2024
-// by DNN Community
+﻿// Copyright (c) 2013-2024 by DNN Community
+//
+// DNN Community licenses this file to you under the MIT license.
+//
+// See the LICENSE file in the project root for more information.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 // documentation files (the "Software"), to deal in the Software without restriction, including without limitation
@@ -16,14 +17,15 @@
 // THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
-//
+
+using DotNetNuke.UI.UserControls;
 
 namespace DotNetNuke.Modules.ActiveForums.Entities
 {
     /// <summary>
     /// Author is really the same as a user. Just separated out to make code more understandable.
     /// </summary>
-	public class AuthorInfo
+    public class AuthorInfo
     {
         private DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo forumUserInfo;
 
@@ -39,7 +41,12 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
 
         public AuthorInfo(int portalId, int moduleId, int userId)
         {
-            this.forumUserInfo = new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(-1).GetByUserId(portalId, userId);
+            this.forumUserInfo = new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(moduleId).GetByUserId(portalId, userId);
+            if (this.forumUserInfo == null)
+            {
+                this.AuthorId = userId;
+                this.DisplayName = this.AuthorId > 0 ? Utilities.GetSharedResource("[RESX:DeletedUser]") : Utilities.GetSharedResource("[RESX:Anonymous]");
+            }
         }
 
         public DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo ForumUser { get => this.forumUserInfo; set => this.forumUserInfo = value; }

--- a/Dnn.CommunityForums/Entities/ForumInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumInfo.cs
@@ -30,7 +30,10 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Modules.ActiveForums.Enums;
     using DotNetNuke.Services.Log.EventLog;
+    using DotNetNuke.Entities.Modules;
+    using DotNetNuke.Entities.Portals;
     using DotNetNuke.Services.Tokens;
+
 
     [TableName("activeforums_Forums")]
     [PrimaryKey("ForumID", AutoIncrement = true)] /* ForumID because needs to match property name NOT database column name */

--- a/Dnn.CommunityForums/Entities/ForumInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumInfo.cs
@@ -26,18 +26,32 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
     using System.Linq;
 
     using DotNetNuke.ComponentModel.DataAnnotations;
+    using DotNetNuke.Entities.Modules;
+    using DotNetNuke.Entities.Portals;
     using DotNetNuke.Modules.ActiveForums.Enums;
     using DotNetNuke.Services.Log.EventLog;
+    using DotNetNuke.Services.Tokens;
 
     [TableName("activeforums_Forums")]
     [PrimaryKey("ForumID", AutoIncrement = true)] /* ForumID because needs to match property name NOT database column name */
     [Scope("ModuleId")]
 
     // TODO [Cacheable("activeforums_Forums", CacheItemPriority.Low)] /* TODO: DAL2 caching cannot be used until all CRUD methods use DAL2; must update Save method to use DAL2 rather than stored procedure */
-    public partial class ForumInfo
+    public class ForumInfo : DotNetNuke.Services.Tokens.IPropertyAccess
     {
+
         private DotNetNuke.Modules.ActiveForums.Entities.ForumGroupInfo forumGroup;
         private List<DotNetNuke.Modules.ActiveForums.Entities.ForumInfo> subforums;
+        private DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo security;
+        private Hashtable forumSettings;
+        private DotNetNuke.Modules.ActiveForums.SettingsInfo mainSettings;
+        private PortalSettings portalSettings;
+        private ModuleInfo moduleInfo;
+
+        public ForumInfo()
+        {
+            this.PortalSettings = Utilities.GetPortalSettings(this.PortalId);
+        }
 
         [ColumnName("ForumId")]
         public int ForumID { get; set; }
@@ -96,7 +110,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
 
         public bool HasProperties { get; set; }
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public DotNetNuke.Modules.ActiveForums.Entities.ForumGroupInfo ForumGroup
         {
             get => this.forumGroup ?? (this.forumGroup = this.LoadForumGroup());
@@ -110,31 +124,31 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             {
                 var log = new DotNetNuke.Services.Log.EventLog.LogInfo { LogTypeKey = DotNetNuke.Abstractions.Logging.EventLogType.ADMIN_ALERT.ToString() };
                 log.LogProperties.Add(new LogDetailInfo("Module", Globals.ModuleFriendlyName));
-                string message = String.Format(Utilities.GetSharedResource("[RESX:ForumGroupMissingForForum]"), this.ForumGroupId, this.ForumID);
+                var message = string.Format(Utilities.GetSharedResource("[RESX:ForumGroupMissingForForum]"), this.ForumGroupId, this.ForumID);
                 log.AddProperty("Message", message);
                 DotNetNuke.Services.Log.EventLog.LogController.Instance.AddLog(log);
 
-                var ex = new NullReferenceException(String.Format(Utilities.GetSharedResource("[RESX:ForumGroupMissingForForum]"), this.ForumGroupId, this.ForumID));
+                var ex = new NullReferenceException(string.Format(Utilities.GetSharedResource("[RESX:ForumGroupMissingForForum]"), this.ForumGroupId, this.ForumID));
                 DotNetNuke.Services.Exceptions.Exceptions.LogException(ex);
                 throw ex;
             }
 
             return group;
         }
-        
-        [IgnoreColumn()]
+
+        [IgnoreColumn]
         public string GroupName => this.ForumGroup.GroupName;
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public string GroupPrefixURL => this.ForumGroup.PrefixURL;
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public string LastTopicUrl { get; set; }
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public DateTime LastRead { get; set; }
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public string LastPostFirstName
         {
             get
@@ -155,7 +169,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             }
         }
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public string LastPostLastName
         {
             get
@@ -176,7 +190,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             }
         }
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public string LastPostDisplayName
         {
             get
@@ -197,25 +211,29 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             }
         }
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public bool InheritSecurity => this.PermissionsId == this.ForumGroup.PermissionsId;
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public bool InheritSettings => this.ForumSettingsKey == this.ForumGroup.GroupSettingsKey;
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public int SubscriberCount => new DotNetNuke.Modules.ActiveForums.Controllers.SubscriptionController().Count(portalId: this.PortalId, moduleId: this.ModuleId, forumId: this.ForumID);
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public string ParentForumName => this.ParentForumId > 0 ? new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().GetById(this.ParentForumId, this.ModuleId).ForumName : string.Empty;
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
+        public string ParentForumUrlPrefix => this.ParentForumId > 0 ? new Controllers.ForumController().GetById(this.ParentForumId, this.ModuleId).PrefixURL : string.Empty;
+
+
+        [IgnoreColumn]
         public int TabId => new DotNetNuke.Entities.Modules.ModuleController().GetModule(this.ModuleId).TabID;
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public string ForumURL => URL.ForumLink(this.TabId, this);
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public List<DotNetNuke.Modules.ActiveForums.Entities.ForumInfo> SubForums
         {
             get => this.subforums ?? this.LoadSubForums();
@@ -229,7 +247,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
 
         private List<DotNetNuke.Modules.ActiveForums.Entities.PropertyInfo> properties;
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public List<DotNetNuke.Modules.ActiveForums.Entities.PropertyInfo> Properties
         {
             get => this.properties ?? (this.properties = this.LoadProperties());
@@ -243,264 +261,14 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
 
         #region "Settings & Security"
 
-        private DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo security;
-        private Hashtable forumSettings;
-
-        [IgnoreColumn()]
-        public DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo Security
+        [IgnoreColumn]
+        public bool GetIsMod(DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo forumUser)
         {
-            get => this.security ?? (this.security = this.LoadSecurity());
-            set => this.security = value;
+            return (!(string.IsNullOrEmpty(DotNetNuke.Modules.ActiveForums.Controllers.ForumController.GetForumsForUser(forumUser.UserRoles, this.PortalId, this.ModuleId, "CanApprove"))));
         }
 
-        internal DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo LoadSecurity()
-        {
-            var security = new DotNetNuke.Modules.ActiveForums.Controllers.PermissionController().GetById(this.PermissionsId, this.ModuleId);
-            if (security == null)
-            {
-                security = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetEmptyPermissions(this.ModuleId);
-                var log = new DotNetNuke.Services.Log.EventLog.LogInfo { LogTypeKey = DotNetNuke.Abstractions.Logging.EventLogType.ADMIN_ALERT.ToString() };
-                log.LogProperties.Add(new LogDetailInfo("Module", Globals.ModuleFriendlyName));
-                string message = String.Format(Utilities.GetSharedResource("[RESX:PermissionsMissingForForum]"), this.PermissionsId, this.ForumID);
-                log.AddProperty("Message", message);
-                DotNetNuke.Services.Log.EventLog.LogController.Instance.AddLog(log);
-            }
-
-            return security;
-        }
-
-        [IgnoreColumn()]
-        public Hashtable ForumSettings
-        {
-            get => this.forumSettings ?? (this.forumSettings = this.LoadSettings());
-            set => this.forumSettings = value;
-        }
-
-        internal Hashtable LoadSettings()
-        {
-            return (Hashtable)DataCache.GetSettings(this.ModuleId, this.ForumSettingsKey, string.Format(CacheKeys.ForumSettingsByKey, this.ModuleId, this.ForumSettingsKey), true);
-        }
-
-        [IgnoreColumn()]
-        public bool AllowAttach => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AllowAttach]);
-
-        [IgnoreColumn()]
-        public bool AllowEmoticons => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AllowEmoticons]);
-
-        [IgnoreColumn()]
-        public bool AllowHTML => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AllowHTML]);
-
-        [IgnoreColumn()]
-        public bool AllowLikes => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AllowLikes]);
-
-        [IgnoreColumn()]
-        public bool AllowPostIcon => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AllowPostIcon]);
-
-        [IgnoreColumn()]
-        public bool AllowRSS => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AllowRSS]);
-
-        [IgnoreColumn()]
-        public bool AllowScript => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AllowScript]);
-
-        [IgnoreColumn()]
-        public bool AllowSubscribe => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AllowSubscribe]);
-
-        [IgnoreColumn()]
-        public int AttachCount => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.AttachCount], 3);
-
-        [IgnoreColumn()]
-        public int AttachMaxSize => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.AttachMaxSize], 1000);
-
-        [IgnoreColumn()]
-        public string AttachTypeAllowed => Utilities.SafeConvertString(this.ForumSettings[ForumSettingKeys.AttachTypeAllowed], ".jpg,.gif,.png");
-
-        [IgnoreColumn()]
-        public bool AttachAllowBrowseSite => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AttachAllowBrowseSite]);
-
-        [IgnoreColumn()]
-        public int MaxAttachWidth => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.MaxAttachWidth], 800);
-
-        [IgnoreColumn()]
-        public int MaxAttachHeight => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.MaxAttachHeight], 800);
-
-        [IgnoreColumn()]
-        public bool AttachInsertAllowed => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AttachInsertAllowed]);
-
-        [IgnoreColumn()]
-        public bool ConvertingToJpegAllowed => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.ConvertingToJpegAllowed]);
-
-        [IgnoreColumn()]
-        public string EditorHeight => Utilities.SafeConvertString(this.ForumSettings[ForumSettingKeys.EditorHeight], "400");
-
-        [IgnoreColumn()]
-        public EditorTypes EditorMobile
-        {
-            get
-            {
-                EditorTypes parseValue;
-                return Enum.TryParse(Utilities.SafeConvertString(this.ForumSettings[ForumSettingKeys.EditorMobile], EditorTypes.HTMLEDITORPROVIDER.ToString()), true, out parseValue)
-                           ? parseValue
-                           : EditorTypes.HTMLEDITORPROVIDER;
-            }
-        }
-
-        [IgnoreColumn()]
-        public EditorTypes EditorType
-        {
-            get
-            {
-                EditorTypes parseValue;
-                return Enum.TryParse(Utilities.SafeConvertString(this.ForumSettings[ForumSettingKeys.EditorType], EditorTypes.HTMLEDITORPROVIDER.ToString()), true, out parseValue)
-                           ? parseValue
-                           : EditorTypes.HTMLEDITORPROVIDER;
-            }
-        }
-
-        [IgnoreColumn()]
-        public HTMLPermittedUsers EditorPermittedUsers
-        {
-            get
-            {
-                HTMLPermittedUsers parseValue;
-                return Enum.TryParse(Utilities.SafeConvertString(this.ForumSettings[ForumSettingKeys.EditorPermittedUsers], "1"), true, out parseValue)
-                           ? parseValue
-                           : HTMLPermittedUsers.AuthenticatedUsers;
-            }
-        }
-
-        [IgnoreColumn()]
-        public string EditorWidth => Utilities.SafeConvertString(this.ForumSettings[ForumSettingKeys.EditorWidth], "100%");
-
-        [IgnoreColumn()]
-        public string EmailAddress => Utilities.SafeConvertString(this.ForumSettings[ForumSettingKeys.EmailAddress], string.Empty);
-
-        [IgnoreColumn()]
-        public bool IndexContent => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.IndexContent]);
-
-        /// <summary>
-        /// Indicates a moderated forum
-        /// </summary>
-        [IgnoreColumn()]
-        public bool IsModerated => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.IsModerated]);
-
-        [IgnoreColumn()]
-        public int TopicsTemplateId => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.TopicsTemplateId]);
-
-        [IgnoreColumn()]
-        public int TopicTemplateId => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.TopicTemplateId]);
-
-        [IgnoreColumn()]
-        public int TopicFormId => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.TopicFormId]);
-
-        [IgnoreColumn()]
-        public int ReplyFormId => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.ReplyFormId]);
-
-        [IgnoreColumn()]
-        public int QuickReplyFormId => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.QuickReplyFormId]);
-
-        [IgnoreColumn()]
-        public int ProfileTemplateId => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.ProfileTemplateId]);
-
-        [IgnoreColumn()]
-        public bool UseFilter => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.UseFilter]);
-
-        [IgnoreColumn()]
-        public int AutoTrustLevel => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.AutoTrustLevel]);
-
-        [IgnoreColumn()]
-        public TrustTypes DefaultTrustValue
-        {
-            get
-            {
-                TrustTypes parseValue;
-                return Enum.TryParse(Utilities.SafeConvertString(this.ForumSettings[ForumSettingKeys.DefaultTrustLevel], "0"), true, out parseValue)
-                       ? parseValue
-                       : TrustTypes.NotTrusted;
-            }
-        }
-
-        [IgnoreColumn()]
-        public int ModApproveTemplateId => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.ModApproveTemplateId]);
-
-        [IgnoreColumn()]
-        public int ModRejectTemplateId => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.ModRejectTemplateId]);
-
-        [IgnoreColumn()]
-        public int ModMoveTemplateId => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.ModMoveTemplateId]);
-
-        [IgnoreColumn()]
-        public int ModDeleteTemplateId => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.ModDeleteTemplateId]);
-
-        [IgnoreColumn()]
-        public int ModNotifyTemplateId => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.ModNotifyTemplateId]);
-
-        [IgnoreColumn()]
-        public bool AllowTags => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AllowTags]);
-
-        [IgnoreColumn()]
-        public bool AutoSubscribeEnabled => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AutoSubscribeEnabled]);
-
-        [IgnoreColumn()]
-        public string AutoSubscribeRoles => Utilities.SafeConvertString(this.ForumSettings[ForumSettingKeys.AutoSubscribeRoles], string.Empty);
-
-        [IgnoreColumn()]
-        public bool AutoSubscribeNewTopicsOnly => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AutoSubscribeNewTopicsOnly]);
-
-        /// <summary>
-        ///  Minimum posts required to create a topic in this forum if the user is not trusted
-        /// </summary>
-        [IgnoreColumn()]
-        public int CreatePostCount => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.CreatePostCount]);
-
-        /// <summary>
-        /// Minimum posts required to reply to a topic in this forum if the user is not trusted
-        /// </summary>
-        [IgnoreColumn()]
-        public int ReplyPostCount => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.ReplyPostCount]);
-
-        #region "Deprecated Methods"
-
-        [Obsolete("Deprecated in Community Forums. Scheduled for removal in 10.00.00. Not Used.")]
-        [IgnoreColumn()]
-        public int LastPostLastPostID { get; set; }
-
-        [Obsolete("Deprecated in Community Forums. Scheduled for removal in 10.00.00. Not Used.")]
-        [IgnoreColumn()]
-        public int LastPostParentPostID { get; set; }
-
-        [Obsolete("Deprecated in Community Forums. Scheduled for removal in 10.00.00. Not Used.")]
-        [IgnoreColumn()]
-        public int CustomFieldType { get; set; }
-
-        [Obsolete("Deprecated in Community Forums. Scheduled for removal in 10.00.00. Not Used.")]
-        [IgnoreColumn()]
-        public int AttachMaxHeight
-        {
-            get { return Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.AttachMaxHeight], 500); }
-        }
-
-        [Obsolete("Deprecated in Community Forums. Scheduled for removal in 10.00.00. Not Used.")]
-        [IgnoreColumn()]
-        public int AttachMaxWidth
-        {
-            get { return Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.AttachMaxWidth], 500); }
-        }
-
-        [Obsolete("Deprecated in Community Forums. Scheduled for removal in 10.00.00. Not Used.")]
-        [IgnoreColumn()]
-        public int EditorStyle
-        {
-            get { return Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.EditorStyle], 1); }
-        }
-
-        [Obsolete("Deprecated in Community Forums. Scheduled for removal in 10.00.00. Not Used.")]
-        [IgnoreColumn()]
-        public string EditorToolBar
-        {
-            get { return Utilities.SafeConvertString(this.ForumSettings[ForumSettingKeys.EditorToolbar], "bold,italic,underline"); }
-        }
-        #endregion "Deprecated Methods"
-        #endregion
+        [IgnoreColumn]
+        public string ThemeLocation => Utilities.ResolveUrl(SettingsBase.GetModuleSettings(this.ModuleId).ThemeLocation);
 
         [IgnoreColumn]
         internal DotNetNuke.Modules.ActiveForums.Enums.ForumStatus GetForumStatusForUser(ForumUserInfo forumUser)
@@ -511,6 +279,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             {
                 return DotNetNuke.Modules.ActiveForums.Enums.ForumStatus.Forbidden;
             }
+
             if (this.LastTopicId == 0)
             {
                 return DotNetNuke.Modules.ActiveForums.Enums.ForumStatus.Empty;
@@ -537,6 +306,302 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             }
         }
 
+
+
+        [IgnoreColumn]
+        public DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo Security
+        {
+            get => this.security ?? (this.security = this.LoadSecurity());
+            set => this.security = value;
+        }
+
+        internal DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo LoadSecurity()
+        {
+            var security = new DotNetNuke.Modules.ActiveForums.Controllers.PermissionController().GetById(this.PermissionsId, this.ModuleId);
+            if (security == null)
+            {
+                security = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetEmptyPermissions(this.ModuleId);
+                var log = new DotNetNuke.Services.Log.EventLog.LogInfo { LogTypeKey = DotNetNuke.Abstractions.Logging.EventLogType.ADMIN_ALERT.ToString() };
+                log.LogProperties.Add(new LogDetailInfo("Module", Globals.ModuleFriendlyName));
+                var message = string.Format(Utilities.GetSharedResource("[RESX:PermissionsMissingForForum]"), this.PermissionsId, this.ForumID);
+                log.AddProperty("Message", message);
+                DotNetNuke.Services.Log.EventLog.LogController.Instance.AddLog(log);
+            }
+
+            return security;
+        }
+
+        [IgnoreColumn]
+        public SettingsInfo MainSettings
+        {
+            get => this.mainSettings ?? (this.mainSettings = this.LoadMainSettings());
+            set => this.mainSettings = value;
+        }
+
+        internal SettingsInfo LoadMainSettings()
+        {
+            return SettingsBase.GetModuleSettings(this.ModuleId);
+        }
+
+        [IgnoreColumn]
+        public PortalSettings PortalSettings
+        {
+            get => this.portalSettings ?? (this.portalSettings = this.LoadPortalSettings());
+            set => this.portalSettings = value;
+        }
+
+        internal PortalSettings LoadPortalSettings()
+        {
+            return Utilities.GetPortalSettings(this.PortalId);
+        }
+
+        [IgnoreColumn]
+        public Hashtable ForumSettings
+        {
+            get => this.forumSettings ?? (this.forumSettings = this.LoadSettings());
+            set => this.forumSettings = value;
+        }
+
+        internal Hashtable LoadSettings()
+        {
+            return DataCache.GetSettings(this.ModuleId, this.ForumSettingsKey, string.Format(CacheKeys.ForumSettingsByKey, this.ModuleId, this.ForumSettingsKey), true);
+        }
+
+        [IgnoreColumn]
+        public ModuleInfo ModuleInfo
+        {
+            get => this.moduleInfo ?? (this.moduleInfo = this.LoadModuleInfo());
+            set => this.moduleInfo = value;
+        }
+
+        internal ModuleInfo LoadModuleInfo()
+        {
+            return DotNetNuke.Entities.Modules.ModuleController.Instance.GetModule(this.ModuleId, DotNetNuke.Common.Utilities.Null.NullInteger, false);
+        }
+
+        [IgnoreColumn]
+        public bool AllowAttach => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AllowAttach]);
+
+        [IgnoreColumn]
+        public bool AllowEmoticons => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AllowEmoticons]);
+
+        [IgnoreColumn]
+        public bool AllowHTML => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AllowHTML]);
+
+        [IgnoreColumn]
+        public bool AllowLikes => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AllowLikes]);
+
+        [IgnoreColumn]
+        public bool AllowPostIcon => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AllowPostIcon]);
+
+        [IgnoreColumn]
+        public bool AllowRSS => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AllowRSS]);
+
+        [IgnoreColumn]
+        public bool AllowScript => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AllowScript]);
+
+        [IgnoreColumn]
+        public bool AllowSubscribe => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AllowSubscribe]);
+
+        [IgnoreColumn]
+        public int AttachCount => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.AttachCount], 3);
+
+        [IgnoreColumn]
+        public int AttachMaxSize => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.AttachMaxSize], 1000);
+
+        [IgnoreColumn]
+        public string AttachTypeAllowed => Utilities.SafeConvertString(this.ForumSettings[ForumSettingKeys.AttachTypeAllowed], ".jpg,.gif,.png");
+
+        [IgnoreColumn]
+        public bool AttachAllowBrowseSite => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AttachAllowBrowseSite]);
+
+        [IgnoreColumn]
+        public int MaxAttachWidth => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.MaxAttachWidth], 800);
+
+        [IgnoreColumn]
+        public int MaxAttachHeight => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.MaxAttachHeight], 800);
+
+        [IgnoreColumn]
+        public bool AttachInsertAllowed => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AttachInsertAllowed]);
+
+        [IgnoreColumn]
+        public bool ConvertingToJpegAllowed => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.ConvertingToJpegAllowed]);
+
+        [IgnoreColumn]
+        public string EditorHeight => Utilities.SafeConvertString(this.ForumSettings[ForumSettingKeys.EditorHeight], "400");
+
+        [IgnoreColumn]
+        public EditorTypes EditorMobile
+        {
+            get
+            {
+                EditorTypes parseValue;
+                return Enum.TryParse(Utilities.SafeConvertString(this.ForumSettings[ForumSettingKeys.EditorMobile], EditorTypes.HTMLEDITORPROVIDER.ToString()), true, out parseValue)
+                           ? parseValue
+                           : EditorTypes.HTMLEDITORPROVIDER;
+            }
+        }
+
+        [IgnoreColumn]
+        public EditorTypes EditorType
+        {
+            get
+            {
+                EditorTypes parseValue;
+                return Enum.TryParse(Utilities.SafeConvertString(this.ForumSettings[ForumSettingKeys.EditorType], EditorTypes.HTMLEDITORPROVIDER.ToString()), true, out parseValue)
+                           ? parseValue
+                           : EditorTypes.HTMLEDITORPROVIDER;
+            }
+        }
+
+        [IgnoreColumn]
+        public HTMLPermittedUsers EditorPermittedUsers
+        {
+            get
+            {
+                HTMLPermittedUsers parseValue;
+                return Enum.TryParse(Utilities.SafeConvertString(this.ForumSettings[ForumSettingKeys.EditorPermittedUsers], "1"), true, out parseValue)
+                           ? parseValue
+                           : HTMLPermittedUsers.AuthenticatedUsers;
+            }
+        }
+
+        [IgnoreColumn]
+        public string EditorWidth => Utilities.SafeConvertString(this.ForumSettings[ForumSettingKeys.EditorWidth], "100%");
+
+        [IgnoreColumn]
+        public string EmailAddress => Utilities.SafeConvertString(this.ForumSettings[ForumSettingKeys.EmailAddress], string.Empty);
+
+        [IgnoreColumn]
+        public bool IndexContent => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.IndexContent]);
+
+        /// <summary>
+        /// Indicates a moderated forum
+        /// </summary>
+        [IgnoreColumn]
+        public bool IsModerated => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.IsModerated]);
+
+        [IgnoreColumn]
+        public int TopicsTemplateId => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.TopicsTemplateId]);
+
+        [IgnoreColumn]
+        public int TopicTemplateId => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.TopicTemplateId]);
+
+        [IgnoreColumn]
+        public int TopicFormId => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.TopicFormId]);
+
+        [IgnoreColumn]
+        public int ReplyFormId => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.ReplyFormId]);
+
+        [IgnoreColumn]
+        public int QuickReplyFormId => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.QuickReplyFormId]);
+
+        [IgnoreColumn]
+        public int ProfileTemplateId => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.ProfileTemplateId]);
+
+        [IgnoreColumn]
+        public bool UseFilter => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.UseFilter]);
+
+        [IgnoreColumn]
+        public int AutoTrustLevel => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.AutoTrustLevel]);
+
+        [IgnoreColumn]
+        public TrustTypes DefaultTrustValue
+        {
+            get
+            {
+                TrustTypes parseValue;
+                return Enum.TryParse(Utilities.SafeConvertString(this.ForumSettings[ForumSettingKeys.DefaultTrustLevel], "0"), true, out parseValue)
+                       ? parseValue
+                       : TrustTypes.NotTrusted;
+            }
+        }
+
+        [IgnoreColumn]
+        public int ModApproveTemplateId => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.ModApproveTemplateId]);
+
+        [IgnoreColumn]
+        public int ModRejectTemplateId => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.ModRejectTemplateId]);
+
+        [IgnoreColumn]
+        public int ModMoveTemplateId => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.ModMoveTemplateId]);
+
+        [IgnoreColumn]
+        public int ModDeleteTemplateId => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.ModDeleteTemplateId]);
+
+        [IgnoreColumn]
+        public int ModNotifyTemplateId => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.ModNotifyTemplateId]);
+
+        [IgnoreColumn]
+        public bool AllowTags => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AllowTags]);
+
+        [IgnoreColumn]
+        public bool AutoSubscribeEnabled => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AutoSubscribeEnabled]);
+
+        [IgnoreColumn]
+        public string AutoSubscribeRoles => Utilities.SafeConvertString(this.ForumSettings[ForumSettingKeys.AutoSubscribeRoles], string.Empty);
+
+        [IgnoreColumn]
+        public bool AutoSubscribeNewTopicsOnly => Utilities.SafeConvertBool(this.ForumSettings[ForumSettingKeys.AutoSubscribeNewTopicsOnly]);
+
+        /// <summary>
+        ///  Minimum posts required to create a topic in this forum if the user is not trusted
+        /// </summary>
+        [IgnoreColumn]
+        public int CreatePostCount => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.CreatePostCount]);
+
+        /// <summary>
+        /// Minimum posts required to reply to a topic in this forum if the user is not trusted
+        /// </summary>
+        [IgnoreColumn]
+        public int ReplyPostCount => Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.ReplyPostCount]);
+
+        #region "Deprecated Methods"
+
+        [Obsolete("Deprecated in Community Forums. Scheduled for removal in 10.00.00. Not Used.")]
+        [IgnoreColumn]
+        public int LastPostLastPostID { get; set; }
+
+        [Obsolete("Deprecated in Community Forums. Scheduled for removal in 10.00.00. Not Used.")]
+        [IgnoreColumn]
+        public int LastPostParentPostID { get; set; }
+
+        [Obsolete("Deprecated in Community Forums. Scheduled for removal in 10.00.00. Not Used.")]
+        [IgnoreColumn]
+        public int CustomFieldType { get; set; }
+
+        [Obsolete("Deprecated in Community Forums. Scheduled for removal in 10.00.00. Not Used.")]
+        [IgnoreColumn]
+        public int AttachMaxHeight
+        {
+            get { return Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.AttachMaxHeight], 500); }
+        }
+
+        [Obsolete("Deprecated in Community Forums. Scheduled for removal in 10.00.00. Not Used.")]
+        [IgnoreColumn]
+        public int AttachMaxWidth
+        {
+            get { return Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.AttachMaxWidth], 500); }
+        }
+
+        [Obsolete("Deprecated in Community Forums. Scheduled for removal in 10.00.00. Not Used.")]
+        [IgnoreColumn]
+        public int EditorStyle
+        {
+            get { return Utilities.SafeConvertInt(this.ForumSettings[ForumSettingKeys.EditorStyle], 1); }
+        }
+
+        [Obsolete("Deprecated in Community Forums. Scheduled for removal in 10.00.00. Not Used.")]
+        [IgnoreColumn]
+        public string EditorToolBar
+        {
+            get { return Utilities.SafeConvertString(this.ForumSettings[ForumSettingKeys.EditorToolbar], "bold,italic,underline"); }
+        }
+        #endregion "Deprecated Methods"
+        #endregion
+
+
+
         [IgnoreColumn]
         internal string GetForumStatusCss(DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo forumUser)
         {
@@ -546,22 +611,27 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                     {
                         return "dcf-forumstatus-no-access";
                     }
+
                 case ForumStatus.Empty:
                     {
                         return "dcf-forumstatus-no-topics";
                     }
+
                 case ForumStatus.NewTopics:
                     {
                         return "dcf-forumstatus-new-topics";
                     }
+
                 case ForumStatus.UnreadTopics:
                     {
                         return "dcf-forumstatus-unread-topics";
                     }
+
                 case ForumStatus.AllTopicsRead:
                     {
                         return "dcf-forumstatus-all-topics-read";
                     }
+
                 default:
                     {
                         return "dcf-forumstatus-all-topics-read";
@@ -578,22 +648,27 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                     {
                         return mainSettings.ThemeLocation + "images/folder_forbidden.png";
                     }
+
                 case ForumStatus.Empty:
                     {
                         return mainSettings.ThemeLocation + "images/folder_closed.png";
                     }
+
                 case ForumStatus.NewTopics:
                     {
                         return mainSettings.ThemeLocation + "images/folder_new.png";
                     }
+
                 case ForumStatus.UnreadTopics:
                     {
                         return mainSettings.ThemeLocation + "images/folder_new.png";
                     }
+
                 case ForumStatus.AllTopicsRead:
                     {
                         return mainSettings.ThemeLocation + "images/folder.png";
                     }
+
                 default:
                     {
                         return mainSettings.ThemeLocation + "images/folder.png";
@@ -610,27 +685,253 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                     {
                         return "fa-folder fa-grey";
                     }
+
                 case ForumStatus.Empty:
                     {
                         return "fa-folder-o fa-grey";
                     }
+
                 case ForumStatus.NewTopics:
                     {
                         return "fa-folder fa-red";
                     }
+
                 case ForumStatus.UnreadTopics:
                     {
                         return "fa-folder fa-red";
                     }
+
                 case ForumStatus.AllTopicsRead:
                     {
                         return "fa-folder fa-blue";
                     }
+
                 default:
                     {
                         return "fa-folder fa-blue";
                     }
             }
+        }
+
+        [IgnoreColumn]
+        public DotNetNuke.Services.Tokens.CacheLevel Cacheability
+        {
+            get
+            {
+                return DotNetNuke.Services.Tokens.CacheLevel.notCacheable;
+            }
+        }
+
+
+        /// <inheritdoc/>
+        public string GetProperty(string propertyName, string format, System.Globalization.CultureInfo formatProvider, DotNetNuke.Entities.Users.UserInfo accessingUser, Scope accessLevel, ref bool propertyNotFound)
+        {
+            // replace any embedded tokens in format string
+            if (format.Contains("!(") && format.Contains(")!"))
+            {
+                format = format.Replace("!(", "[").Replace(")!", "]");
+                var tokenReplacer = new DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer(this.PortalSettings, new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(accessingUser.PortalID, accessingUser.UserID), this)
+                {
+                    AccessingUser = accessingUser,
+                };
+                format = tokenReplacer.ReplaceEmbeddedTokens(format);
+            }
+
+            propertyName = propertyName.ToLowerInvariant();
+
+            if (propertyName.Contains("lastpostsubject:"))
+            {
+                if (this.LastPostID > 0)
+                {
+                    int intLength = 0;
+                    if ((propertyName.ToString().IndexOf("[lastpostsubject:", 0) + 1) > 0)
+                    {
+                        int inStart = (propertyName.ToString().IndexOf("[lastpostsubject:", 0) + 1) + 17;
+                        int inEnd = (propertyName.ToString().IndexOf("]", inStart - 1) + 1);
+                        string sLength = propertyName.ToString().Substring(inStart - 1, inEnd - inStart);
+                        intLength = Convert.ToInt32(sLength);
+                    }
+
+                    return PropertyAccess.FormatString(DotNetNuke.Modules.ActiveForums.Controllers.ForumController.GetLastPostSubjectLinkTag(this.LastPostID, this.LastTopicId, System.Web.HttpUtility.HtmlDecode(this.LastPostSubject), intLength, this), format);
+                }
+            }
+
+            switch (propertyName)
+            {
+                case "forumid":
+                    return PropertyAccess.FormatString(this.ForumID.ToString(), format);
+                case "themelocation":
+                    return PropertyAccess.FormatString(this.ThemeLocation.ToString(), format);
+                case "forumdescription":
+                    return PropertyAccess.FormatString(this.ForumDesc, format);
+                case "forumname":
+                    return PropertyAccess.FormatString(this.ForumName, format);
+                case "forumnamenolink":
+                    return PropertyAccess.FormatString(this.ForumName, format);
+                case "forumgroupid":
+                    return PropertyAccess.FormatString(this.ForumGroupId.ToString(), format);
+                case "grouplink":
+                case "forumgrouplink":
+                    return PropertyAccess.FormatString(new ControlUtils().BuildUrl(this.TabId,
+                            this.ModuleId,
+                            this.ForumGroup.PrefixURL,
+                            string.Empty,
+                            this.ForumGroupId,
+                            -1,
+                            -1,
+                            -1,
+                            string.Empty,
+                            1,
+                            -1,
+                            -1),
+                        format);
+                case "forumlink":
+                case "forumurl":
+                    return PropertyAccess.FormatString(new ControlUtils().BuildUrl(this.TabId,
+                            this.ModuleId,
+                            this.ForumGroup.PrefixURL,
+                            this.PrefixURL,
+                            this.ForumGroupId,
+                            this.ForumID,
+                            -1,
+                            -1,
+                            string.Empty,
+                            1,
+                            -1,
+                            this.SocialGroupId),
+                        format);
+                case "parentforumlink":
+                    return PropertyAccess.FormatString(new ControlUtils().BuildUrl(this.TabId,
+                            this.ModuleId,
+                            this.ForumGroup.PrefixURL,
+                            this.ParentForumUrlPrefix,
+                            this.ForumGroupId,
+                            this.ParentForumId,
+                            -1,
+                            -1,
+                            string.Empty,
+                            1,
+                            -1,
+                            this.SocialGroupId),
+                        format);
+                case "lastpostdate":
+                    return this.LastPostID < 1
+                        ? string.Empty
+                        : PropertyAccess.FormatString(Utilities.GetUserFormattedDateTime(
+                                (DateTime?)this.LastPostDateTime,
+                                formatProvider,
+                                accessingUser.Profile.PreferredTimeZone.GetUtcOffset(DateTime.UtcNow)),
+                            format);
+                case "parentforumname":
+                    return this.ParentForumId < 1
+                        ? string.Empty
+                        : PropertyAccess.FormatString(this.ParentForumName, format);
+                case "parentforumid":
+                    return this.ParentForumId < 1
+                        ? string.Empty
+                        : PropertyAccess.FormatString(this.ParentForumId.ToString(), format);
+                case "forumgroupname":
+                case "groupname":
+                    return PropertyAccess.FormatString(this.ForumGroup.GroupName, format);
+                case "socialgroupid":
+                    return PropertyAccess.FormatString(this.SocialGroupId.ToString(), format);
+                case "lastpostid":
+                    return PropertyAccess.FormatString(this.LastPostID.ToString(), format);
+                case "subscribercount":
+                    return PropertyAccess.FormatString(this.SubscriberCount.ToString(), format);
+                case "totaltopics":
+                    return PropertyAccess.FormatString(this.TotalTopics.ToString(), format);
+                case "totalreplies":
+                    return PropertyAccess.FormatString(this.TotalReplies.ToString(), format);
+                case "lastpostsubject":
+                    return this.LastPostID < 1
+                        ? string.Empty
+                        : PropertyAccess.FormatString(this.LastPostSubject.ToString(), format);
+                case "lastpostuserid":
+                    return this.LastPostID < 1
+                        ? string.Empty
+                        : PropertyAccess.FormatString(this.LastPostUserID.ToString(), format);
+                case "lastpostusername":
+                    return this.LastPostID < 1
+                        ? string.Empty
+                        : PropertyAccess.FormatString(this.LastPostUserName.ToString(), format);
+                case "lastpostfirstname":
+                    return this.LastPostID < 1
+                        ? string.Empty
+                        : PropertyAccess.FormatString(this.LastPostFirstName.ToString(), format);
+                case "lastpostlastname":
+                    return this.LastPostID < 1
+                        ? string.Empty
+                        : PropertyAccess.FormatString(this.LastPostLastName.ToString(), format);
+                case "lastpostauthordisplaynamelink":
+                    return PropertyAccess.FormatString(
+                        this.LastPostID > 0 && this.LastPostUserID > 0 ?
+                            DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.CanLinkToProfile(
+                                this.PortalSettings,
+                                this.MainSettings,
+                                this.ModuleId,
+                                new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(
+                                    accessingUser.PortalID,
+                                    accessingUser.UserID),
+                                new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(
+                                    accessingUser.PortalID,
+                                    this.LastPostUserID)) ?
+                                Utilities.NavigateURL(this.PortalSettings.UserTabId,
+                                    string.Empty,
+                                    new[] { $"userId={this.LastPostUserID}" })
+                                : string.Empty : string.Empty, format);
+                case "lastpostdisplayname":
+                case "lastpostauthordisplayname":
+                    return PropertyAccess.FormatString(
+                        this.LastPostID > 0 && this.LastPostUserID > 0 ?
+                            DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetDisplayName(
+                                this.PortalSettings,
+                                this.MainSettings,
+                                isMod: new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(accessingUser.PortalID, accessingUser.UserID).GetIsMod(this.ModuleId),
+                                isAdmin: new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(accessingUser.PortalID, accessingUser.UserID).IsAdmin || new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(accessingUser.PortalID, accessingUser.UserID).IsSuperUser,
+                                this.LastPostUserID,
+                                this.LastPostUserName,
+                                this.LastPostFirstName,
+                                this.LastPostLastName,
+                                this.LastPostDisplayName).Replace("&amp;#", "&#").Replace("Anonymous", this.LastPostDisplayName)
+                            : string.Empty, format);
+
+                case "statuscssclass":
+                    return PropertyAccess.FormatString(
+                        this.GetForumStatusCss(new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(
+                                accessingUser.PortalID,
+                                accessingUser.UserID)),
+                        format);
+                case "forumicon":
+                    return PropertyAccess.FormatString(
+                        this.GetForumFolderIcon(new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(
+                                accessingUser.PortalID,
+                                accessingUser.UserID),
+                            this.mainSettings),
+                        format);
+                case "forumiconcss":
+                    return PropertyAccess.FormatString(
+                        this.GetForumFolderIconCss(new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(
+                                accessingUser.PortalID,
+                                accessingUser.UserID)),
+                        format);
+                case "rsslink":
+                    {
+                        if (this.AllowRSS && DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(this.Security.Read, new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(accessingUser.PortalID, accessingUser.UserID).UserRoles))
+                        {
+                            var url = new Uri(Utilities.NavigateURL(this.TabId));
+                            return PropertyAccess.FormatString(
+                                $"{url.Scheme}://{url.Host}:{url.Port}/DesktopModules/ActiveForums/feeds.aspx?portalid={this.PortalId}&forumid={this.ForumID}&tabid={this.TabId}&moduleid={this.ModuleId}" + (this.SocialGroupId > 0 ? $"&GroupId={this.SocialGroupId}" : string.Empty),
+                                format);
+                        }
+
+                        return string.Empty;
+                    }
+
+            }
+
+            propertyNotFound = true;
+            return string.Empty;
         }
     }
 }

--- a/Dnn.CommunityForums/Entities/ForumTrackingInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumTrackingInfo.cs
@@ -86,7 +86,7 @@ internal class ForumTrackingInfo
             this.forumUser = new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.Forum.ModuleId).GetByUserId(this.Forum.PortalId, this.UserId);
             if (this.forumUser == null)
             {
-                this.forumUser = new DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo
+                this.forumUser = new DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo(this.ModuleId)
                 {
                     UserId = this.UserId,
                 };

--- a/Dnn.CommunityForums/Entities/ForumUserInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumUserInfo.cs
@@ -18,18 +18,21 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+
+
 namespace DotNetNuke.Modules.ActiveForums.Entities
 {
     using System;
     using DotNetNuke.ComponentModel.DataAnnotations;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Users;
+    using DotNetNuke.Services.Tokens;
     using DotNetNuke.Entities.Modules;
 
     [TableName("activeforums_UserProfiles")]
     [PrimaryKey("ProfileId", AutoIncrement = true)]
     [Scope("PortalId")]
-    public class ForumUserInfo
+    public class ForumUserInfo : DotNetNuke.Services.Tokens.IPropertyAccess
     {
         private DotNetNuke.Entities.Users.UserInfo userInfo;
         private PortalSettings portalSettings;
@@ -40,7 +43,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         public ForumUserInfo()
         {
             this.userInfo = new DotNetNuke.Entities.Users.UserInfo();
-        }        
+        }
 
         public ForumUserInfo(int moduleId)
         {
@@ -71,7 +74,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
 
         public DateTime DateCreated { get; set; } = DateTime.UtcNow;
 
-        public DateTime? DateUpdated { get; set; } 
+        public DateTime? DateUpdated { get; set; }
 
         public DateTime? DateLastActivity { get; set; }
 
@@ -170,7 +173,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             get => this.portalSettings ?? (this.portalSettings = Utilities.GetPortalSettings(this.PortalId));
             set => this.portalSettings = value;
         }
-        
+
         [IgnoreColumn]
         public SettingsInfo MainSettings
         {
@@ -251,51 +254,51 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             return RoleIds;
         }
         [IgnoreColumn]
-         internal int GetLastReplyRead(DotNetNuke.Modules.ActiveForums.Entities.TopicInfo ti)
-         {
-             var topicTrak = new DotNetNuke.Modules.ActiveForums.Controllers.TopicTrackingController().GetByUserIdTopicId(this.UserId, ti.TopicId);
-             var forumTrak = new DotNetNuke.Modules.ActiveForums.Controllers.ForumTrackingController().GetByUserIdForumId(this.UserId, ti.ForumId);
-             if (forumTrak?.MaxReplyRead > topicTrak?.LastReplyId || topicTrak == null)
-             {
-                 if (forumTrak != null)
-                 {
-                     return forumTrak.MaxReplyRead;
-                 }
-             }
-             else
-             {
-                 return topicTrak.LastReplyId;
-             }
+        internal int GetLastReplyRead(DotNetNuke.Modules.ActiveForums.Entities.TopicInfo ti)
+        {
+            var topicTrak = new DotNetNuke.Modules.ActiveForums.Controllers.TopicTrackingController().GetByUserIdTopicId(this.UserId, ti.TopicId);
+            var forumTrak = new DotNetNuke.Modules.ActiveForums.Controllers.ForumTrackingController().GetByUserIdForumId(this.UserId, ti.ForumId);
+            if (forumTrak?.MaxReplyRead > topicTrak?.LastReplyId || topicTrak == null)
+            {
+                if (forumTrak != null)
+                {
+                    return forumTrak.MaxReplyRead;
+                }
+            }
+            else
+            {
+                return topicTrak.LastReplyId;
+            }
 
-             return 0;
+            return 0;
 
-             // from stored procedure
-             // CASE WHEN FT.MaxReplyRead > TT.LastReplyId OR TT.LastReplyID IS NULL THEN ISNULL(FT.MaxReplyRead,0) ELSE TT.LastReplyId END AS UserLastReplyRead, 
-         }
+            // from stored procedure
+            // CASE WHEN FT.MaxReplyRead > TT.LastReplyId OR TT.LastReplyID IS NULL THEN ISNULL(FT.MaxReplyRead,0) ELSE TT.LastReplyId END AS UserLastReplyRead, 
+        }
 
-         [IgnoreColumn]
-         internal int GetLastTopicRead(DotNetNuke.Modules.ActiveForums.Entities.TopicInfo ti)
-         {
-             var topicTrak = new DotNetNuke.Modules.ActiveForums.Controllers.TopicTrackingController().GetByUserIdTopicId(this.UserId, ti.TopicId);
-             var forumTrak = new DotNetNuke.Modules.ActiveForums.Controllers.ForumTrackingController().GetByUserIdForumId(this.UserId, ti.ForumId);
-             if (forumTrak?.MaxTopicRead > topicTrak?.TopicId || topicTrak == null)
-             {
-                 if (forumTrak != null)
-                 {
-                     return forumTrak.MaxTopicRead;
-                 }
-             }
-             else
-             {
-                 return topicTrak.TopicId;
-             }
+        [IgnoreColumn]
+        internal int GetLastTopicRead(DotNetNuke.Modules.ActiveForums.Entities.TopicInfo ti)
+        {
+            var topicTrak = new DotNetNuke.Modules.ActiveForums.Controllers.TopicTrackingController().GetByUserIdTopicId(this.UserId, ti.TopicId);
+            var forumTrak = new DotNetNuke.Modules.ActiveForums.Controllers.ForumTrackingController().GetByUserIdForumId(this.UserId, ti.ForumId);
+            if (forumTrak?.MaxTopicRead > topicTrak?.TopicId || topicTrak == null)
+            {
+                if (forumTrak != null)
+                {
+                    return forumTrak.MaxTopicRead;
+                }
+            }
+            else
+            {
+                return topicTrak.TopicId;
+            }
 
-             return 0;
+            return 0;
 
-             // from stored procedure
-             // CASE WHEN FT.MaxTopicRead > TT.TopicId OR TT.TopicId IS NULL THEN ISNULL(FT.MaxTopicRead,0) ELSE TT.TopicId END AS UserLastTopicRead,
-         }
-        
+            // from stored procedure
+            // CASE WHEN FT.MaxTopicRead > TT.TopicId OR TT.TopicId IS NULL THEN ISNULL(FT.MaxTopicRead,0) ELSE TT.TopicId END AS UserLastTopicRead,
+        }
+
         [IgnoreColumn]
         internal bool GetIsTopicRead(DotNetNuke.Modules.ActiveForums.Entities.TopicInfo ti)
         {
@@ -350,7 +353,110 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             return 0;
         }
 
-         
+
+        [IgnoreColumn]
+        public DotNetNuke.Services.Tokens.CacheLevel Cacheability
+        {
+            get
+            {
+                return DotNetNuke.Services.Tokens.CacheLevel.notCacheable;
+            }
+        }
+
+        public string GetProperty(string propertyName, string format, System.Globalization.CultureInfo formatProvider, DotNetNuke.Entities.Users.UserInfo accessingUser, Scope accessLevel, ref bool propertyNotFound)
+        {
+
+            // replace any embedded tokens in format string
+            if (format.Contains("["))
+            {
+                var tokenReplacer = new DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer(this.PortalSettings, this)
+                {
+                    AccessingUser = accessingUser,
+                };
+                format = tokenReplacer.ReplaceEmbeddedTokens(format);
+            }
+            propertyName = propertyName.ToLowerInvariant();
+            switch (propertyName)
+            {
+                case "userid":
+                    return PropertyAccess.FormatString(this.UserId.ToString(), format);
+                case "username":
+                    return PropertyAccess.FormatString(this.Username, format);
+                case "avatar":
+                    return PropertyAccess.FormatString(this.Avatar, format);
+                case "usercaption":
+                    return PropertyAccess.FormatString(this.UserCaption, format);
+                case "displayname":
+                    return PropertyAccess.FormatString(this.DisplayName, format);
+                case "email":
+                    return PropertyAccess.FormatString(this.Email, format);
+                case "firstname":
+                    return PropertyAccess.FormatString(this.FirstName, format);
+                case "lastname":
+                    return PropertyAccess.FormatString(this.LastName, format);
+                case "datecreated":
+                    return Utilities.GetUserFormattedDateTime((DateTime?)this.DateCreated, formatProvider, accessingUser.Profile.PreferredTimeZone.GetUtcOffset(DateTime.UtcNow));
+                case "dateupdated":
+                    return Utilities.GetUserFormattedDateTime(this.DateUpdated, formatProvider, accessingUser.Profile.PreferredTimeZone.GetUtcOffset(DateTime.UtcNow));
+                case "datelastpost":
+                    return Utilities.GetUserFormattedDateTime(this.DateLastPost, formatProvider, accessingUser.Profile.PreferredTimeZone.GetUtcOffset(DateTime.UtcNow));
+                case "datelastreply":
+                    return Utilities.GetUserFormattedDateTime(this.DateLastReply, formatProvider, accessingUser.Profile.PreferredTimeZone.GetUtcOffset(DateTime.UtcNow));
+                case "datelastactivity":
+                    return Utilities.GetUserFormattedDateTime(this.DateLastActivity, formatProvider, accessingUser.Profile.PreferredTimeZone.GetUtcOffset(DateTime.UtcNow));
+                case "postcount":
+                    return PropertyAccess.FormatString(this.PostCount.ToString(), format);
+                case "replycount":
+                    return PropertyAccess.FormatString(this.ReplyCount.ToString(), format);
+                case "topiccount":
+                    return PropertyAccess.FormatString(this.TopicCount.ToString(), format);
+                case "answercount":
+                    return PropertyAccess.FormatString(this.AnswerCount.ToString(), format);
+                case "rewardpoints":
+                    return PropertyAccess.FormatString(this.RewardPoints.ToString(), format);
+                case "userprofilelink":
+                    return PropertyAccess.FormatString(
+                        DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.CanLinkToProfile(
+                            this.PortalSettings,
+                            this.MainSettings,
+                            this.ModuleId,
+                            new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(
+                                accessingUser.PortalID,
+                                accessingUser.UserID),
+                            this)
+                            ? Utilities.NavigateURL(this.portalSettings.UserTabId,
+                                string.Empty,
+                                new[] { $"userId={this.UserId}" })
+                            : string.Empty,
+                        format);
+                case "signature":
+                    var sSignature = string.Empty;
+                    if (mainSettings.AllowSignatures != 0 && !this.PrefBlockSignatures && !this.SignatureDisabled)
+                    {
+                        sSignature = this?.Signature ?? string.Empty;
+                        if (!string.IsNullOrEmpty(sSignature))
+                        {
+                            sSignature = Utilities.ManageImagePath(sSignature);
+
+                            switch (mainSettings.AllowSignatures)
+                            {
+                                case 1:
+                                    sSignature = System.Web.HttpUtility.HtmlEncode(sSignature);
+                                    sSignature = sSignature.Replace(System.Environment.NewLine, "<br />");
+                                    break;
+                                case 2:
+                                    sSignature = System.Web.HttpUtility.HtmlDecode(sSignature);
+                                    break;
+                            }
+                        }
+                    }
+
+                    return PropertyAccess.FormatString(sSignature, format);
+            }
+
+            propertyNotFound = true;
+            return string.Empty;
+        }
 
     }
 }

--- a/Dnn.CommunityForums/Entities/IPostInfo.cs
+++ b/Dnn.CommunityForums/Entities/IPostInfo.cs
@@ -20,7 +20,7 @@
 
 namespace DotNetNuke.Modules.ActiveForums.Entities
 {
-    public interface IPostInfo
+    public interface IPostInfo : DotNetNuke.Services.Tokens.IPropertyAccess
     {
         int ForumId { get; set; }
 
@@ -50,7 +50,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
 
         DotNetNuke.Modules.ActiveForums.Entities.TopicInfo Topic { get; }
 
-        DotNetNuke.Modules.ActiveForums.Enums.PostStatus GetPostStatusForUser(ForumUserInfo forumUser);
+        DotNetNuke.Modules.ActiveForums.Enums.PostStatus GetPostStatusForUser(DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo forumUser);
 
         string GetPostStatusCss(DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo forumUser);
     }

--- a/Dnn.CommunityForums/Entities/TopicInfo.cs
+++ b/Dnn.CommunityForums/Entities/TopicInfo.cs
@@ -36,22 +36,24 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
 
     using DotNetNuke.Collections;
     using DotNetNuke.ComponentModel.DataAnnotations;
+    using DotNetNuke.Services.Tokens;
+    using DotNetNuke.Entities.Portals;
 
     [TableName("activeforums_Topics")]
     [PrimaryKey("TopicId", AutoIncrement = true)]
 #pragma warning disable SA1402 // File may only contain a single type
     public class TopicInfo : IPostInfo
 #pragma warning restore SA1402 // File may only contain a single type
-       
+
     {
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public class Category
         {
             public int id;
             public string name;
             public bool selected;
 
-            [IgnoreColumn()]
+            [IgnoreColumn]
             public Category(int id, string name, bool selected)
             {
                 this.id = id;
@@ -76,16 +78,16 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         [IgnoreColumn]
         public bool IsTopic => true;
 
-        [IgnoreColumn] 
+        [IgnoreColumn]
         public bool IsReply => false;
- 
+
         [IgnoreColumn]
         public int ReplyId => 0;
 
         [IgnoreColumn]
         public int PostId { get => this.TopicId; }
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public int ForumId
         {
             get
@@ -101,10 +103,10 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             set => this.forumId = value;
         }
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public int PortalId { get => this.Forum.PortalId; }
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public int ModuleId { get => this.Forum.ModuleId; }
 
         public int ContentId { get; set; }
@@ -142,25 +144,31 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         [ColumnName("URL")]
         public string TopicUrl { get; set; } = string.Empty;
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
+        public string Subject => this.Content.Subject;
+
+        [IgnoreColumn]
+        public string Summary => this.Content.Summary;
+
+        [IgnoreColumn]
         public string URL => !string.IsNullOrEmpty(this.TopicUrl) && !string.IsNullOrEmpty(this.ForumURL) ? this.ForumURL + this.TopicUrl : string.Empty;
 
-        [IgnoreColumn()]
-        public string ForumURL => !string.IsNullOrEmpty(this.Forum.PrefixURL) && !string.IsNullOrEmpty(this.TopicUrl) ? "/" + this.Forum.PrefixURL + "/" : string.Empty;
+        [IgnoreColumn]
+        public string ForumURL => string.IsNullOrEmpty(this.Forum.PrefixURL) && !string.IsNullOrEmpty(this.TopicUrl) ? "/" + this.Forum.PrefixURL + "/" : string.Empty;
 
         public int NextTopic { get; set; }
 
         public int PrevTopic { get; set; }
 
         public string TopicData { get; set; } = string.Empty;
-        
-        [IgnoreColumn()]
+
+        [IgnoreColumn]
         public int LastReplyId { get; set; }
-        
-        [IgnoreColumn()]
+
+        [IgnoreColumn]
         public int Rating { get; set; }
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public DotNetNuke.Modules.ActiveForums.Entities.TopicInfo Topic
         {
             get => this;
@@ -170,11 +178,11 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         {
             return this;
         }
-        
-        [IgnoreColumn()]
+
+        [IgnoreColumn]
         public int SubscriberCount => new DotNetNuke.Modules.ActiveForums.Controllers.SubscriptionController().Count(portalId: this.PortalId, moduleId: this.ModuleId, forumId: this.ForumId, topicId: this.TopicId);
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public DotNetNuke.Modules.ActiveForums.Entities.ContentInfo Content
         {
             get => this.contentInfo ?? (this.contentInfo = this.GetContent());
@@ -186,7 +194,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             return new DotNetNuke.Modules.ActiveForums.Controllers.ContentController().GetById(this.ContentId);
         }
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public DotNetNuke.Modules.ActiveForums.Entities.ForumInfo Forum
         {
             get => this.forumInfo ?? (this.forumInfo = this.GetForum());
@@ -197,35 +205,35 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         {
             return new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().GetById(this.ForumId); /* can't get using moduleId since ModuleId comes from Forum */
         }
-        
-        [IgnoreColumn()]
+
+        [IgnoreColumn]
         public DotNetNuke.Modules.ActiveForums.Entities.AuthorInfo Author
         {
             get => this.author ?? (this.author = this.GetAuthor(this.PortalId, this.ModuleId, this.Content.AuthorId));
             set => this.author = value;
         }
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public DotNetNuke.Modules.ActiveForums.Entities.ReplyInfo LastReply
         {
             get => this.lastReply ?? (this.lastReply = new DotNetNuke.Modules.ActiveForums.Controllers.ReplyController().GetById(this.LastReplyId));
             set => this.lastReply = value;
         }
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public DotNetNuke.Modules.ActiveForums.Entities.AuthorInfo LastReplyAuthor
         {
             get => this.lastReplyAuthor ?? (this.lastReplyAuthor = this.lastReply == null ? null : this.GetAuthor(this.PortalId, this.ModuleId, this.lastReply.Content.AuthorId));
             set => this.lastReplyAuthor = value;
         }
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         internal DotNetNuke.Modules.ActiveForums.Entities.AuthorInfo GetAuthor(int portalId, int moduleId, int authorId)
         {
             return new DotNetNuke.Modules.ActiveForums.Entities.AuthorInfo(portalId, moduleId, authorId);
         }
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public string Tags
         {
             get
@@ -243,7 +251,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             }
         }
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public IEnumerable<Category> Categories
         {
             // TODO: Clean this up
@@ -260,10 +268,10 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             }
         }
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public IEnumerable<Category> SelectedCategories => this.Categories.Where(c => c.selected).ToList();
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public string SelectedCategoriesAsString
         {
             get
@@ -282,7 +290,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             }
         }
 
-        [IgnoreColumn()]
+        [IgnoreColumn]
         public IEnumerable<DotNetNuke.Modules.ActiveForums.Entities.TopicPropertyInfo> TopicProperties
         {
             set
@@ -302,8 +310,8 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                 }
             }
         }
-        
-        [IgnoreColumn()]
+
+        [IgnoreColumn]
         internal DotNetNuke.Modules.ActiveForums.Enums.TopicStatus GetTopicStatusForUser(ForumUserInfo forumUser)
         {
             var canView = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(this.Forum.Security.View, forumUser?.UserRoles);
@@ -472,5 +480,212 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             return css;
         }
 
+        [IgnoreColumn]
+        public DotNetNuke.Services.Tokens.CacheLevel Cacheability
+        {
+            get
+            {
+                return DotNetNuke.Services.Tokens.CacheLevel.notCacheable;
+            }
+        }
+        [IgnoreColumn]
+        public string GetProperty(string propertyName, string format, System.Globalization.CultureInfo formatProvider, DotNetNuke.Entities.Users.UserInfo accessingUser, Scope accessLevel, ref bool propertyNotFound)
+        {
+            // replace any embedded tokens in format string
+            if (format.Contains("["))
+            {
+                var tokenReplacer = new DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer(this.Forum.PortalSettings, new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(accessingUser.PortalID, accessingUser.UserID), this)
+                {
+                    AccessingUser = accessingUser,
+                };
+                format = tokenReplacer.ReplaceEmbeddedTokens(format);
+            }
+            propertyName = propertyName.ToLowerInvariant();
+            switch (propertyName)
+            {
+                case "postid":
+                    return PropertyAccess.FormatString(this.PostId.ToString(), format);
+                case "topicid":
+                    return PropertyAccess.FormatString(this.TopicId.ToString(), format);
+                case "contentid":
+                    return PropertyAccess.FormatString(this.ContentId.ToString(), format);
+                case "forumid":
+                    return PropertyAccess.FormatString(this.forumId.ToString(), format);
+                case "subject":
+                    return PropertyAccess.FormatString(this.Subject, format);
+                case "summary":
+                    return PropertyAccess.FormatString(this.Summary, format);
+                case "body":
+                    return PropertyAccess.FormatString(this.Content.Body, format);
+                case "lastreplyid":
+                    return PropertyAccess.FormatString(this.LastReplyId.ToString(), format);
+                case "replycount":
+                    return PropertyAccess.FormatString(this.ReplyCount.ToString(), format);
+                case "viewcount":
+                    return PropertyAccess.FormatString(this.ViewCount.ToString(), format);
+                case "subscribercount":
+                    return PropertyAccess.FormatString(this.SubscriberCount.ToString(), format);
+                case "status":
+                    return this.StatusId == -1 ? string.Empty : PropertyAccess.FormatString(this.StatusId.ToString(), format);
+                case "statusid":
+                    return PropertyAccess.FormatString(this.StatusId.ToString(), format);
+                case "previoustopic":
+                    return PropertyAccess.FormatString(this.PrevTopic.ToString(), format);
+                case "previoustopiclink":
+                    if (this.PrevTopic != 0)
+                    {
+                        var @params = new List<string>()
+                {
+                    $"{ParamKeys.ViewType}={Views.Topic}",
+                    $"{ParamKeys.ForumId}={this.ForumId}",
+                    $"{ParamKeys.TopicId}={this.PrevTopic}",
+                };
+                        if (this.Forum.SocialGroupId > 0)
+                        {
+                            @params.Add($"{Literals.GroupId}={this.Forum.SocialGroupId}");
+                        }
+
+                        return PropertyAccess.FormatString(Utilities.NavigateURL(this.Forum.TabId, string.Empty, @params.ToArray()), format);
+                    }
+
+                    return string.Empty;
+                case "nexttopic":
+                    return PropertyAccess.FormatString(this.NextTopic.ToString(), format);
+                case "nexttopiclink":
+                    if (this.NextTopic != 0)
+                    {
+                        var @params = new List<string>()
+                {
+                    $"{ParamKeys.ViewType}={Views.Topic}",
+                    $"{ParamKeys.ForumId}={this.ForumId}",
+                    $"{ParamKeys.TopicId}={this.NextTopic}",
+                };
+                        if (this.Forum.SocialGroupId > 0)
+                        {
+                            @params.Add($"{Literals.GroupId}={this.Forum.SocialGroupId}");
+                        }
+
+                        return PropertyAccess.FormatString(Utilities.NavigateURL(this.Forum.TabId, string.Empty, @params.ToArray()), format);
+                    }
+
+                    return string.Empty;
+                case "rating":
+                    return this.Rating < 1 ? string.Empty : PropertyAccess.FormatString(this.Rating.ToString(), format);
+                case "topicurl":
+                    return PropertyAccess.FormatString(this.TopicUrl.ToString(), format);
+                case "forumurl":
+                    return PropertyAccess.FormatString(this.ForumURL.ToString(), format);
+                case "link":
+                    return PropertyAccess.FormatString(this.URL.ToString(), format);
+                case "url":
+                    return PropertyAccess.FormatString(this.URL.ToString(), format);
+                case "lastreplydisplayname":
+                    return PropertyAccess.FormatString(this.lastReplyAuthor.DisplayName, format);
+                case "datecreated":
+                    return PropertyAccess.FormatString(Utilities.GetUserFormattedDateTime((DateTime?)this.Content.DateCreated, formatProvider, accessingUser.Profile.PreferredTimeZone.GetUtcOffset(DateTime.UtcNow)), format);
+                case "dateupdated":
+                    return PropertyAccess.FormatString(Utilities.GetUserFormattedDateTime((DateTime?)this.Content.DateUpdated, formatProvider, accessingUser.Profile.PreferredTimeZone.GetUtcOffset(DateTime.UtcNow)), format);
+                case "modipaddress":
+                    return !this.Forum.GetIsMod(new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(accessingUser.PortalID, accessingUser.UserID)) ? string.Empty : PropertyAccess.FormatString(this.Content.IPAddress, format);
+                case "modeditdate":
+                    if (this.Forum.GetIsMod(new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(accessingUser.PortalID, accessingUser.UserID)) &&
+                        this.Content.DateUpdated != this.Content.DateCreated)
+                    {
+                        return PropertyAccess.FormatString(Utilities.GetUserFormattedDateTime((DateTime?)this.Content.DateUpdated, formatProvider, accessingUser.Profile.PreferredTimeZone.GetUtcOffset(DateTime.UtcNow)), format);
+                    }
+
+                    return string.Empty;
+                case "lastpostdate":
+                    return this.LastReply?.Content != null ? PropertyAccess.FormatString(Utilities.GetUserFormattedDateTime((DateTime?)this.LastReply.Content.DateCreated, formatProvider, accessingUser.Profile.PreferredTimeZone.GetUtcOffset(DateTime.UtcNow)), format) : string.Empty;
+                case "editdate":
+                    return PropertyAccess.FormatString(Utilities.GetUserFormattedDateTime((DateTime?)this.Content.DateUpdated, formatProvider, accessingUser.Profile.PreferredTimeZone.GetUtcOffset(DateTime.UtcNow)), format);
+                case "authorid":
+                    return PropertyAccess.FormatString(this.Content.AuthorId.ToString(), format);
+                case "authorname":
+                    return PropertyAccess.FormatString(this.Content.AuthorName, format);
+                case "authordisplaynamelink":
+                    return PropertyAccess.FormatString(
+                        DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.CanLinkToProfile(
+                        this.Forum.PortalSettings,
+                        this.Forum.MainSettings,
+                        this.ModuleId,
+                        new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(
+                            accessingUser.PortalID,
+                            accessingUser.UserID),
+                        this.Author.ForumUser) ?
+                            Utilities.NavigateURL(this.Forum.PortalSettings.UserTabId,
+                                string.Empty,
+                                new[] { $"userId={this.Content.AuthorId}" })
+                            : string.Empty,
+                        format);
+                case "authordisplayname":
+                    return PropertyAccess.FormatString(
+                        string.IsNullOrEmpty(this.Author?.DisplayName) ? this.Content.AuthorName :
+                            DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetDisplayName(
+                                this.Forum.PortalSettings,
+                                this.Forum.MainSettings,
+                                isMod: new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(accessingUser.PortalID, accessingUser.UserID).GetIsMod(this.ModuleId),
+                                isAdmin: new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(accessingUser.PortalID, accessingUser.UserID).IsAdmin || new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(accessingUser.PortalID, accessingUser.UserID).IsSuperUser,
+                                this.Author.AuthorId,
+                                this.Author.Username,
+                                this.Author.FirstName,
+                                this.Author.LastName,
+                                this.Author.DisplayName).Replace("&amp;#", "&#").Replace("Anonymous", this.Content.AuthorName),
+                        format);
+                case "authorfirstname":
+                    return PropertyAccess.FormatString(string.IsNullOrEmpty(this.Author?.DisplayName) ? this.Content.AuthorName : this.Author.FirstName, format);
+                case "authorlastname":
+                    return PropertyAccess.FormatString(string.IsNullOrEmpty(this.Author?.DisplayName) ? this.Content.AuthorName : this.Author.LastName, format);
+                case "lastreplyauthorid":
+                    return PropertyAccess.FormatString(this.LastReply?.Author?.AuthorId.ToString(), format);
+                case "lastreplyauthorname":
+                    return PropertyAccess.FormatString(string.IsNullOrEmpty(this.LastReply?.Content?.AuthorName) ? string.Empty : this.LastReply?.Content?.AuthorName, format);
+                case "lastreplyauthordisplayname":
+                    return PropertyAccess.FormatString(string.IsNullOrEmpty(this.LastReply?.Author?.DisplayName) ? this.LastReply?.Content?.AuthorName : this.LastReply?.Author?.DisplayName, format);
+                case "lastreplyauthorfirstname":
+                    return PropertyAccess.FormatString(string.IsNullOrEmpty(this.LastReply?.Author?.FirstName) ? this.LastReply?.Content?.AuthorName : this.LastReply?.Author?.FirstName, format);
+                case "lastreplyauthorlastname":
+                    return PropertyAccess.FormatString(string.IsNullOrEmpty(this.LastReply?.Author?.LastName) ? this.LastReply?.Content?.AuthorName : this.LastReply?.Author?.LastName, format);
+                case "lastreplyauthoremail":
+                    return this.LastReplyId > 0 ? PropertyAccess.FormatString(this.LastReply?.Author?.Email, format) : string.Empty;
+                case "lastpostauthordisplaynamelink":
+                    return PropertyAccess.FormatString(
+                        this.LastReplyId > 0 && this.LastReply.Author.AuthorId > 0 ?
+                            DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.CanLinkToProfile(
+                                this.Forum.PortalSettings,
+                                this.Forum.MainSettings,
+                                this.ModuleId,
+                                new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(
+                                    accessingUser.PortalID,
+                                    accessingUser.UserID),
+                                this.LastReply.Author.ForumUser) ?
+                                Utilities.NavigateURL(this.Forum.PortalSettings.UserTabId,
+                                    string.Empty,
+                                    new[] { $"userId={this.LastReplyAuthor.AuthorId}" })
+                                : string.Empty : string.Empty, format);
+                case "lastpostauthordisplayname":
+                    return PropertyAccess.FormatString(
+                        this.LastReplyId > 0 ? this.LastReply.Author.AuthorId > 0 ? DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetDisplayName(
+                                this.Forum.PortalSettings,
+                                this.Forum.MainSettings,
+                                isMod: new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(accessingUser.PortalID, accessingUser.UserID).GetIsMod(this.ModuleId),
+                                isAdmin: new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(accessingUser.PortalID, accessingUser.UserID).IsAdmin || new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(accessingUser.PortalID, accessingUser.UserID).IsSuperUser,
+                                this.LastReply.Author.AuthorId,
+                                this.LastReply.Author.Username,
+                                this.LastReply.Author.FirstName,
+                                this.LastReply.Author.LastName,
+                                this.LastReply.Author.DisplayName).Replace("&amp;#", "&#").Replace("Anonymous", this.LastReply.Content.AuthorName)
+                            : this.LastReply.Content.AuthorName : string.Empty, format);
+                case "statuscssclass":
+                    return PropertyAccess.FormatString(this.GetPostStatusCss(new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(accessingUser.PortalID, accessingUser.UserID)), format);
+                case "posticon":
+                    return PropertyAccess.FormatString(this.GetPostStatusCss(new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(accessingUser.PortalID, accessingUser.UserID)), format);
+                case "posticoncss":
+                    return PropertyAccess.FormatString(this.GetPostStatusCss(new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(accessingUser.PortalID, accessingUser.UserID)), format);
+            }
+
+            propertyNotFound = true;
+            return string.Empty;
+        }
     }
 }

--- a/Dnn.CommunityForums/Entities/TopicInfo.cs
+++ b/Dnn.CommunityForums/Entities/TopicInfo.cs
@@ -154,7 +154,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         public string URL => !string.IsNullOrEmpty(this.TopicUrl) && !string.IsNullOrEmpty(this.ForumURL) ? this.ForumURL + this.TopicUrl : string.Empty;
 
         [IgnoreColumn]
-        public string ForumURL => string.IsNullOrEmpty(this.Forum.PrefixURL) && !string.IsNullOrEmpty(this.TopicUrl) ? "/" + this.Forum.PrefixURL + "/" : string.Empty;
+        public string ForumURL => !string.IsNullOrEmpty(this.Forum.PrefixURL) && !string.IsNullOrEmpty(this.TopicUrl) ? "/" + this.Forum.PrefixURL + "/" : string.Empty;
 
         public int NextTopic { get; set; }
 
@@ -293,11 +293,6 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         [IgnoreColumn]
         public IEnumerable<DotNetNuke.Modules.ActiveForums.Entities.TopicPropertyInfo> TopicProperties
         {
-            set
-            {
-                this.TopicData = DotNetNuke.Modules.ActiveForums.Controllers.TopicPropertyController.Serialize(this.Forum, value);
-            }
-
             get
             {
                 if (this.TopicData == string.Empty)

--- a/Dnn.CommunityForums/Entities/TopicTrackingInfo.cs
+++ b/Dnn.CommunityForums/Entities/TopicTrackingInfo.cs
@@ -82,7 +82,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             this.forumUser = new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.Topic.ModuleId).GetByUserId(this.Topic.PortalId, this.UserId);
             if (this.forumUser == null)
             {
-                this.forumUser = new DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo
+                this.forumUser = new DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo(this.Topic.ModuleId)
                 {
                     UserId = this.UserId,
                 };

--- a/Dnn.CommunityForums/Services/Tokens/ResourceStringTokenReplacer.cs
+++ b/Dnn.CommunityForums/Services/Tokens/ResourceStringTokenReplacer.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) 2013-2024 by DNN Community
+//
+// DNN Community licenses this file to you under the MIT license.
+//
+// See the LICENSE file in the project root for more information.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
+{
+    using System.Text.RegularExpressions;
+    using DotNetNuke.Services.Tokens;
+
+    internal class ResourceStringTokenReplacer : DotNetNuke.Services.Tokens.IPropertyAccess
+    {
+        public CacheLevel Cacheability
+        {
+            get
+            {
+                return CacheLevel.fullyCacheable;
+            }
+        }
+
+        public string GetProperty(string propertyName, string format, System.Globalization.CultureInfo formatProvider, DotNetNuke.Entities.Users.UserInfo accessingUser, Scope accessLevel, ref bool propertyNotFound)
+        {
+            return Utilities.GetSharedResource($"[RESX:{propertyName}]");
+        }
+
+        internal static string ReplaceResourceTokens(string tokenizedText)
+        {
+            const string pattern = @"(\[RESX:.+?\])";
+            var matches = new Regex(pattern).Matches(tokenizedText);
+            foreach (Match match in matches)
+            {
+                var sKey = match.Value;
+                string sReplace = Utilities.GetSharedResource(match.Value);
+                var newValue = match.Value;
+                if (!string.IsNullOrEmpty(sReplace))
+                {
+                    newValue = sReplace;
+                }
+                tokenizedText = tokenizedText.Replace(sKey, newValue);
+            }
+
+            return tokenizedText;
+        }
+
+    }
+}

--- a/Dnn.CommunityForums/Services/Tokens/TokenReplacer.cs
+++ b/Dnn.CommunityForums/Services/Tokens/TokenReplacer.cs
@@ -1,0 +1,1460 @@
+﻿// Copyright (c) 2013-2024 by DNN Community
+//
+// DNN Community licenses this file to you under the MIT license.
+//
+// See the LICENSE file in the project root for more information.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Data.SqlTypes;
+    using System.Linq;
+    using System.Text;
+    using System.Text.RegularExpressions;
+    using System.Web;
+
+    using DotNetNuke.Abstractions;
+    using DotNetNuke.Entities.Host;
+    using DotNetNuke.Entities.Portals;
+    using DotNetNuke.Entities.Users;
+    using DotNetNuke.Modules.ActiveForums.Entities;
+    using DotNetNuke.Services.Log.EventLog;
+    using DotNetNuke.Services.Tokens;
+
+    internal class TokenReplacer : DotNetNuke.Services.Tokens.BaseCustomTokenReplace
+    {
+        private const string PropertySource_resx = "resx";
+        private const string PropertySource_forum = "forum";
+        private const string PropertySource_forumuser = "forumuser";
+        private const string PropertySource_user = "user";
+        private const string PropertySource_profile = "profile";
+        private const string PropertySource_membership = "membership";
+        private const string PropertySource_tab = "tab";
+        private const string PropertySource_module = "module";
+        private const string PropertySource_portal = "portal";
+        private const string PropertySource_host = "host";
+        private const string PropertySource_forumtopic = "forumtopic";
+        private const string PropertySource_forumpost = "forumpost";
+
+        public TokenReplacer(DotNetNuke.Entities.Portals.PortalSettings portalSettings, DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo forumUser, DotNetNuke.Modules.ActiveForums.Entities.ForumInfo forumInfo)
+        {
+            this.PropertySource[key: PropertySource_resx] = new DotNetNuke.Modules.ActiveForums.Services.Tokens.ResourceStringTokenReplacer();
+            this.PropertySource[key: PropertySource_forum] = forumInfo;
+            this.PropertySource[key: PropertySource_forumuser] = forumUser;
+            this.PropertySource[key: PropertySource_user] = forumUser.UserInfo;
+            this.PropertySource[key: PropertySource_profile] = new ProfilePropertyAccess(forumUser.UserInfo);
+            this.PropertySource[key: PropertySource_membership] = new MembershipPropertyAccess(forumUser.UserInfo);
+            this.PropertySource[key: PropertySource_tab] = portalSettings.ActiveTab;
+            this.PropertySource[key: PropertySource_module] = forumInfo.ModuleInfo;
+            this.PropertySource[key: PropertySource_portal] = portalSettings;
+            this.PropertySource[key: PropertySource_host] = new HostPropertyAccess();
+            this.CurrentAccessLevel = Scope.DefaultSettings;
+        }
+
+        public TokenReplacer(DotNetNuke.Entities.Portals.PortalSettings portalSettings, DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo forumUser, DotNetNuke.Modules.ActiveForums.Entities.TopicInfo topicInfo)
+        {
+            this.PropertySource[key: PropertySource_resx] = new DotNetNuke.Modules.ActiveForums.Services.Tokens.ResourceStringTokenReplacer();
+            this.PropertySource[key: PropertySource_forum] = topicInfo.Forum;
+            this.PropertySource[key: PropertySource_forumtopic] = topicInfo;
+            this.PropertySource[key: PropertySource_forumuser] = topicInfo.Author.ForumUser;
+            this.PropertySource[key: PropertySource_user] = topicInfo.Author.ForumUser.UserInfo;
+            this.PropertySource[key: PropertySource_profile] = new ProfilePropertyAccess(topicInfo.Author.ForumUser.UserInfo);
+            this.PropertySource[key: PropertySource_membership] = new MembershipPropertyAccess(topicInfo.Author.ForumUser.UserInfo);
+            this.PropertySource[key: PropertySource_tab] = portalSettings.ActiveTab;
+            this.PropertySource[key: PropertySource_module] = topicInfo.Forum.ModuleInfo;
+            this.PropertySource[key: PropertySource_portal] = portalSettings;
+            this.PropertySource[key: PropertySource_host] = new HostPropertyAccess();
+            this.CurrentAccessLevel = Scope.DefaultSettings;
+        }
+
+        public TokenReplacer(DotNetNuke.Entities.Portals.PortalSettings portalSettings, DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo forumUser, DotNetNuke.Modules.ActiveForums.Entities.IPostInfo postInfo)
+        {
+            this.PropertySource[key: PropertySource_resx] = new DotNetNuke.Modules.ActiveForums.Services.Tokens.ResourceStringTokenReplacer();
+            this.PropertySource[key: PropertySource_forum] = postInfo.Forum;
+            this.PropertySource[key: PropertySource_forumtopic] = postInfo.Topic;
+            this.PropertySource[key: PropertySource_forumpost] = postInfo;
+            this.PropertySource[key: PropertySource_forumuser] = postInfo.Author.ForumUser;
+            this.PropertySource[key: PropertySource_user] = postInfo.Author.ForumUser.UserInfo;
+            this.PropertySource[key: PropertySource_profile] = new ProfilePropertyAccess(postInfo.Author.ForumUser.UserInfo);
+            this.PropertySource[key: PropertySource_membership] = new MembershipPropertyAccess(postInfo.Author.ForumUser.UserInfo);
+            this.PropertySource[key: PropertySource_tab] = portalSettings.ActiveTab;
+            this.PropertySource[key: PropertySource_module] = postInfo.Forum.ModuleInfo;
+            this.PropertySource[key: PropertySource_portal] = portalSettings;
+            this.PropertySource[key: PropertySource_host] = new HostPropertyAccess();
+            this.CurrentAccessLevel = Scope.DefaultSettings;
+        }
+
+        public TokenReplacer(DotNetNuke.Entities.Portals.PortalSettings portalSettings, DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo forumUser)
+        {
+            this.PropertySource[key: PropertySource_resx] = new DotNetNuke.Modules.ActiveForums.Services.Tokens.ResourceStringTokenReplacer();
+            this.PropertySource[key: PropertySource_forumuser] = forumUser;
+            this.PropertySource[key: PropertySource_user] = forumUser.UserInfo;
+            this.PropertySource[key: PropertySource_profile] = new ProfilePropertyAccess(forumUser.UserInfo);
+            this.PropertySource[key: PropertySource_membership] = new MembershipPropertyAccess(forumUser.UserInfo);
+            this.PropertySource[key: PropertySource_tab] = portalSettings.ActiveTab;
+            this.PropertySource[key: PropertySource_module] = forumUser.ModuleInfo;
+            this.PropertySource[key: PropertySource_portal] = portalSettings;
+            this.PropertySource[key: PropertySource_host] = new HostPropertyAccess();
+            this.CurrentAccessLevel = Scope.DefaultSettings;
+        }
+
+        public TokenReplacer(DotNetNuke.Entities.Portals.PortalSettings portalSettings, DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo forumUser, DotNetNuke.Modules.ActiveForums.Entities.AuthorInfo author)
+        {
+            this.PropertySource[key: PropertySource_resx] = new DotNetNuke.Modules.ActiveForums.Services.Tokens.ResourceStringTokenReplacer();
+            this.PropertySource[key: PropertySource_forumuser] = forumUser;
+            this.PropertySource[key: PropertySource_user] = author.ForumUser.UserInfo;
+            this.PropertySource[key: PropertySource_profile] = new ProfilePropertyAccess(author.ForumUser.UserInfo);
+            this.PropertySource[key: PropertySource_membership] = new MembershipPropertyAccess(author.ForumUser.UserInfo);
+            this.PropertySource[key: PropertySource_tab] = portalSettings.ActiveTab;
+            this.PropertySource[key: PropertySource_module] = forumUser.ModuleInfo;
+            this.PropertySource[key: PropertySource_portal] = portalSettings;
+            this.PropertySource[key: PropertySource_host] = new HostPropertyAccess();
+            this.CurrentAccessLevel = Scope.DefaultSettings;
+        }
+
+        public new string ReplaceTokens(string source)
+        {
+            return base.ReplaceTokens(source);
+        }
+
+        internal static StringBuilder ReplaceModuleTokens(StringBuilder template, DotNetNuke.Entities.Portals.PortalSettings portalSettings, SettingsInfo mainSettings, ForumUserInfo forumUser, int tabId, int forumModuleId)
+        {
+            template = RemoveObsoleteTokens(template);
+            template = MapLegacyPortalTokenSynonyms(template);
+            template = MapLegacyModuleTokenSynonyms(template);
+
+            string language = forumUser?.UserInfo?.Profile?.PreferredLocale ?? portalSettings?.DefaultLanguage;
+            var urlNavigator = new Services.URLNavigator();
+
+            template.Replace("[PAGENAME]", HttpUtility.HtmlEncode(string.IsNullOrEmpty(portalSettings.ActiveTab.Title) ? portalSettings.ActiveTab.TabName : portalSettings.ActiveTab.Title));
+            if (template.ToString().Contains("[FORUMMAINLINK"))
+            {
+                template.Replace("[FORUMMAINLINK]", string.Format(GetTokenFormatString("[FORUMMAINLINK]", portalSettings, language), urlNavigator.NavigateURL(tabId)));
+            }
+
+            template = new StringBuilder(DotNetNuke.Modules.ActiveForums.Services.Tokens.ResourceStringTokenReplacer.ReplaceResourceTokens(template.ToString()));
+            var tokenReplace = new DotNetNuke.Services.Tokens.TokenReplace
+            {
+                AccessingUser = forumUser.UserInfo,
+                DebugMessages = false,
+                PortalSettings = portalSettings,
+                ModuleInfo = forumUser.ModuleInfo,
+                User = forumUser.UserInfo,
+                ModuleId = forumModuleId,
+            };
+            template = new StringBuilder(tokenReplace.ReplaceEnvironmentTokens(template.ToString()));
+            return template;
+        }
+
+        internal static StringBuilder ReplaceTopicActionTokens(StringBuilder template, DotNetNuke.Modules.ActiveForums.Entities.TopicInfo topic, DotNetNuke.Entities.Portals.PortalSettings portalSettings, SettingsInfo mainSettings, INavigationManager navigationManager, ForumUserInfo forumUser, HttpRequest request, int tabId, bool useListActions = true)
+        {
+            bool bDelete = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(topic.Forum.Security.Delete, forumUser.UserRoles);
+            bool bLock = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(topic.Forum.Security.Lock, forumUser.UserRoles);
+            bool bEdit = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(topic.Forum.Security.Edit, forumUser.UserRoles);
+            bool bSubscribe = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(topic.Forum.Security.Subscribe, forumUser.UserRoles);
+            bool bModerate = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(topic.Forum.Security.Moderate, forumUser.UserRoles);
+            bool bSplit = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(topic.Forum.Security.Split, forumUser.UserRoles);
+            bool bTrust = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(topic.Forum.Security.Trust, forumUser.UserRoles);
+            bool bMove = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(topic.Forum.Security.Move, forumUser.UserRoles);
+            bool bPin = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(topic.Forum.Security.Pin, forumUser.UserRoles);
+            bool bBan = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(topic.Forum.Security.Ban, forumUser.UserRoles);
+            bool isTrusted = Utilities.IsTrusted((int)topic.Forum.DefaultTrustValue, forumUser.TrustLevel, DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(topic.Forum.Security.Trust, forumUser.UserRoles));
+
+            if (bDelete && (bModerate || (topic.Content.AuthorId == forumUser.UserId && !topic.IsLocked)))
+            {
+                template.Replace("[ACTIONS:DELETE]", "<a href=\"javascript:void(0)\" onclick=\"amaf_topicDel(" + topic.Forum.ModuleId + "," + topic.Forum.ForumID + "," + topic.TopicId.ToString() + ");\" style=\"vertical-align:middle;\" title=\"[RESX:DeleteTopic]\" /><i class=\"fa fa-trash-o fa-fw fa-blue\"></i></a>");
+            }
+            else
+            {
+                template.Replace("[ACTIONS:DELETE]", string.Empty);
+            }
+
+            if ((bModerate && bEdit) || (bEdit && topic.Content.AuthorId == forumUser.UserId && (mainSettings.EditInterval == 0 || SimulateDateDiff.DateDiff(SimulateDateDiff.DateInterval.Minute, topic.Content.DateCreated, DateTime.UtcNow) < mainSettings.EditInterval)))
+            {
+                string[] editParams = { ParamKeys.ViewType + "=post", "action=te", ParamKeys.ForumId + "=" + topic.Forum.ForumID, ParamKeys.TopicId + "=" + topic.TopicId.ToString() };
+                template.Replace("[ACTIONS:EDIT]", "<a title=\"[RESX:EditTopic]\" href=\"" + Utilities.NavigateURL(tabId, string.Empty, editParams) + "\"><i class=\"fa fa-pencil-square-o fa-fw fa-blue\"></i></a>");
+                template.Replace("[AF:QUICKEDITLINK]", "<a href=\"javascript:void(0)\" title=\"[RESX:TopicQuickEdit]\" onclick=\"amaf_quickEdit(" + topic.Forum.ModuleId + "," + topic.Forum.ForumID + "," + topic.TopicId.ToString() + ");\"><i class=\"fa fa-cog fa-fw fa-blue\"></i></a>");
+                ;
+            }
+            else
+            {
+                template.Replace("[AF:QUICKEDITLINK]", string.Empty);
+                template.Replace("[ACTIONS:EDIT]", string.Empty);
+            }
+
+            if (bMove && (bModerate || (topic.Content.AuthorId == forumUser.UserId)))
+            {
+
+                template.Replace("[ACTIONS:MOVE]", "<a href=\"javascript:void(0)\" onclick=\"javascript:amaf_openMove(" + topic.Forum.ModuleId + "," + topic.Forum.ForumID + "," + topic.TopicId.ToString() + ");\" title=\"[RESX:MoveTopic]\" style=\"vertical-align:middle;\" /><i class=\"fa fa-exchange fa-rotate-90 fa-blue\"></i></a>");
+            }
+            else
+            {
+                template.Replace("[ACTIONS:MOVE]", string.Empty);
+            }
+
+            if (bLock && (bModerate || (topic.Content.AuthorId == forumUser.UserId)))
+            {
+
+                template.Replace("[ACTIONS:LOCK]", "<a href=\"javascript:void(0)\" class=\"dcf-topic-lock-outer\" onclick=\"javascript:if(confirm('[RESX:Confirm:Lock]')){amaf_Lock(" + topic.Forum.ModuleId + "," + topic.Forum.ForumID + "," + topic.TopicId.ToString() + ");};\" title=\"[RESX:LockTopic]\" style=\"vertical-align:middle;\"><i class=\"fa fa-lock fa-fw fa-blue dcf-topic-lock-inner\"></i></a>");
+            }
+            else
+            {
+                template.Replace("[ACTIONS:LOCK]", string.Empty);
+            }
+
+            if (bPin && (bModerate || (topic.Content.AuthorId == forumUser.UserId)))
+            {
+                template.Replace("[ACTIONS:PIN]", "<a href=\"javascript:void(0)\" class=\"dcf-topic-pin-outer\" onclick=\"javascript:if(confirm('[RESX:Confirm:Pin]')){amaf_Pin(" + topic.Forum.ModuleId + "," + topic.Forum.ForumID + "," + topic.TopicId.ToString() + ");};\" title=\"[RESX:PinTopic]\" style=\"vertical-align:middle;\"><i class=\"fa fa-thumb-tack fa-fw fa-blue dcf-topic-pin-pin dcf-topic-pin-inner\"></i></a>");
+            }
+            else
+            {
+                template.Replace("[ACTIONS:PIN]", string.Empty);
+            }
+
+            if (topic.IsLocked)
+            {
+                template.Replace("fa-lock", "fa-unlock");
+                template.Replace("[RESX:Lock]", "[RESX:UnLock]");
+                template.Replace("[RESX:LockTopic]", "[RESX:UnLockTopic]");
+                template.Replace("[RESX:Confirm:Lock]", "[RESX:Confirm:UnLock]");
+                template.Replace("[ICONLOCK]", "&nbsp;&nbsp;<i id=\"af-topicsview-lock-" + topic.TopicId.ToString() + "\" class=\"fa fa-lock fa-fw fa-red\"></i>");
+            }
+            else
+            {
+                template.Replace("[ICONLOCK]", "&nbsp;&nbsp;<i id=\"af-topicsview-lock-" + topic.TopicId.ToString() + "\" class=\"fa fa-fw fa-red\"></i>");
+            }
+
+            if (topic.IsPinned)
+            {
+                template.Replace("dcf-topic-pin-pin", "dcf-topic-pin-unpin");
+                template.Replace("[RESX:Pin]", "[RESX:UnPin]");
+                template.Replace("[RESX:PinTopic]", "[RESX:UnPinTopic]");
+                template.Replace("[RESX:Confirm:Pin]", "[RESX:Confirm:UnPin]");
+                template.Replace("[ICONPIN]", "&nbsp;&nbsp;<i id=\"af-topicsview-pin-" + topic.TopicId.ToString() + "\" class=\"fa fa-thumb-tack fa-fw fa-red\"></i>");
+            }
+            else
+            {
+                template.Replace("[ICONPIN]", "&nbsp;&nbsp;<i id=\"af-topicsview-pin-" + topic.TopicId.ToString() + "\" class=\"fa fa-fw fa-red\"></i>");
+            }
+
+            return template;
+        }
+
+        internal static StringBuilder ReplacePostActionTokens(StringBuilder template, DotNetNuke.Modules.ActiveForums.Entities.IPostInfo post, DotNetNuke.Entities.Portals.PortalSettings portalSettings, SettingsInfo mainSettings, INavigationManager navigationManager, ForumUserInfo forumUser, HttpRequest request, int tabId, bool canReply, bool useListActions = true)
+        {
+            bool bDelete = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(post.Forum.Security.Delete, forumUser.UserRoles);
+            bool bLock = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(post.Forum.Security.Lock, forumUser.UserRoles);
+            bool bEdit = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(post.Forum.Security.Edit, forumUser.UserRoles);
+            bool bSubscribe = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(post.Forum.Security.Subscribe, forumUser.UserRoles);
+            bool bModerate = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(post.Forum.Security.Moderate, forumUser.UserRoles);
+            bool bSplit = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(post.Forum.Security.Split, forumUser.UserRoles);
+            bool bTrust = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(post.Forum.Security.Trust, forumUser.UserRoles);
+            bool bMove = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(post.Forum.Security.Move, forumUser.UserRoles);
+            bool bPin = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(post.Forum.Security.Pin, forumUser.UserRoles);
+            bool bBan = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(post.Forum.Security.Ban, forumUser.UserRoles);
+            bool isTrusted = Utilities.IsTrusted((int)post.Forum.DefaultTrustValue, forumUser.TrustLevel, DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(post.Forum.Security.Trust, forumUser.UserRoles));
+
+            // Delete Action
+            if (bDelete && (bModerate || (post.Author.AuthorId == forumUser.UserId && !post.Topic.IsLocked)))
+            {
+                if (useListActions)
+                {
+                    template.Replace("[ACTIONS:DELETE]", "<li onclick=\"amaf_postDel(" + post.Forum.ModuleId + "," + post.Forum.ForumID + "," + post.Topic.TopicId + "," + post.ReplyId + ");\" title=\"[RESX:Delete]\"><i class=\"fa fa-trash-o fa-fw fa-blue\"></i><span class=\"dcf-link-text\">[RESX:Delete]</span></li>");
+                }
+                else
+                {
+                    template.Replace("[ACTIONS:DELETE]", "<a href=\"javascript:void(0);\" class=\"af-actions\" onclick=\"amaf_postDel(" + post.Forum.ModuleId + "," + post.Forum.ForumID + "," + post.Topic.TopicId + "," + post.ReplyId + ");\" title=\"[RESX:Delete]\"><i class=\"fa fa-trash-o fa-fw fa-blue\"></i><span class=\"dcf-link-text\">[RESX:Delete]</span></a>");
+                }
+            }
+            else
+            {
+                template.Replace("[ACTIONS:DELETE]", string.Empty);
+            }
+
+            // Ban Action (Note: can't ban yourself or a superuser/admin)
+            if ((bBan || forumUser.IsAdmin || forumUser.IsSuperUser) && (post.Author.AuthorId != -1) && (post.Author.AuthorId != forumUser.UserId) && (post.Author != null) && (!post.Author.ForumUser.IsSuperUser) && (!post.Author.ForumUser.IsAdmin))
+            {
+                var banParams = new List<string>
+                {
+                    $"{ParamKeys.ViewType}={Views.ModerateBan}",
+                    $"{ParamKeys.ForumId}={post.Forum.ForumID}",
+                    $"{ParamKeys.TopicId}={post.Topic.TopicId}",
+                    $"{ParamKeys.ReplyId}={post.ReplyId}",
+                    $"{ParamKeys.AuthorId}={post.Author.AuthorId}",
+                };
+                if (useListActions)
+                {
+                    template.Replace("[ACTIONS:BAN]", "<li onclick=\"window.location.href='" + Utilities.NavigateURL(tabId, string.Empty, banParams.ToArray()) + "';\" title=\"[RESX:Ban]\"><i class=\"fa fa-ban fa-fw fa-blue\"></i><span class=\"dcf-link-text\">[RESX:Ban]</span></li>");
+                }
+                else
+                {
+                    template.Replace("[ACTIONS:BAN]", "<a class=\"af-actions\" href=\"" + Utilities.NavigateURL(tabId, string.Empty, banParams.ToArray()) + "\" tooltip=\"Deletes all posts for this user and unauthorizes the user.\" title=\"[RESX:Ban]\"><i class=\"fa fa-ban fa-fw fa-blue\"></i><span class=\"dcf-link-text\">[RESX:Ban]</span></a>");
+                }
+            }
+            else
+            {
+                template.Replace("[ACTIONS:BAN]", string.Empty);
+            }
+
+            // Edit Action
+            if ((bModerate && bEdit) || (bEdit && post.Author.AuthorId == forumUser.UserId && (mainSettings.EditInterval == 0 || SimulateDateDiff.DateDiff(SimulateDateDiff.DateInterval.Minute, post.Content.DateCreated, DateTime.UtcNow) < mainSettings.EditInterval)))
+            {
+                var editParams = new List<string>() {
+                    $"{ParamKeys.ViewType}={Views.Post}",
+                    $"{ParamKeys.Action}={(post.IsReply ? PostActions.ReplyEdit : PostActions.TopicEdit)}",
+                    $"{ParamKeys.ForumId}={post.Forum.ForumID}",
+                    $"{ParamKeys.TopicId}={post.Topic.TopicId}",
+                    $"{ParamKeys.PostId}={post.PostId}",
+                };
+                if (post.Forum.SocialGroupId > 0)
+                {
+                    editParams.Add(Literals.GroupId + "=" + post.Forum.SocialGroupId);
+                }
+
+                if (useListActions)
+                {
+                    template.Replace("[ACTIONS:EDIT]", "<li onclick=\"window.location.href='" + Utilities.NavigateURL(tabId, string.Empty, editParams.ToArray()) + "';\" title=\"[RESX:Edit]\"><i class=\"fa fa-pencil fa-fw fa-blue\"></i><span class=\"dcf-link-text\">[RESX:Edit]</span></li>");
+                }
+                else
+                {
+                    template.Replace("[ACTIONS:EDIT]", "<a class=\"af-actions\" href=\"" + Utilities.NavigateURL(tabId, string.Empty, editParams.ToArray()) + "\" title=\"[RESX:Edit]\"><i class=\"fa fa-pencil fa-fw fa-blue\"></i><span class=\"dcf-link-text\">[RESX:Edit]</span></a>");
+                }
+            }
+            else
+            {
+                template.Replace("[ACTIONS:EDIT]", string.Empty);
+            }
+
+            // Reply and Quote Actions
+            if (!post.Topic.IsLocked && canReply)
+            {
+                var quoteParams = new List<string> { $"{ParamKeys.ViewType}={Views.Post}", $"{ParamKeys.ForumId}={post.Forum.ForumID}", $"{ParamKeys.TopicId}={post.Topic.TopicId}", $"{ParamKeys.QuoteId}={post.PostId}" };
+                var replyParams = new List<string> { $"{ParamKeys.ViewType}={Views.Post}", $"{ParamKeys.ForumId}={post.Forum.ForumID}", $"{ParamKeys.TopicId}={post.Topic.TopicId}", $"{ParamKeys.ReplyId}={post.PostId}" };
+                if (post.Forum.SocialGroupId > 0)
+                {
+                    quoteParams.Add($"{Literals.GroupId}={post.Forum.SocialGroupId}");
+                    replyParams.Add($"{Literals.GroupId}={post.Forum.SocialGroupId}");
+                }
+
+                if (useListActions)
+                {
+                    template.Replace("[ACTIONS:QUOTE]", "<li onclick=\"window.location.href='" + Utilities.NavigateURL(tabId, string.Empty, quoteParams.ToArray()) + "';\" title=\"[RESX:Quote]\"><i class=\"fa fa-quote-left fa-fw fa-blue\"></i><span class=\"dcf-link-text\">[RESX:Quote]</span></li>");
+                    template.Replace("[ACTIONS:REPLY]", "<li onclick=\"window.location.href='" + Utilities.NavigateURL(tabId, string.Empty, replyParams.ToArray()) + "';\" title=\"[RESX:Reply]\"><i class=\"fa fa-reply fa-fw fa-blue\"></i><span class=\"dcf-link-text\">[RESX:Reply]</span></li>");
+                }
+                else
+                {
+                    template.Replace("[ACTIONS:QUOTE]", "<a class=\"af-actions\" href=\"" + Utilities.NavigateURL(tabId, string.Empty, quoteParams.ToArray()) + "\" title=\"[RESX:Quote]\"><i class=\"fa fa-quote-left fa-fw fa-blue\"></i><span class=\"dcf-link-text\">[RESX:Quote]</span></a>");
+                    template.Replace("[ACTIONS:REPLY]", "<a class=\"af-actions\" href=\"" + Utilities.NavigateURL(tabId, string.Empty, replyParams.ToArray()) + "\" title=\"[RESX:Reply]\"><i class=\"fa fa-reply fa-fw fa-blue\"></i><span class=\"dcf-link-text\">[RESX:Reply]</span></a>");
+                }
+            }
+            else
+            {
+                template.Replace("[ACTIONS:QUOTE]", string.Empty);
+                template.Replace("[ACTIONS:REPLY]", string.Empty);
+            }
+
+            if (bMove && (bModerate || (post.Author.AuthorId == forumUser.UserId)))
+            {
+                template.Replace("[ACTIONS:MOVE]", "<li onclick=\"javascript:amaf_openMove(" + post.Forum.ModuleId + "," + post.Forum.ForumID + "," + post.TopicId + ")\"';\" title=\"[RESX:Move]\"><i class=\"fa fa-exchange fa-rotate-90 fa-blue\"></i><span class=\"dcf-link-text\">[RESX:Move]</span></li>");
+            }
+            else
+            {
+                template = template.Replace("[ACTIONS:MOVE]", string.Empty);
+            }
+
+            if (bLock && (bModerate || (post.Author.AuthorId == forumUser.UserId)))
+            {
+                if (post.Topic.IsLocked)
+                {
+                    template = template.Replace("[ACTIONS:LOCK]", "<li class=\"dcf-topic-lock-outer\" onclick=\"javascript:if(confirm('[RESX:Confirm:UnLock]')){amaf_Lock(" + post.Forum.ModuleId + "," + post.Forum.ForumID + "," + post.Topic.TopicId + ");};\" title=\"[RESX:UnLockTopic]\"><i class=\"fa fa-unlock fa-fm fa-blue dcf-topic-lock-inner\"></i><span class=\"dcf-topic-lock-text dcf-link-text \">[RESX:UnLock]</span></li>");
+                }
+                else
+                {
+                    template = template.Replace("[ACTIONS:LOCK]", "<li class=\"dcf-topic-lock-outer\" onclick=\"javascript:if(confirm('[RESX:Confirm:Lock]')){amaf_Lock(" + post.Forum.ModuleId + "," + post.Forum.ForumID + "," + post.Topic.TopicId + ");};\" title=\"[RESX:LockTopic]\"><i class=\"fa fa-lock fa-fm fa-blue dcf-topic-lock-inner\"></i><span class=\"dcf-topic-lock-text dcf-link-text\">[RESX:Lock]</span></li>");
+                }
+            }
+            else
+            {
+                template = template.Replace("[ACTIONS:LOCK]", string.Empty);
+            }
+            if (bPin && (bModerate || (post.Author.AuthorId == forumUser.UserId)))
+            {
+                if (post.Topic.IsPinned)
+                {
+                    template.Replace("[ACTIONS:PIN]", "<li class=\"dcf-topic-pin-outer\" onclick=\"javascript:if(confirm('[RESX:Confirm:UnPin]')){amaf_Pin(" + post.Forum.ModuleId + "," + post.Forum.ForumID + "," + post.Topic.TopicId + ");};\" title=\"[RESX:UnPinTopic]\"><i class=\"fa fa-thumb-tack fa-fm fa-blue dcf-topic-pin-unpin dcf-topic-pin-inner\"></i><span class=\"dcf-topic-pin-text dcf-link-text\">[RESX:UnPin]</span></li>");
+                }
+                else
+                {
+                    template.Replace("[ACTIONS:PIN]", "<li class=\"dcf-topic-pin-outer\" onclick=\"javascript:if(confirm('[RESX:Confirm:Pin]')){amaf_Pin(" + post.Forum.ModuleId + "," + post.Forum.ForumID + "," + post.Topic.TopicId + ");};\" title=\"[RESX:PinTopic]\"><i class=\"fa fa-thumb-tack fa-fm fa-blue dcf-topic-pin-pin dcf-topic-pin-inner\"></i><span class=\"dcf-topic-pin-text dcf-link-text\">[RESX:Pin]</span></li>");
+                }
+            }
+            else
+            {
+                template = template.Replace("[ACTIONS:PIN]", string.Empty);
+            }
+
+            // Status
+            if (post.Topic.StatusId <= 0 || (post.Topic.StatusId == 3 && (post.IsReply && post.StatusId == 0)))
+            {
+                template.Replace("[ACTIONS:ANSWER]", string.Empty);
+            }
+            else if (post.IsReply && post.StatusId == 1)
+            {
+                // Answered
+                if (useListActions)
+                {
+                    template.Replace("[ACTIONS:ANSWER]", "<li class=\"af-answered\" title=\"[RESX:Status:Answer]\"><em></em>[RESX:Status:Answer]</li>");
+                }
+                else
+                {
+                    template.Replace("[ACTIONS:ANSWER]", "<span class=\"af-actions af-answered\" title=\"[RESX:Status:Answer]\"><em></em>[RESX:Status:Answer]</span>");
+                }
+            }
+            else
+            {
+                // Not Answered
+                if (post.IsReply && (bEdit && (bModerate || (forumUser.UserId == post.Topic.Author.AuthorId && !post.Topic.IsLocked))))
+                {
+                    // Can mark answer
+                    if (useListActions)
+                    {
+                        template.Replace("[ACTIONS:ANSWER]", "<li class=\"af-markanswer\" onclick=\"amaf_MarkAsAnswer(" + post.Forum.ModuleId + "," + post.Forum.ForumID + "," + post.Topic.TopicId + "," + post.ReplyId + ");\" title=\"[RESX:Status:SelectAnswer]\"><em></em>[RESX:Status:SelectAnswer]</li>");
+                    }
+                    else
+                    {
+                        template.Replace("[ACTIONS:ANSWER]", "<a class=\"af-actions af-markanswer\" href=\"#\" onclick=\"amaf_MarkAsAnswer(" + post.Forum.ModuleId + "," + post.Forum.ForumID + "," + post.Topic.TopicId + "," + post.ReplyId + "); return false;\" title=\"[RESX:Status:SelectAnswer]\"><em></em>[RESX:Status:SelectAnswer]</a>");
+                    }
+                }
+                else
+                {
+                    // Display Nothing
+                    template.Replace("[ACTIONS:ANSWER]", string.Empty);
+                }
+            }
+
+            if (request.IsAuthenticated)
+            {
+                var alertParams = new List<string>
+                {
+                    $"{ParamKeys.ViewType}=modreport",
+                    $"{ParamKeys.ForumId}={post.ForumId}",
+                    $"{ParamKeys.TopicId}={post.TopicId}",
+                    $"{ParamKeys.ReplyId}={post.ReplyId}",
+                };
+                if (post.Forum.SocialGroupId > 0)
+                {
+                    alertParams.Add($"{Literals.GroupId}={post.Forum.SocialGroupId}");
+                }
+                if (useListActions)
+                {
+                    template.Replace("[ACTIONS:ALERT]", "<li onclick=\"window.location.href='" + Utilities.NavigateURL(tabId, string.Empty, alertParams.ToArray()) + "';\" title=\"[RESX:Alert]\"><i class=\"fa fa-bell-o fa-fw fa-blue\"></i><span class=\"dcf-link-text\">[RESX:Alert]</span></li>");
+                }
+                else
+                {
+                    template.Replace("[ACTIONS:ALERT]", "<a class=\"af-actions\" href=\"" + Utilities.NavigateURL(tabId, string.Empty, alertParams.ToArray()) + "\" title=\"[RESX:Alert]\"><i class=\"fa fa-bell-o fa-fw fa-blue\"></i><span class=\"dcf-link-text\">[RESX:Alert]</span></a>");
+                }
+            }
+            else
+            {
+                template.Replace("[ACTIONS:ALERT]", string.Empty);
+            }
+
+            return template;
+        }
+
+        internal static StringBuilder ReplaceForumTokens(StringBuilder template, DotNetNuke.Modules.ActiveForums.Entities.ForumInfo forum, DotNetNuke.Entities.Portals.PortalSettings portalSettings, SettingsInfo mainSettings, INavigationManager navigationManager, ForumUserInfo forumUser, HttpRequest request, int tabId, CurrentUserTypes currentUserType)
+        {
+            string language = forumUser?.UserInfo?.Profile?.PreferredLocale ?? portalSettings?.DefaultLanguage;
+
+            if (navigationManager == null)
+            {
+                navigationManager = new Services.URLNavigator().NavigationManager();
+            }
+
+            template = RemoveObsoleteTokens(template);
+            template = MapLegacyForumTokenSynonyms(template, forumUser, forum, portalSettings, language);
+
+            /* if no last post or user can't view via security, or subject missing, remove associated last topic tokens */
+            if (forum.LastPostID == 0 ||
+                !DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(forum.Security.View, forumUser.UserRoles) ||
+                string.IsNullOrEmpty(HttpUtility.HtmlDecode(forum.LastPostSubject)))
+            {
+                template = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.RemovePrefixedToken(template, "[FORUM:LASTPOSTSUBJECT");
+                template = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.RemovePrefixedToken(template, "[FORUM:LASTPOSTDISPLAYNAME");
+                template = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.RemovePrefixedToken(template, "[FORUM:LASTPOSTAUTHORDISPLAYNAME");
+                template = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.RemovePrefixedToken(template, "[FORUM:LASTPOSTAUTHORDISPLAYNAMELINK");
+                template = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.RemovePrefixedToken(template, "[FORUM:LASTPOSTDATE");
+                template.Replace("[AF:CONTROL:ADDFAVORITE]", string.Empty);
+                template.Replace("[RESX:BY]", string.Empty);
+            }
+
+            if (template.ToString().Contains("[GROUPCOLLAPSE]"))
+            {
+                template.Replace("[GROUPCOLLAPSE]", DotNetNuke.Modules.ActiveForums.Injector.InjectCollapsibleOpened(target: $"group{forum.ForumGroupId}", title: Utilities.GetSharedResource("[RESX:ToggleGroup]")));
+            }
+
+            if (template.ToString().Contains("[AF:CONTROL:ADDFAVORITE]"))
+            {
+                string forumUrl = new ControlUtils().BuildUrl(tabId, forum.ModuleId, forum.ForumGroup.PrefixURL, forum.PrefixURL, forum.ForumGroupId, forum.ForumID, -1, -1, string.Empty, 1, -1, forum.SocialGroupId);
+                template.Replace("[AF:CONTROL:ADDFAVORITE]", "<a href=\"javascript:afAddBookmark('" + forum.ForumName + "','" + forumUrl + "');\"><img src=\"" + mainSettings.ThemeLocation + "images/favorites16_add.png\" border=\"0\" alt=\"[RESX:AddToFavorites]\" /></a>");
+            }
+
+            template = new StringBuilder(DotNetNuke.Modules.ActiveForums.Services.Tokens.ResourceStringTokenReplacer.ReplaceResourceTokens(template.ToString()));
+            var tokenReplace = new DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer(portalSettings, forumUser, forum)
+            {
+                CurrentAccessLevel = Scope.DefaultSettings,
+                AccessingUser = forumUser.UserInfo,
+            };
+            template = new StringBuilder(tokenReplace.ReplaceEmbeddedTokens(template.ToString()));
+            template = new StringBuilder(tokenReplace.ReplaceTokens(template.ToString()));
+
+            return template;
+        }
+
+        internal static StringBuilder ReplaceUserTokens(StringBuilder template, DotNetNuke.Entities.Portals.PortalSettings portalSettings, SettingsInfo mainSettings, DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo forumUser, ForumUserInfo accessingUser, int forumModuleId)
+        {
+            string language = accessingUser?.UserInfo?.Profile?.PreferredLocale ?? portalSettings?.DefaultLanguage;
+            string dateFormat = Globals.DefaultDateFormat;
+
+            template = RemoveObsoleteTokens(template);
+            template = MapLegacyUserTokenSynonyms(template, forumUser, portalSettings, language);
+
+            template.Replace("[FORUMUSER:DISPLAYNAME]", DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetDisplayName(portalSettings, mainSettings, forumUser.GetIsMod(forumModuleId), forumUser.IsAdmin, forumUser.UserId, forumUser.Username, forumUser.FirstName, forumUser.LastName, forumUser.DisplayName));
+
+            template.Replace("[FORUMUSER:USERID]", forumUser?.UserId.ToString());
+            template.Replace("[FORUMUSER:USERNAME]", HttpUtility.HtmlEncode(forumUser?.Username).Replace("&amp;#", "&#"));
+            template.Replace("[FORUMUSER:FIRSTNAME]", HttpUtility.HtmlEncode(forumUser?.FirstName).Replace("&amp;#", "&#"));
+            template.Replace("[FORUMUSER:LASTNAME]", HttpUtility.HtmlEncode(forumUser?.LastName).Replace("&amp;#", "&#"));
+            template.Replace("[FORUMUSER:FULLNAME]", string.Concat(forumUser?.FirstName, " ", forumUser?.LastName));
+            template.Replace("[FORUMUSER:USERCAPTION]", forumUser.UserCaption);
+            template.Replace("[FORUMUSER:EMAIL]", forumUser.Email);
+
+            // Post Count
+            template.Replace("[FORUMUSER:POSTCOUNT]", (forumUser.PostCount == 0) ? string.Empty : forumUser.PostCount.ToString());
+            template.Replace("[FORUMUSER:DATELASTPOST]", (forumUser.DateLastPost == DateTime.MinValue) ? string.Empty : Utilities.GetUserFormattedDateTime(forumUser.DateLastPost, forumUser.PortalId, accessingUser.UserId));
+            template.Replace("[FORUMUSER:TOPICCOUNT]", forumUser.TopicCount.ToString());
+            template.Replace("[FORUMUSER:REPLYCOUNT]", forumUser.ReplyCount.ToString());
+            template.Replace("[FORUMUSER:VIEWCOUNT]", forumUser?.ViewCount.ToString());
+
+            // Points
+            if (mainSettings.EnablePoints && forumUser?.UserId > 0)
+            {
+                var totalPoints = (forumUser?.TopicCount * mainSettings.TopicPointValue) + (forumUser?.ReplyCount * mainSettings.ReplyPointValue) + (forumUser?.AnswerCount * mainSettings.AnswerPointValue) + forumUser?.RewardPoints;
+                template.Replace("[FORUMUSER:TOTALPOINTS]", totalPoints.ToString());
+                template.Replace("[FORUMUSER:ANSWERCOUNT]", forumUser?.AnswerCount.ToString());
+                template.Replace("[FORUMUSER:REWARDPOINTS]", forumUser?.RewardPoints.ToString());
+            }
+            else
+            {
+                template.Replace("[FORUMUSER:TOTALPOINTS]", string.Empty);
+                template.Replace("[FORUMUSER:ANSWERCOUNT]", string.Empty);
+                template.Replace("[FORUMUSER:REWARDPOINTS]", string.Empty);
+            }
+
+            // Rank
+            template.Replace("[FORUMUSER:RANKDISPLAY]", (forumUser.UserId > 0) ? DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetUserRank(forumModuleId, forumUser, 0) : string.Empty);
+            template.Replace("[FORUMUSER:RANKNAME]", (forumUser.UserId > 0) ? DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetUserRank(forumModuleId, forumUser, 1) : string.Empty);
+
+            // Avatar
+            if (template.ToString().Contains("[FORUMUSER:AVATAR]"))
+            {
+                var sAvatar = string.Empty;
+                if (!forumUser.PrefBlockAvatars && !forumUser.AvatarDisabled)
+                {
+                    sAvatar = DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetAvatar(
+                        forumUser.UserId,
+                        mainSettings.AvatarWidth,
+                        mainSettings.AvatarHeight);
+
+                }
+
+                template.Replace("[FORUMUSER:AVATAR]", sAvatar);
+            }
+
+            // User Status
+            var sUserStatus = string.Empty;
+            if (mainSettings.UsersOnlineEnabled && forumUser.UserId > 0)
+            {
+                sUserStatus = DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.UserStatus(mainSettings.ThemeLocation, forumUser.IsUserOnline, forumUser.UserId, forumModuleId, "[RESX:UserOnline]", "[RESX:UserOffline]");
+            }
+
+            template.Replace("[FORUMUSER:USERSTATUS]", sUserStatus);
+            template.Replace("[FORUMUSER:USERSTATUS:CSS]", sUserStatus.Contains("online") ? "af-status-online" : "af-status-offline");
+
+            template = ExtractAndReplaceDateTokenWithOptionalFormatParameter(template, "[FORUMUSER:DATELASTACTIVITY", forumUser.DateLastActivity, portalSettings, forumUser);
+            template = ExtractAndReplaceDateTokenWithOptionalFormatParameter(template, "[FORUMUSER:DATECREATED", forumUser.DateCreated, portalSettings, forumUser);
+
+            return template;
+        }
+
+        internal static StringBuilder ReplaceTopicTokens(StringBuilder template, DotNetNuke.Modules.ActiveForums.Entities.TopicInfo topic, DotNetNuke.Entities.Portals.PortalSettings portalSettings, SettingsInfo mainSettings, INavigationManager navigationManager, DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo forumUser, HttpRequest request)
+        {
+            string language = forumUser?.UserInfo?.Profile.PreferredLocale ?? portalSettings?.DefaultLanguage;
+
+            if (navigationManager == null)
+            {
+                navigationManager = (INavigationManager)new Services.URLNavigator();
+            }
+
+            var @params = new List<string>();
+
+            template = RemoveObsoleteTokens(template);
+            template = MapLegacyTopicTokenSynonyms(template, forumUser, topic, portalSettings, language);
+
+            /* if user can't read via security, remove topic tokens */
+            if (!DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(topic.Forum.Security.Read, forumUser.UserRoles))
+            {
+                template = RemovePrefixedToken(template, "[LASTPOSTSUBJECT");
+                template.Replace("[LASTPOSTDATE]", string.Empty);
+                template.Replace("[BODYTITLE]", string.Empty);
+                template.Replace("[BODY]", string.Empty);
+                template.Replace("[AF:ICONLINK:LASTREPLY]", string.Empty);
+                template.Replace("[AF:URL:LASTREPLY]", string.Empty);
+            }
+
+            /* if no replies, remove associated tokens */
+            if (topic.LastReplyId < 1)
+            {
+                template.Replace("[AF:ICONLINK:LASTREPLY]", string.Empty);
+                template.Replace("[AF:URL:LASTREPLY]", string.Empty);
+                template.Replace("[AF:UI:MINIPAGER]", string.Empty);
+            }
+
+            // replace tokens unique to topic itself
+            template.Replace("[REPLIES]", topic.ReplyCount.ToString());
+
+            string sBodyTitle = GetTopicTitle(topic.Content.Body);
+
+            template.Replace("[BODYTITLE]", sBodyTitle);
+            template = ReplaceBody(template, topic.Content, mainSettings, request.Url);
+
+            int BodyLength = -1;
+            string BodyTrim = string.Empty;
+
+            if (template.ToString().Contains("[TOPICSUBJECT:"))
+            {
+                const string pattern = "(\\[TOPICSUBJECT:(.+?)\\])";
+                foreach (Match m in Regex.Matches(template.ToString(), pattern))
+                {
+                    var maxLength = Utilities.SafeConvertInt(m.Groups[2].Value, 255);
+                    if (topic.Content.Subject.Length > maxLength)
+                    {
+                        template.Replace(m.Value, topic.Subject.Substring(0, maxLength) + "...");
+                    }
+                    else
+                    {
+                        template.Replace(m.Value, Utilities.StripHTMLTag(topic.Subject));
+                    }
+                }
+            }
+
+            /* from topicsview */
+            if (template.ToString().Contains("[BODY:"))
+            {
+                const string pattern = "(\\[BODY:(.+?)\\])";
+                foreach (Match m in Regex.Matches(template.ToString(), pattern))
+                {
+                    var maxLength = Utilities.SafeConvertInt(m.Groups[2].Value, 512);
+                    if (topic?.Content?.Body?.Length > maxLength)
+                    {
+                        template.Replace(m.Value, topic?.Content?.Body?.Substring(0, maxLength) + "...");
+                    }
+                    else
+                    {
+                        template.Replace(m.Value, topic?.Content?.Body);
+                    }
+                }
+            }
+
+            /* from topic view */
+            if (template.ToString().Contains("[BODY:"))
+            {
+                int inStart = (template.ToString().IndexOf("[BODY:", 0) + 1) + 5;
+                int inEnd = (template.ToString().IndexOf("]", inStart - 1) + 1) - 1;
+                string sLength = template.ToString().Substring(inStart, inEnd - inStart);
+                BodyLength = Convert.ToInt32(sLength);
+                BodyTrim = "[BODY:" + BodyLength.ToString() + "]";
+            }
+
+            if (template.ToString().Contains("[SUMMARY]") && string.IsNullOrEmpty(topic.Content.Summary) &&
+                string.IsNullOrEmpty(BodyTrim))
+            {
+                BodyTrim = "[BODY:250]";
+                BodyLength = 250;
+            }
+
+            string BodyPlain = string.Empty;
+            if (!string.IsNullOrEmpty(BodyTrim))
+            {
+                BodyPlain = topic?.Content?.Body?.Replace("<br>", System.Environment.NewLine).Replace("<br />", System.Environment.NewLine);
+                BodyPlain = Utilities.StripHTMLTag(BodyPlain);
+                if (BodyLength > 0 & BodyPlain.Length > BodyLength)
+                {
+                    BodyPlain = BodyPlain.Substring(0, BodyLength);
+                }
+
+                BodyPlain = BodyPlain.Replace(System.Environment.NewLine, "<br />");
+                template.Replace(BodyTrim, BodyPlain);
+            }
+
+            if (string.IsNullOrEmpty(topic?.Content?.Summary))
+            {
+                topic.Content.Summary = BodyPlain;
+                topic.Content.Summary = topic.Content.Summary.Replace("<br />", "  ");
+            }
+
+            if (topic.IsLocked)
+            {
+                template.Replace("fa-lock", "fa-unlock");
+                template.Replace("[RESX:Lock]", "[RESX:UnLock]");
+                template.Replace("[RESX:LockTopic]", "[RESX:UnLockTopic]");
+                template.Replace("[RESX:Confirm:Lock]", "[RESX:Confirm:UnLock]");
+            }
+
+            if (template.ToString().Contains("[ICONLOCK]"))
+            {
+                template.Replace("[ICONLOCK]", string.Format(GetTokenFormatString(topic.IsLocked ? "[ICONLOCK]-ShowIcon" : "[ICONLOCK]-HideIcon", portalSettings, language), topic.TopicId.ToString()));
+            }
+
+            if (topic.IsPinned)
+            {
+                template.Replace("dcf-topic-pin-pin", "dcf-topic-pin-unpin");
+                template.Replace("[RESX:Pin]", "[RESX:UnPin]");
+                template.Replace("[RESX:PinTopic]", "[RESX:UnPinTopic]");
+                template.Replace("[RESX:Confirm:Pin]", "[RESX:Confirm:UnPin]");
+            }
+
+            if (template.ToString().Contains("[ICONPIN]"))
+            {
+                template.Replace("[ICONPIN]", string.Format(GetTokenFormatString(topic.IsPinned ? "[ICONPIN]-ShowIcon" : "[ICONPIN]-HideIcon", portalSettings, language), topic.TopicId.ToString()));
+            }
+
+            if (template.ToString().Contains("[TOPICURL]") ||
+                template.ToString().Contains("[AF:ICONLINK:LASTREAD]") ||
+                template.ToString().Contains("[AF:ICONLINK:LASTREPLY]") ||
+                template.ToString().Contains("[AF:URL:LASTREAD]") ||
+                template.ToString().Contains("[AF:URL:LASTREPLY]") ||
+                template.ToString().Contains("[SUBJECT]") ||
+                template.ToString().Contains("[SUBJECTLINK]") ||
+                template.ToString().Contains("[LASTPOST") ||
+                template.ToString().Contains("[AF:LABEL:Last"))
+            {
+                @params = new List<string>
+                {
+                    $"{ParamKeys.TopicId}={topic.TopicId}", $"{ParamKeys.ContentJumpId}={topic.LastReplyId}",
+                };
+
+                if (topic.Forum.SocialGroupId > 0)
+                {
+                    @params.Add($"{Literals.GroupId}={topic.Forum.SocialGroupId}");
+                }
+
+                string sLastReplyURL = navigationManager.NavigateURL(portalSettings.ActiveTab.TabID, string.Empty, @params.ToArray());
+                string sTopicURL = new ControlUtils().BuildUrl(portalSettings.ActiveTab.TabID, topic.Forum.ModuleId, topic.Forum.ForumGroup.PrefixURL, topic.Forum.PrefixURL, topic.Forum.ForumGroupId, topic.Forum.ForumID, topic.TopicId, topic.TopicUrl, -1, -1, string.Empty, 1, -1, topic.Forum.SocialGroupId);
+                if (!(string.IsNullOrEmpty(sTopicURL)))
+                {
+                    if (sTopicURL.EndsWith("/"))
+                    {
+                        sLastReplyURL = sTopicURL + (Utilities.UseFriendlyURLs(topic.Forum.ModuleId)
+                            ? string.Concat("#", topic.TopicId)
+                            : string.Concat("?", ParamKeys.ContentJumpId, "=", topic.LastReplyId));
+                    }
+                }
+
+                template.Replace("[AF:ICONLINK:LASTREPLY]", string.Format(GetTokenFormatString("[ICONLINK-LASTREPLY]", portalSettings, language), sLastReplyURL, mainSettings.ThemeLocation));
+                template.Replace("[AF:URL:LASTREPLY]", sLastReplyURL);
+
+                string sLastReadURL = string.Empty;
+                int? userLastReplyRead = forumUser?.GetLastReplyRead(topic);
+                if (userLastReplyRead > 0)
+                {
+                    @params = new List<string>
+                    {
+                        $"{ParamKeys.ForumId}={topic.ForumId}",
+                        $"{ParamKeys.TopicId}={topic.TopicId}",
+                        $"{ParamKeys.ViewType}={Views.Topic}",
+                        $"{ParamKeys.FirstNewPost}={userLastReplyRead}",
+                    };
+                    if (topic.Forum.SocialGroupId > 0)
+                    {
+                        @params.Add($"{Literals.GroupId}={topic.Forum.SocialGroupId}");
+                    }
+
+                    sLastReadURL = navigationManager.NavigateURL(portalSettings.ActiveTab.TabID, string.Empty, @params.ToArray());
+
+                    if (mainSettings.UseShortUrls)
+                    {
+                        @params = new List<string>
+                        {
+                            $"{ParamKeys.TopicId}={topic.TopicId}",
+                            $"{ParamKeys.FirstNewPost}={userLastReplyRead}",
+                        };
+                        if (topic.Forum.SocialGroupId > 0)
+                        {
+                            @params.Add($"{Literals.GroupId}={topic.Forum.SocialGroupId}");
+                        }
+
+                        sLastReadURL = navigationManager.NavigateURL(portalSettings.ActiveTab.TabID, string.Empty, @params.ToArray());
+                    }
+
+                    if (sTopicURL.EndsWith("/"))
+                    {
+                        sLastReadURL = sTopicURL + (Utilities.UseFriendlyURLs(topic.Forum.ModuleId)
+                            ? string.Concat("#", userLastReplyRead)
+                            : string.Concat("?", ParamKeys.FirstNewPost, "=", userLastReplyRead));
+                    }
+                }
+
+                template.Replace("[AF:ICONLINK:LASTREAD]", string.Format(GetTokenFormatString("[ICONLINK-LASTREAD]", portalSettings, language), sLastReadURL, mainSettings.ThemeLocation));
+                template.Replace("[AF:URL:LASTREAD]", sLastReadURL);
+
+                if (forumUser.PrefJumpLastPost && sLastReadURL != string.Empty)
+                {
+                    sTopicURL = sLastReadURL;
+                }
+
+                if (template.ToString().Contains("[SUBJECT]") || template.ToString().Contains("[SUBJECTLINK]"))
+                {
+                    string sPollImage = (topic.TopicType == TopicTypes.Poll ? GetTokenFormatString("[POSTICON]", portalSettings, language) : string.Empty);
+                    topic.Content.Subject = Utilities.StripHTMLTag(topic.Content.Subject);
+                    template.Replace("[SUBJECT]", topic.Content.Subject.Replace("[", "&#91").Replace("]", "&#93") + sPollImage);
+                    if (template.ToString().Contains("[SUBJECTLINK]"))
+                    {
+                        string slink = null;
+                        string subject = HttpUtility.HtmlDecode(topic.Subject);
+                        subject = Utilities.StripHTMLTag(subject);
+                        subject = subject.Replace("\"", string.Empty).Replace("#", string.Empty).Replace("%", string.Empty).Replace("+", string.Empty);
+
+                        if (sTopicURL == string.Empty)
+                        {
+                            @params = new List<string>
+                            {
+                                $"{ParamKeys.ForumId}={topic.ForumId}",
+                                $"{ParamKeys.TopicId}={topic.TopicId}",
+                                $"{ParamKeys.ViewType}={Views.Topic}",
+                            };
+                            if (mainSettings.UseShortUrls)
+                            {
+                                @params.Add($"${ParamKeys.TopicId}={topic.TopicId}");
+                            }
+
+                            slink = "<a title=\"" + sBodyTitle + "\" href=\"" + navigationManager.NavigateURL(portalSettings.ActiveTab.TabID, string.Empty, @params.ToArray()) + "\">" + subject + "</a>";
+                        }
+                        else
+                        {
+                            slink = "<a title=\"" + sBodyTitle + "\" href=\"" + sTopicURL + "\">" + subject + "</a>";
+                        }
+
+                        template.Replace("[SUBJECTLINK]", slink + sPollImage);
+                    }
+                }
+                if (template.ToString().Contains("[LASTPOST]"))
+                {
+                    if (topic.LastReply?.ReplyId == 0)
+                    {
+                        template = TemplateUtils.ReplaceSubSection(template, string.Empty, "[LASTPOST]", "[/LASTPOST]");
+                    }
+                    else
+                    {
+                        string sLastReply = TemplateUtils.GetTemplateSection(template.ToString(), "[LASTPOST]", "[/LASTPOST]");
+                        int iLength = 0;
+                        if (sLastReply.Contains("[LASTPOSTSUBJECT:"))
+                        {
+                            int inStart = (sLastReply.IndexOf("[LASTPOSTSUBJECT:", 0) + 1) + 17;
+                            int inEnd = (sLastReply.IndexOf("]", inStart - 1) + 1);
+                            string sLength = sLastReply.Substring(inStart - 1, inEnd - inStart);
+                            iLength = Convert.ToInt32(sLength);
+                        }
+
+                        string LastReplySubjectReplaceTag = "[LASTPOSTSUBJECT:" + iLength.ToString() + "]";
+                        string sLastReplyTemp = sLastReply;
+
+                        sLastReplyTemp = sLastReplyTemp.Replace("[AF:ICONLINK:LASTREPLY]", string.Format(GetTokenFormatString("[ICONLINK-LASTREPLY]", portalSettings, language), sLastReplyURL, mainSettings.ThemeLocation));
+                        sLastReplyTemp = sLastReplyTemp.Replace("[AF:URL:LASTREPLY]", sLastReplyURL);
+
+                        int PageSize = mainSettings.PageSize;
+                        if (forumUser.UserId > 0)
+                        {
+                            PageSize = forumUser.PrefPageSize;
+                        }
+
+                        if (PageSize < 5)
+                        {
+                            PageSize = 10;
+                        }
+
+                        sLastReplyTemp = sLastReplyTemp.Replace(LastReplySubjectReplaceTag, Utilities.GetLastPostSubject(topic.LastReply.ReplyId, topic.TopicId, topic.ForumId, portalSettings.ActiveTab.TabID, topic.LastReply.Content.Subject, iLength, pageSize: PageSize, replyCount: topic.ReplyCount, canRead: true));
+                        if (template.ToString().Contains("[LASTPOSTDISPLAYNAME]"))
+                        {
+                            if (topic.LastReply.Author.AuthorId > 0)
+                            {
+                                sLastReplyTemp = sLastReplyTemp.Replace("[LASTPOSTDISPLAYNAME]", DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetDisplayName(portalSettings, mainSettings, forumUser.GetIsMod(topic.ModuleId), forumUser.IsAdmin || forumUser.IsSuperUser, topic.LastReply.Author.AuthorId, topic.LastReply.Author.Username, topic.LastReply.Author.FirstName, topic.LastReply.Author.LastName, topic.LastReply.Author.DisplayName).ToString().Replace("&amp;#", "&#"));
+                            }
+                            else
+                            {
+                                sLastReplyTemp = sLastReplyTemp.Replace("[LASTPOSTDISPLAYNAME]", topic.LastReply.Content.AuthorName);
+                            }
+                        }
+
+                        if (template.ToString().Contains("[LASTPOSTDATE]"))
+                        {
+                            sLastReplyTemp = sLastReplyTemp.Replace("[LASTPOSTDATE]", Utilities.GetUserFormattedDateTime(topic.LastReply.Content.DateCreated, portalSettings.PortalId, forumUser.UserId));
+                        }
+
+                        template = TemplateUtils.ReplaceSubSection(template, sLastReplyTemp, "[LASTPOST]", "[/LASTPOST]");
+                    }
+                }
+            }
+
+            template = new StringBuilder(DotNetNuke.Modules.ActiveForums.Services.Tokens.ResourceStringTokenReplacer.ReplaceResourceTokens(template.ToString()));
+            var tokenReplace = new DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer(portalSettings, forumUser, topic)
+            {
+                AccessingUser = forumUser.UserInfo
+            };
+            template = new StringBuilder(tokenReplace.ReplaceEmbeddedTokens(template.ToString()));
+            template = new StringBuilder(tokenReplace.ReplaceTokens(template.ToString()));
+
+            return template;
+        }
+
+        internal static StringBuilder ReplacePostTokens(StringBuilder template, DotNetNuke.Modules.ActiveForums.Entities.IPostInfo post, DotNetNuke.Entities.Portals.PortalSettings portalSettings, SettingsInfo mainSettings, INavigationManager navigationManager, DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo forumUser, HttpRequest request)
+        {
+            string language = forumUser?.UserInfo?.Profile.PreferredLocale ?? portalSettings?.DefaultLanguage;
+
+            if (navigationManager == null)
+            {
+                navigationManager = (INavigationManager)new Services.URLNavigator();
+            }
+
+            template = RemoveObsoleteTokens(template);
+            template = MapLegacyPostTokenSynonyms(template, forumUser, post, portalSettings, language);
+
+            // Perform Profile Related replacements
+            var author = new DotNetNuke.Modules.ActiveForums.Entities.AuthorInfo(post.PortalId, post.Forum.ModuleId, post.Author.AuthorId);
+            if (template.ToString().Contains("[POSTINFO]"))
+            {
+                var sPostInfo = TemplateUtils.GetPostInfo(post.ModuleId, author.ForumUser, post.Forum.ThemeLocation, post.Forum.GetIsMod(forumUser), post.Content.IPAddress, author.ForumUser.IsUserOnline, forumUser.CurrentUserType, forumUser.UserId, forumUser.PrefBlockAvatars, forumUser.UserInfo.Profile.PreferredTimeZone.GetUtcOffset(DateTime.UtcNow));
+                template.Replace("[POSTINFO]", sPostInfo);
+            }
+            template = ReplaceBody(template, post.Content, mainSettings, request.Url);
+
+            template = new StringBuilder(DotNetNuke.Modules.ActiveForums.Services.Tokens.ResourceStringTokenReplacer.ReplaceResourceTokens(template.ToString()));
+            var tokenReplace = new DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer(portalSettings, forumUser, post)
+            {
+                AccessingUser = forumUser.UserInfo
+            };
+            template = new StringBuilder(tokenReplace.ReplaceEmbeddedTokens(template.ToString()));
+            template = new StringBuilder(tokenReplace.ReplaceTokens(template.ToString()));
+
+            return template;
+        }
+
+        private static StringBuilder ExtractAndReplaceDateTokenWithOptionalFormatParameter(StringBuilder template, string tokenPrefix, DateTime? datetime, PortalSettings portalSettings, ForumUserInfo forumUser)
+        {
+            if (datetime == null ||
+                datetime == DateTime.MinValue ||
+                datetime == SqlDateTime.MinValue.Value ||
+                datetime == Utilities.NullDate())
+            {
+                return RemovePrefixedToken(template, tokenPrefix);
+            }
+
+            var replacementToken = $"{tokenPrefix}]";
+            var dateFormat = Globals.DefaultDateFormat;
+            if (template.ToString().Contains($"{tokenPrefix}:"))
+            {
+                dateFormat = template.ToString().Substring(template.ToString().IndexOf($"{tokenPrefix}:", StringComparison.Ordinal) + replacementToken.Length, 1);
+                if (string.IsNullOrEmpty(dateFormat))
+                {
+                    dateFormat = Globals.DefaultDateFormat;
+                }
+
+                replacementToken = $"{tokenPrefix}:{dateFormat}]";
+
+            }
+
+            return ReplaceDateToken(template, replacementToken, (DateTime)datetime, portalSettings, forumUser, dateFormat);
+        }
+
+        internal static StringBuilder ReplaceDateToken(StringBuilder template, string token, DateTime datetime, PortalSettings portalSettings, ForumUserInfo accessingUser, string dateFormat = "g")
+        {
+            if (template.ToString().Contains(token))
+            {
+                if (datetime != DateTime.MinValue &&
+                    datetime != SqlDateTime.MinValue.Value &&
+                    datetime != Utilities.NullDate())
+                {
+                    return template.Replace(token, Utilities.GetUserFormattedDateTime((DateTime?)datetime, portalSettings.PortalId, accessingUser.UserId, dateFormat));
+                }
+
+                return template.Replace(token, string.Empty);
+            }
+
+            return template;
+        }
+
+        internal static StringBuilder RemoveObsoleteTokens(StringBuilder template)
+        {
+            // no longer using this
+            template = RemoveObsoleteTokenByPrefix(template, "[SPLITBUTTONS2");
+            // Add This -- obsolete so just remove
+            template = RemoveObsoleteTokenByPrefix(template, "[AF:CONTROL:ADDTHIS");
+
+            // no longer using these
+            string[] tokens = {
+                "[DATECREATED]",
+                "[OCCUPATION]",
+                "[WEBSITE]",
+                "[AF:PROFILE:YAHOO]",
+                "[AF:PROFILE:MSN]",
+                "[AF:PROFILE:ICQ]",
+                "[AF:PROFILE:AOL]",
+                "[AF:PROFILE:OCCUPATION]",
+                "[AF:PROFILE:INTERESTS]",
+                "[AF:PROFILE:LOCATION]",
+                "[AF:PROFILE:WEBSITE]",
+                "[AF:CONTROL:AVATAREDIT]",
+                "[AF:BUTTON:PROFILEEDIT]",
+                "[AF:BUTTON:PROFILESAVE]",
+                "[AF:BUTTON:PROFILECANCEL]",
+                "[AF:PROFILE:BIO]",
+                "[MODUSERSETTINGS]",
+            };
+
+            //var tokens = GetObsoleteTokens();
+            if (tokens.Length > 0)
+            {
+                tokens.ToList().ForEach(t => template = RemoveObsoleteToken(template, t));
+            }
+
+            return template;
+        }
+
+        internal static StringBuilder RemoveControlTokensForDnnPrintMode(StringBuilder template)
+        {
+            string[] tokens = {
+                "[ADDREPLY]",
+                "[QUICKREPLY]",
+                "[TOPICSUBSCRIBE]",
+                "[AF:CONTROL:PRINTER]",
+                "[AF:CONTROL:EMAIL]",
+                "[PAGER1]",
+                "[PAGER2]",
+                "[SORTDROPDOWN]",
+                "[POSTRATINGBUTTON]",
+                "[JUMPTO]",
+                "[NEXTTOPIC]",
+                "[PREVTOPIC]",
+                "[FORUMTOPIC:PREVIOUSTOPICLINK]",
+                "[FORUMTOPIC:NEXTTOPICLINK]",
+                "[AF:CONTROL:STATUS]",
+                "[ACTIONS:DELETE]",
+                "[ACTIONS:EDIT]",
+                "[ACTIONS:QUOTE]",
+                "[ACTIONS:REPLY]",
+                "[ACTIONS:ANSWER]",
+                "[ACTIONS:ALERT]",
+                "[ACTIONS:BAN]",
+                "[ACTIONS:MOVE]",
+                "[RESX:SortPosts]",
+            };
+
+            tokens.ToList().ForEach(t => template.Replace(t, string.Empty));
+            return template;
+        }
+
+        internal static StringBuilder MapLegacyPortalTokenSynonyms(StringBuilder template)
+        {
+            template = ReplaceTokenSynonym(template, "[PORTALID]", "[PORTAL:PORTALID]");
+            template = ReplaceTokenSynonym(template, "[PORTALNAME]", "[PORTAL:PORTALNAME]");
+            return template;
+        }
+
+        internal static StringBuilder MapLegacyModuleTokenSynonyms(StringBuilder template)
+        {
+            template = ReplaceTokenSynonym(template, "[MODULEID]", "[MODULE:MODULEID]");
+            template = ReplaceTokenSynonym(template, "[TABID]", "[TAB:TABID]");
+            return template;
+        }
+
+        internal static StringBuilder MapLegacyForumTokenSynonyms(StringBuilder template, DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo forumUser, DotNetNuke.Modules.ActiveForums.Entities.ForumInfo forum, DotNetNuke.Entities.Portals.PortalSettings portalSettings, string language)
+        {
+            template = ReplaceTokenSynonym(template, "[FORUMID]", "[FORUM:FORUMID]");
+            template = ReplaceTokenSynonym(template, "[FORUMGROUPID]", "[FORUM:FORUMGROUPID]");
+            template = ReplaceTokenSynonym(template, "[PARENTFORUMID]", "[FORUM:PARENTFORUMID]");
+            template = ReplaceTokenSynonym(template, "[PARENTFORUMNAME]", "[FORUM:PARENTFORUMNAME]");
+            template = ReplaceTokenSynonym(template, "[GROUPNAME]", "[FORUM:FORUMGROUPNAME]");
+            template = ReplaceTokenSynonym(template, "[FORUMSUBSCRIBERCOUNT]", "[FORUM:SUBSCRIBERCOUNT]");
+            template = ReplaceTokenSynonym(template, "[TOTALREPLIES]", "[FORUM:TOTALREPLIES]");
+            template = ReplaceTokenSynonym(template, "[TOTALTOPICS]", "[FORUM:TOTALTOPICS]");
+            template = ReplaceTokenSynonym(template, "[FORUMNAMENOLINK]", "[FORUM:FORUMNAME]");
+            template = ReplaceTokenSynonym(template, "[AF:CONTROL:FORUMID]", "[FORUM:FORUMID]");
+            template = ReplaceTokenSynonym(template, "[AF:CONTROL:FORUMGROUPID]", "[FORUM:FORUMGROUPID]");
+            template = ReplaceTokenSynonym(template, "[LASTPOSTDATE]", "[FORUM:LASTPOSTDATE]");
+
+            template = ReplaceTokenSynonymPrefix(template, "[LASTPOSTSUBJECT", "[FORUM:LASTPOSTSUBJECT");
+
+            var tokenReplacer = new DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer(portalSettings, forumUser, forum)
+            {
+                AccessingUser = forumUser.UserInfo
+            };
+            template = ReplaceLegacyTokenWithFormatString(template, tokenReplacer, portalSettings, language, "[RSSLINK]", "[FORUM:RSSLINK", "[RSSLINK]");
+            template = ReplaceLegacyTokenWithFormatString(template, tokenReplacer, portalSettings, language, "[PARENTFORUMLINK]", "[FORUM:PARENTFORUMLINK", "[PARENTFORUMLINK]");
+            template = ReplaceLegacyTokenWithFormatString(template, tokenReplacer, portalSettings, language, "[FORUMDESCRIPTION]", "[FORUM:FORUMDESCRIPTION", "[FORUMDESCRIPTION]");
+            template = ReplaceLegacyTokenWithFormatString(template, tokenReplacer, portalSettings, language, "[FORUMICON]", "[FORUM:FORUMICON", "[FORUMICON]");
+            template = ReplaceLegacyTokenWithFormatString(template, tokenReplacer, portalSettings, language, "[MODLINK]", "[FORUM:MODLINK", "[MODLINK]");
+            template = ReplaceLegacyTokenWithFormatString(template, tokenReplacer, portalSettings, language, "[FORUMGROUPLINK]", "[FORUM:FORUMGROUPLINK", "[FORUMGROUPLINK]");
+
+            /* note: this purposely uses same token format string [FORUMLINK] for both [FORUMNAME] and [FORUMLINK] */
+            template = ReplaceLegacyTokenWithFormatString(template, tokenReplacer, portalSettings, language, "[FORUMNAME]", "[FORUM:FORUMLINK", "[FORUMLINK]");
+            template = ReplaceLegacyTokenWithFormatString(template, tokenReplacer, portalSettings, language, "[FORUMLINK]", "[FORUM:FORUMLINK", "[FORUMLINK]");
+
+            /* note: these purposely use same target token but with different format string resource keys */
+            template = ReplaceLegacyTokenWithFormatString(template, tokenReplacer, portalSettings, language, "[FORUMICONCSS]", "[FORUM:FORUMICONCSS", "[FORUMICONCSS]");
+            template = ReplaceLegacyTokenWithFormatString(template, tokenReplacer, portalSettings, language, "[FORUMICONSM]", "[FORUM:FORUMICONCSS", "[FORUMICONSM]");
+
+            template = ReplaceLegacyTokenWithFormatString(template, tokenReplacer, portalSettings, language, "[DISPLAYNAME]", "[FORUM:LASTPOSTAUTHORDISPLAYNAMELINK", "[FORUMLASTPOSTAUTHORDISPLAYNAMELINK]", "[FORUM:LASTPOSTDISPLAYNAME]");
+
+            return template;
+        }
+
+        internal static StringBuilder MapLegacyUserTokenSynonyms(StringBuilder template, DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo forumUser, DotNetNuke.Entities.Portals.PortalSettings portalSettings, string language)
+        {
+            template = ReplaceTokenSynonym(template, "[SENDERUSERNAME]", "[FORUMUSER:USERNAME]");
+            template = ReplaceTokenSynonym(template, "[SENDERFIRSTNAME", "[FORUMUSER:FIRSTNAME]");
+            template = ReplaceTokenSynonym(template, "[SENDERLASTNAME]", "[FORUMUSER:LASTNAME]");
+            template = ReplaceTokenSynonym(template, "[SENDERDISPLAYNAME]", "[FORUMUSER:DISPLAYNAME]");
+
+            template = ReplaceTokenSynonym(template, "[SIGNATURE]", "[FORUMUSER:SIGNATURE]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:SIGNATURE]", "[FORUMUSER:SIGNATURE]");
+
+            template = ReplaceTokenSynonym(template, "[USERCAPTION]", "[FORUMUSER:USERCAPTION]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:USERCAPTION]", "[FORUMUSER:USERCAPTION]");
+
+            template = ReplaceTokenSynonym(template, "[AVATAR]", "[FORUMUSER:AVATAR]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:AVATAR]", "[FORUMUSER:AVATAR]");
+
+            template = ReplaceTokenSynonym(template, "[RANKNAME]", "[FORUMUSER:RANKNAME]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:RANKNAME]", "[FORUMUSER:RANKNAME]");
+
+            template = ReplaceTokenSynonym(template, "[RANKDISPLAY]", "[FORUMUSER:RANKDISPLAY]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:RANKDISPLAY]", "[FORUMUSER:RANKDISPLAY]");
+
+            template = ReplaceTokenSynonym(template, "[USERNAME]", "[FORUMUSER:USERNAME]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:USERNAME]", "[FORUMUSER:USERNAME]");
+
+            template = ReplaceTokenSynonym(template, "[USERID]", "[FORUMUSER:USERID]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:USERID]", "[FORUMUSER:USERID]");
+
+            template = ReplaceTokenSynonym(template, "[EMAIL]", "[FORUMUSER:EMAIL]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:EMAIL]", "[FORUMUSER:EMAIL]");
+
+            template = ReplaceTokenSynonym(template, "[FIRSTNAME]", "[FORUMUSER:FIRSTNAME]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:FIRSTNAME]", "[FORUMUSER:FIRSTNAME]");
+            template = ReplaceTokenSynonym(template, "[LASTNAME]", "[FORUMUSER:LASTNAME]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:LASTNAME]", "[FORUMUSER:FIRSTNAME]");
+
+            template = ReplaceTokenSynonym(template, "[MEMBERSINCE]", "[FORUMUSER:DATECREATED]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:DATECREATED]", "[FORUMUSER:DATECREATED]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:MEMBERSINCE]", "[FORUMUSER:DATECREATED]");
+
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:LASTACTIVE]", "[FORUMUSER:DATELASTACTIVITY]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:DATELASTACTIVITY]", "[FORUMUSER:DATELASTACTIVITY]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:DATELASTPOST]", "[FORUMUSER:DATELASTPOST]");
+
+            template = ReplaceTokenSynonym(template, "[USERCAPTION]", "[FORUMUSER:USERCAPTION]");
+            template = ReplaceTokenSynonym(template, "[[AF:PROFILE:USERCAPTION]", "[FORUMUSER:USERCAPTION]");
+
+            template = ReplaceTokenSynonym(template, "[USERSTATUS]", "[FORUMUSER:USERSTATUS]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:USERSTATUS]", "[FORUMUSER:USERSTATUS]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:USERSTATUS:CSS]", "[FORUMUSER:USERSTATUSCSS]");
+
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:TOTALPOINTS]", "[FORUMUSER:TOTALPOINTS]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:VIEWCOUNT]", "[FORUMUSER:VIEWCOUNT]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:ANSWERCOUNT]", "[FORUMUSER:ANSWERCOUNT]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:REWARDPOINTS]", "[FORUMUSER:REWARDPOINTS]");
+
+            template = ReplaceTokenSynonym(template, "[POSTS]", "[FORUMUSER:POSTS]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:POSTS]", "[FORUMUSER:POSTS]");
+
+            template = ReplaceTokenSynonym(template, "[POSTCOUNT]", "[FORUMUSER:POSTCOUNT]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:POSTCOUNT]", "[FORUMUSER:POSTCOUNT]");
+
+            template = ReplaceTokenSynonym(template, "[AF:POINTS:TOPICCOUNT]", "[FORUMUSER:TOPICCOUNT]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:TOPICCOUNT]", "[FORUMUSER:TOPICCOUNT]");
+
+            template = ReplaceTokenSynonym(template, "[AF:POINTS:REPLYCOUNT]", "[FORUMUSER:REPLYCOUNT]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:REPLYCOUNT]", "[FORUMUSER:REPLYCOUNT]");
+
+            var tokenReplacer = new DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer(portalSettings, forumUser)
+            {
+                AccessingUser = forumUser.UserInfo
+            };
+            template = ReplaceLegacyTokenWithFormatString(template, tokenReplacer, portalSettings, language, "[DISPLAYNAME]", "[FORUMUSER:USERPROFILELINK", "[DISPLAYNAMELINK]", "[FORUMUSER:DISPLAYNAME]");
+            template = ReplaceLegacyTokenWithFormatString(template, tokenReplacer, portalSettings, language, "[AF:PROFILE:DISPLAYNAME]", "[FORUMUSER:USERPROFILELINK", "[DISPLAYNAMELINK]", "[FORUMUSER:DISPLAYNAME]");
+            return template;
+        }
+
+        internal static StringBuilder MapLegacyTopicTokenSynonyms(StringBuilder template, DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo forumUser, DotNetNuke.Modules.ActiveForums.Entities.TopicInfo topic, DotNetNuke.Entities.Portals.PortalSettings portalSettings, string language)
+        {
+            // replace synonyms
+            template = ReplaceTokenSynonym(template, "[AF:LABEL:LastPostDate]", "[FORUMTOPIC:LASTPOSTDATE]");
+            template = ReplaceTokenSynonym(template, "[AF:LABEL:TopicDateCreated]", "[FORUMTOPIC:DATECREATED]");
+            template = ReplaceTokenSynonym(template, "[TOPICID]", "[FORUMTOPIC:POSTID]");
+            template = ReplaceTokenSynonym(template, "[AF:LABEL:ReplyCount]", "[FORUMTOPIC:REPLYCOUNT]");
+            template = ReplaceTokenSynonym(template, "[VIEWS]", "[FORUMTOPIC:VIEWCOUNT]");
+            template = ReplaceTokenSynonym(template, "[SUMMARY]", "[FORUMTOPIC:SUMMARY]");
+            template = ReplaceTokenSynonym(template, "[TOPICSUBSCRIBERCOUNT]", "[FORUMTOPIC:SUBSCRIBERCOUNT]");
+            template = ReplaceTokenSynonym(template, "[TOPICSUBJECT]", "[FORUMTOPIC:SUBJECT]");
+            template = ReplaceTokenSynonym(template, "[REPLYCOUNT]", "[FORUMTOPIC:REPLYCOUNT]");
+            template = ReplaceTokenSynonym(template, "[VIEWCOUNT]", "[FORUMTOPIC:VIEWCOUNT]");
+            template = ReplaceTokenSynonym(template, "[TOPICURL]", "[FORUMTOPIC:URL]");
+
+            var tokenReplacer = new DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer(portalSettings, forumUser, topic)
+            {
+                AccessingUser = forumUser.UserInfo
+            };
+
+            template = ReplaceLegacyTokenWithFormatString(template, tokenReplacer, portalSettings, language, "[POSTICON]", "[FORUMTOPIC:POSTICON", "[POSTICON]");
+            template = ReplaceLegacyTokenWithFormatString(template, tokenReplacer, portalSettings, language, "[POSTRATINGDISPLAY]", "[FORUMTOPIC:RATING", "[POSTRATING]");
+            template = ReplaceLegacyTokenWithFormatString(template, tokenReplacer, portalSettings, language, "[STATUS]", "[FORUMTOPIC:STATUS", "[TOPICSTATUS]");
+            template = ReplaceLegacyTokenWithFormatString(template, tokenReplacer, portalSettings, language, "[STATUS]", "[FORUMTOPIC:STATUS", "[TOPICSTATUS]");
+            template = ReplaceLegacyTokenWithFormatString(template, tokenReplacer, portalSettings, language, "[NEXTTOPIC]", "[FORUMTOPIC:NEXTTOPICLINK", "[NEXTTOPICLINK]");
+            template = ReplaceLegacyTokenWithFormatString(template, tokenReplacer, portalSettings, language, "[PREVTOPIC]", "[FORUMTOPIC:PREVIOUSTOPICLINK", "[PREVTOPICLINK]");
+            template = ReplaceLegacyTokenWithFormatString(template, tokenReplacer, portalSettings, language, "[STARTEDBY]", "[FORUMTOPIC:AUTHORDISPLAYNAMELINK", "[TOPICAUTHORDISPLAYNAMELINK]", "[FORUMTOPIC:AUTHORDISPLAYNAME]");
+            template = ReplaceLegacyTokenWithFormatString(template, tokenReplacer, portalSettings, language, "[LASTPOSTDISPLAYNAME]", "[FORUMTOPIC:LASTPOSTAUTHORDISPLAYNAMELINK", "[TOPICLASTPOSTAUTHORDISPLAYNAMELINK]", "[FORUMTOPIC:LASTPOSTAUTHORDISPLAYNAME]");
+            template = ReplaceLegacyTokenWithFormatString(template, tokenReplacer, portalSettings, language, "[AF:LABEL:TopicAuthor]", "[FORUMTOPIC:AUTHORDISPLAYNAMELINK", "[TOPICAUTHORDISPLAYNAMELINK]", "[FORUMTOPIC:AUTHORDISPLAYNAME]");
+            template = ReplaceLegacyTokenWithFormatString(template, tokenReplacer, portalSettings, language, "[AF:LABEL:LastPostAuthor]", "[FORUMTOPIC:LASTPOSTAUTHORDISPLAYNAMELINK", "[TOPICLASTPOSTAUTHORDISPLAYNAMELINK]", "[FORUMTOPIC:LASTPOSTAUTHORDISPLAYNAME]");
+
+            return template;
+        }
+
+        internal static StringBuilder MapLegacyPostTokenSynonyms(StringBuilder template, DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo forumUser, DotNetNuke.Modules.ActiveForums.Entities.IPostInfo post, DotNetNuke.Entities.Portals.PortalSettings portalSettings, string language)
+        {
+            template = ReplaceTokenSynonym(template, "[POSTID]", "[FORUMPOST:POSTID]");
+            template = ReplaceTokenSynonym(template, "[POSTDATE]", "[FORUMPOST:DATECREATED]");
+            template = ReplaceTokenSynonym(template, "[MODEDITDATE]", "[FORUMPOST:MODEDITDATE]");
+            template = ReplaceTokenSynonym(template, "[MODIPADDRESS]", "[FORUMPOST:MODIPADDRESS]");
+            template = ReplaceTokenSynonym(template, "[REPLYID]", "[FORUMPOST:POSTID]");
+            template = ReplaceTokenSynonym(template, "[REPLYID]", "[FORUMPOST:POSTID]");
+            template = ReplaceTokenSynonym(template, "[POSTICONCSS]", "[FORUMPOST:POSTICONCSS]");
+
+            var tokenReplacer = new DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer(portalSettings, forumUser, post)
+            {
+                AccessingUser = forumUser.UserInfo
+            };
+
+            template = ReplaceLegacyTokenWithFormatString(template, tokenReplacer, portalSettings, language, "[POSTICON]", "[FORUMPOST:POSTICON", "[POSTICON]");
+
+            return template;
+        }
+
+        private static StringBuilder ReplaceLegacyTokenWithFormatString(StringBuilder template, TokenReplacer tokenReplacer, DotNetNuke.Entities.Portals.PortalSettings portalSettings, string language, string oldTokenName, string newTokenNamePrefix, string formatStringResourceKey, string replaceWithIfEmpty = "")
+        {
+            string formatString = GetTokenFormatString(formatStringResourceKey, portalSettings, language);
+            formatString = DotNetNuke.Modules.ActiveForums.Services.Tokens.ResourceStringTokenReplacer.ReplaceResourceTokens(formatString);
+            if (tokenReplacer.ContainsTokens(formatString))
+            {
+                formatString = tokenReplacer.ReplaceTokens(formatString);
+            }
+
+            return ReplaceTokenSynonym(template, oldTokenName, $"{newTokenNamePrefix}|{formatString}{(!string.IsNullOrEmpty(replaceWithIfEmpty) ? string.Concat("|", replaceWithIfEmpty) : string.Empty)}]");
+        }
+
+        private static StringBuilder ReplaceTokenSynonymPrefix(StringBuilder template, string oldTokenNamePrefix, string newTokenNamePrefix)
+        {
+            return ReplaceTokenSynonym(template, oldTokenNamePrefix, newTokenNamePrefix);
+        }
+
+        private static StringBuilder ReplaceTokenSynonym(StringBuilder template, string fromToken, string toToken)
+        {
+            if (template.ToString().Contains(fromToken))
+            {
+                var log = new LogInfo { LogTypeKey = Abstractions.Logging.EventLogType.ADMIN_ALERT.ToString() };
+                log.LogProperties.Add(new LogDetailInfo("Module", Globals.ModuleFriendlyName));
+                var message = string.Format(Utilities.GetSharedResource("[RESX:ReplaceObsoleteToken]"), fromToken, toToken);
+                log.AddProperty("Message", message);
+                LogController.Instance.AddLog(log);
+                return template.Replace(fromToken, toToken);
+            }
+
+            return template;
+        }
+
+        private static StringBuilder RemoveObsoleteToken(StringBuilder template, string token)
+        {
+            if (template.ToString().Contains(token))
+            {
+                var log = new LogInfo { LogTypeKey = Abstractions.Logging.EventLogType.ADMIN_ALERT.ToString() };
+                log.LogProperties.Add(new LogDetailInfo("Module", Globals.ModuleFriendlyName));
+                var message = string.Format(Utilities.GetSharedResource("[RESX:RemoveObsoleteToken]"), token);
+                log.AddProperty("Message", message);
+                LogController.Instance.AddLog(log);
+                return template.Replace(token, string.Empty);
+            }
+
+            return template;
+        }
+
+        private static StringBuilder RemoveObsoleteTokenByPrefix(StringBuilder template, string tokenPrefix)
+        {
+            if (template.ToString().Contains(tokenPrefix))
+            {
+                var log = new LogInfo { LogTypeKey = Abstractions.Logging.EventLogType.ADMIN_ALERT.ToString() };
+                log.LogProperties.Add(new LogDetailInfo("Module", Globals.ModuleFriendlyName));
+                var message = string.Format(Utilities.GetSharedResource("[RESX:RemoveObsoletePrefixedToken]"), tokenPrefix);
+                log.AddProperty("Message", message);
+                LogController.Instance.AddLog(log);
+                return RemovePrefixedToken(template, tokenPrefix);
+            }
+
+            return template;
+        }
+
+        internal static StringBuilder RemovePrefixedToken(StringBuilder template, string tokenPrefix)
+        {
+            // remove initial [ if passed in with tokenPrefix
+            if (tokenPrefix.StartsWith("["))
+            {
+                tokenPrefix = tokenPrefix.Remove(0, 1);
+            }
+
+            // matches [token [embedded token] [embedded token].... ] to remove entire string
+            string pattern = $@"\[{tokenPrefix}(?>\[(?<c>)|[^\[\]]+|\](?<-c>))*(?(c)(?!))\]";
+            return new StringBuilder(new Regex(pattern).Replace(template.ToString(), string.Empty));
+
+            ////////if (tokenPrefix.Substring(0, 1) != "[")
+            ////////{
+            ////////    tokenPrefix = "[" + tokenPrefix;
+            ////////}
+            ////////if (template.ToString().Contains(tokenPrefix))
+            ////////{
+            ////////    int inStart = template.ToString().IndexOf(tokenPrefix, 0);
+            ////////    int inEnd = template.ToString().IndexOf("]", inStart - 1);
+            ////////    template.Remove(inStart, (inEnd - inStart) + 1);
+            ////////}
+            return template;
+        }
+
+        private static string GetTokenFormatString(string key, DotNetNuke.Entities.Portals.PortalSettings portalSettings, string language = "en-US")
+        {
+            string formatString = Utilities.LocalizeString(key, Globals.LegacyTokenResourceFile, (DotNetNuke.Entities.Portals.PortalSettings)portalSettings, language);
+            return formatString;
+        }
+
+        private static StringBuilder ReplaceBody(StringBuilder template,
+            DotNetNuke.Modules.ActiveForums.Entities.ContentInfo content,
+            SettingsInfo mainSettings,
+            Uri uri)
+        {
+            if (template.ToString().Contains("[BODY]"))
+            {
+                string sBody = content?.Body;
+                if (string.IsNullOrEmpty(content?.Body))
+                {
+                    sBody = " <br />";
+                }
+                else
+                {
+                    sBody = Utilities.ManageImagePath(HttpUtility.HtmlDecode(content?.Body), uri);
+
+                    sBody = sBody.Replace("[", "&#91;").Replace("]", "&#93;");
+                    if (sBody.ToUpper().Contains("&#91;CODE&#93;"))
+                    {
+                        sBody = Regex.Replace(sBody, "(&#91;CODE&#93;)", "[CODE]", RegexOptions.IgnoreCase);
+                        sBody = Regex.Replace(sBody, "(&#91;\\/CODE&#93;)", "[/CODE]", RegexOptions.IgnoreCase);
+                    }
+
+                    // sBody = sBody.Replace("&lt;CODE&gt;", "<CODE>")
+                    if (Regex.IsMatch(sBody, "\\[CODE([^>]*)\\]", RegexOptions.IgnoreCase))
+                    {
+                        var objCode = new CodeParser();
+                        sBody = CodeParser.ParseCode(HttpUtility.HtmlDecode(sBody));
+                    }
+
+                    sBody = Utilities.StripExecCode(sBody);
+                    if (mainSettings.AutoLinkEnabled)
+                    {
+                        sBody = Utilities.AutoLinks(sBody, uri.Host);
+                    }
+
+                    if (sBody.Contains("<%@"))
+                    {
+                        sBody = sBody.Replace("<%@ ", "&lt;&#37;@ ");
+                    }
+
+                    if (content.Body.ToLowerInvariant().Contains("runat"))
+                    {
+                        sBody = Regex.Replace(sBody, "runat", "&#114;&#117;nat", RegexOptions.IgnoreCase);
+                    }
+                }
+
+                template.Replace("[BODY]", sBody);
+            }
+
+            return template;
+        }
+
+        private static string GetTopicTitle(string body)
+        {
+            if (!string.IsNullOrEmpty(body))
+            {
+
+                body = HttpUtility.HtmlDecode(body);
+                body = body.Replace("<br>", System.Environment.NewLine);
+                body = Utilities.StripHTMLTag(body);
+                body = body.Length > 500 ? body.Substring(0, 500) + "..." : body;
+                body = body.Replace("\"", "'");
+                body = body.Replace("?", string.Empty);
+                body = body.Replace("+", string.Empty);
+                body = body.Replace("%", string.Empty);
+                body = body.Replace("#", string.Empty);
+                body = body.Replace("@", string.Empty);
+                return body.Trim();
+            }
+
+            return string.Empty;
+        }
+
+
+        internal string ReplaceEmbeddedTokens(string source)
+        {
+            const string pattern = @"(?<token>(?:(?<text>\[\])|\[(?:(?<object>[^{}\]\[:]+):(?<property>[^\]\[\|]+))(?:\|(?:(?<format>[^\]\[]+)\|(?<ifEmpty>[^\]\[]+))|\|(?:(?<format>[^\|\]\[]+)))?\])|(?<text>\[[^\]\[]+\])|(?<text>[^\]\[]+)\1)";
+            var matches = new Regex(pattern).Matches(source);
+            // int goodMatches = 0;
+            if (matches.Count > 0)
+            {
+                foreach (Match match in matches)
+                {
+                    if (!string.IsNullOrEmpty(match.Groups["token"]?.Value) && match.Groups["object"] != null && this.PropertySource.ContainsKey(match.Groups["object"].Value.ToLowerInvariant()))
+                    {
+                        //goodMatches++;
+                        source = source.Replace(match.Groups["token"].Value, this.ReplaceTokens(match.Groups["token"].Value));
+                    }
+                }
+
+                //if (goodMatches > 0)
+                //{
+                //    this.ReplaceEmbeddedTokens(source);
+                //}
+            }
+
+            return source;
+        }
+    }
+}

--- a/Dnn.CommunityForums/class/Globals.cs
+++ b/Dnn.CommunityForums/class/Globals.cs
@@ -151,6 +151,7 @@ namespace DotNetNuke.Modules.ActiveForums
         public const string AdminResourceFile = Globals.ModulePath + "App_LocalResources/AdminResources.resx";
         public const string SharedResourceFile = Globals.ModulePath + "App_LocalResources/SharedResources.resx";
         public const string ControlPanelResourceFile = Globals.ModulePath + "App_LocalResources/ControlPanel.ascx.resx";
+        public const string LegacyTokenResourceFile = Globals.ModulePath + "App_LocalResources/LegacyTokenResources.resx";
         public const string CacheDependencyFile = Globals.ModulePath + "cache/cachedep.resources";
 
         public const string ForumsControlsRegisterAMTag = "<%@ Register TagPrefix=\"am\" Namespace=\"DotNetNuke.Modules.ActiveForums.Controls\" Assembly=\"DotNetNuke.Modules.ActiveForums\" %>";
@@ -162,6 +163,8 @@ namespace DotNetNuke.Modules.ActiveForums
         public const int GroupCount = 10000000;
         public const int ForumCount = 10000000;
         public const int SiteCount = -1;
+
+        public const string DefaultDateFormat = "g";
 
         public const string ModerationNotificationType = "AF-ForumModeration";
         public const string ContentAlertNotificationType = "AF-ContentAlert";

--- a/Dnn.CommunityForums/class/TemplateUtils.cs
+++ b/Dnn.CommunityForums/class/TemplateUtils.cs
@@ -408,9 +408,9 @@ namespace DotNetNuke.Modules.ActiveForums
         }
         #endregion "Deprecated Methods"
 
-        private static string GetPostInfo(int ModuleId, DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo user, string imagePath, bool isMod, string ipAddress, bool isUserOnline, CurrentUserTypes currentUserType, int currentUserId, bool userPrefHideAvatar, TimeSpan timeZoneOffset)
+        internal static string GetPostInfo(int moduleId, DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo user, string imagePath, bool isMod, string ipAddress, bool isUserOnline, CurrentUserTypes currentUserType, int currentUserId, bool userPrefHideAvatar, TimeSpan timeZoneOffset)
         {
-            var sPostInfo = ParseProfileInfo(ModuleId, user, imagePath, isMod, ipAddress, currentUserType, currentUserId, userPrefHideAvatar, timeZoneOffset);
+            var sPostInfo = ParseProfileInfo(moduleId, user, imagePath, isMod, ipAddress, currentUserType, currentUserId, userPrefHideAvatar, timeZoneOffset);
             if (sPostInfo.ToLower().Contains("<br"))
             {
                 return sPostInfo;
@@ -883,6 +883,20 @@ namespace DotNetNuke.Modules.ActiveForums
                 template = template.Substring(0, intStartTag) + subTemplate + template.Substring(intEndTag + endTag.Length);
             }
 
+            return template;
+        }
+
+        public static StringBuilder ReplaceSubSection(StringBuilder template, string subTemplate, string startTag, string endTag)
+        {
+            var intStartTag = template.ToString().IndexOf(startTag, StringComparison.Ordinal);
+            var intEndTag = template.ToString().IndexOf(endTag, StringComparison.Ordinal);
+            if (intStartTag >= 0 && intEndTag > intStartTag)
+            {
+                var intSubTempStart = intStartTag + startTag.Length;
+                var intSubTempEnd = intEndTag - 1;
+                var intSubTempLength = intSubTempEnd - intSubTempStart;
+                template = new StringBuilder(template.ToString().Substring(0, intStartTag) + subTemplate + template.ToString().Substring(intEndTag + endTag.Length));
+            }
             return template;
         }
 

--- a/Dnn.CommunityForums/controls/af_post.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_post.ascx.cs
@@ -605,24 +605,8 @@ namespace DotNetNuke.Modules.ActiveForums
                             userDisplay = "none";
                         }
 
-                        DotNetNuke.Modules.ActiveForums.Entities.ContentInfo ci;
-                        if (postId == this.TopicId)
-                        {
-                            ci = ti.Content;
-                            sPostedBy = string.Format(sPostedBy, DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetDisplayName(this.PortalSettings, this.MainSettings, false, false, ti.Content.AuthorId, ti.Author.Username, ti.Author.FirstName, ti.Author.LastName, ti.Author.DisplayName), Utilities.GetSharedResource("On.Text"), Utilities.GetUserFormattedDateTime(ti.Content.DateCreated, this.PortalId, this.UserId));
-
-                        }
-                        else
-                        {
-                            var ri = new DotNetNuke.Modules.ActiveForums.Controllers.ReplyController().GetById(postId);
-                            ci = ri.Content;
-                            sPostedBy = string.Format(sPostedBy, DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetDisplayName(this.PortalSettings, this.MainSettings, false, false, ri.Content.AuthorId, ri.Author.Username, ri.Author.FirstName, ri.Author.LastName, ri.Author.DisplayName), Utilities.GetSharedResource("On.Text"), Utilities.GetUserFormattedDateTime(ti.Content.DateCreated, this.PortalId, this.UserId));
-                        }
-
-                        if (ci != null)
-                        {
-
-                        }
+                        var post = postId == this.TopicId ? ti : (DotNetNuke.Modules.ActiveForums.Entities.IPostInfo)new DotNetNuke.Modules.ActiveForums.Controllers.ReplyController().GetById(postId);
+                        sPostedBy = string.Format(sPostedBy, DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetDisplayName(this.PortalSettings, this.MainSettings, false, false, post.Author.AuthorId, post.Author.Username, post.Author.FirstName, post.Author.LastName, post.Author.DisplayName), Utilities.GetSharedResource("On.Text"), Utilities.GetUserFormattedDateTime(post.Content.DateCreated, this.PortalId, this.UserId));
                     }
 
                     if (this.allowHTML && this.editorType != EditorTypes.TEXTBOX)

--- a/Dnn.CommunityForums/controls/af_quickreply.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_quickreply.ascx.cs
@@ -257,7 +257,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 }
             }
 
-            DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo user = new DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo();
+            DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo user = new DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo(this.ForumModuleId);
             if (this.UserId > 0)
             {
                 user = this.ForumUser;


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Implements support for DNN core token replacement APIs
Centralizes token replacement within module

Another PR will actually implement and utilize the replacement logic in each "view" used by the Forums module.

## Changes made
- Implement IPropertyAccess for forum, forumuser, topic, reply, post
- Add token replacement and mapping from "legacy" tokens to new tokens and DNN standard tokens
- Adds a resource file for "legacy" token mapping that inject HTML markup (newer tokens do not inject markup) 

## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1069 