### PR TITLE
FIX: Exception loading module settings

### DIFF
--- a/Dnn.CommunityForums/ForumSettings.ascx.cs
+++ b/Dnn.CommunityForums/ForumSettings.ascx.cs
@@ -421,6 +421,19 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             }
             else
             {
+                /* this is to avoid a scenario where a site was upgraded from pre-8.1, these might still be invalid and need to be cleaned up using update logic */
+                if (this.ForumConfig.Contains("modmove") ||
+                    this.ForumConfig.Contains("moddelete") ||
+                    this.ForumConfig.Contains("modedit") ||
+                    this.ForumConfig.Contains("modapprove") ||
+                    this.ForumConfig.Contains("moduser") ||
+                    this.ForumConfig.Contains("modpin") ||
+                    this.ForumConfig.Contains("modlock"))
+                {
+                    DotNetNuke.Modules.ActiveForums.Helpers.UpgradeModuleSettings.UpgradeSocialGroupForumConfigModuleSettings_080100();
+                    DotNetNuke.Modules.ActiveForums.Helpers.UpgradeModuleSettings.UpgradeSocialGroupForumConfigModuleSettings_080200();
+                }
+
                 xDoc.LoadXml(this.ForumConfig);
             }
 


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Upgrade code included in #1023 didn't completely cleanup old module setting "ForumConfig", which is used for Forums security metadata when used for social groups. This causes an exception when accessing module settings. 

## Changes made
- Updated upgrade code to remove old settings
- Detect anomalies and re-run upgrade code (this should only affect anyone who built 8.2 from this repo as a pre-released version (@Timo-Breumelhof ) and upgraded an existing site but leaving it in just in case).

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1078