### PR TITLE
ENH: Enable move topic to hidden forum

### DIFF
--- a/Dnn.CommunityForums/Controllers/ForumController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumController.cs
@@ -174,14 +174,14 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
         public static string GetForumsHtmlOption(int moduleId, User currentUser)
         {
             var user = new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(moduleId).GetByUserId(DotNetNuke.Entities.Portals.PortalController.Instance.GetCurrentPortalSettings().PortalId, currentUser.UserId);
-            return GetForumsHtmlOption(moduleId, user);
+            return GetForumsHtmlOption(moduleId, currentUser: user, includeHiddenForums: true);
         }
 
-        internal static string GetForumsHtmlOption(int moduleId, DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo currentUser)
+        internal static string GetForumsHtmlOption(int moduleId, DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo currentUser, bool includeHiddenForums)
         {
             var sb = new StringBuilder();
             int index = 1;
-            var forums = new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().GetForums(moduleId).Where(f => !f.Hidden && (f.ForumGroup != null) && !(f.ForumGroup.Hidden) && (currentUser.IsSuperUser || DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(f.Security?.View, currentUser.UserRoles)));
+            var forums = new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().GetForums(moduleId).Where(f => (includeHiddenForums || !f.Hidden) && (f.ForumGroup != null) && (includeHiddenForums || !f.ForumGroup.Hidden) && (currentUser.IsSuperUser || DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(f.Security?.View, currentUser.UserRoles)));
             DotNetNuke.Modules.ActiveForums.Controllers.ForumController.IterateForumsList(forums.ToList(), currentUser, fi =>
                 {
                     sb.AppendFormat("<option value=\"{0}\">{1}</option>", "-1", fi.GroupName);
@@ -196,7 +196,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                 {
                     sb.AppendFormat("<option value=\"{0}\">----{1}</option>", fi.ForumID.ToString(), fi.ForumName);
                     index += 1;
-                }
+                },
+                includeHiddenForums
                 );
             return sb.ToString();
         }
@@ -371,10 +372,11 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
         internal static void IterateForumsList(System.Collections.Generic.List<DotNetNuke.Modules.ActiveForums.Entities.ForumInfo> forums, DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo forumUserInfo,
             Action<DotNetNuke.Modules.ActiveForums.Entities.ForumInfo> groupAction,
             Action<DotNetNuke.Modules.ActiveForums.Entities.ForumInfo> forumAction,
-            Action<DotNetNuke.Modules.ActiveForums.Entities.ForumInfo> subForumAction)
+            Action<DotNetNuke.Modules.ActiveForums.Entities.ForumInfo> subForumAction,
+            bool includeHiddenForums)
         {
             string tmpGroupKey = string.Empty;
-            foreach (DotNetNuke.Modules.ActiveForums.Entities.ForumInfo fi in forums.Where(f => !f.Hidden && f.ForumGroup != null && !f.ForumGroup.Hidden && (forumUserInfo.IsSuperUser || DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(f.Security?.View, forumUserInfo.UserRoles))))
+            foreach (DotNetNuke.Modules.ActiveForums.Entities.ForumInfo fi in forums.Where(f => (includeHiddenForums || !f.Hidden) && f.ForumGroup != null && (includeHiddenForums || !f.ForumGroup.Hidden) && (forumUserInfo.IsSuperUser || DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(f.Security?.View, forumUserInfo.UserRoles))))
             {
                 string groupKey = $"{fi.GroupName}{fi.ForumGroupId}";
                 if (tmpGroupKey != groupKey)

--- a/Dnn.CommunityForums/Services/Controllers/ForumController.cs
+++ b/Dnn.CommunityForums/Services/Controllers/ForumController.cs
@@ -114,7 +114,7 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Controllers
         public HttpResponseMessage ListForHtml(ForumDto dto)
         {
             var user = new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ForumModuleId).GetByUserId(this.ActiveModule.PortalID, this.UserInfo.UserID);
-            return this.Request.CreateResponse(HttpStatusCode.OK, DotNetNuke.Modules.ActiveForums.Controllers.ForumController.GetForumsHtmlOption(this.ForumModuleId, user));
+            return this.Request.CreateResponse(HttpStatusCode.OK, DotNetNuke.Modules.ActiveForums.Controllers.ForumController.GetForumsHtmlOption(this.ForumModuleId, user, includeHiddenForums: true));
         }
     }
 }

--- a/Dnn.CommunityForums/class/ForumController.cs
+++ b/Dnn.CommunityForums/class/ForumController.cs
@@ -24,6 +24,7 @@ namespace DotNetNuke.Modules.ActiveForums
     using System.Data;
     using System.IO;
     using System.Linq;
+    using System.Net;
     using System.Reflection;
     using System.Text;
 
@@ -46,7 +47,7 @@ namespace DotNetNuke.Modules.ActiveForums
         public string GetForumsHtmlOption(int portalId, int moduleId, User currentUser)
         {
             var user = new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(moduleId).GetByUserId(portalId, currentUser.UserId);
-            return DotNetNuke.Modules.ActiveForums.Controllers.ForumController.GetForumsHtmlOption(moduleId, user);
+            return DotNetNuke.Modules.ActiveForums.Controllers.ForumController.GetForumsHtmlOption(moduleId, user, includeHiddenForums: true);
         }
 
         [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Use DotNetNuke.Modules.ActiveForums.Controllers.ForumController.Forums_Save.")]

--- a/Dnn.CommunityForums/controls/af_quickjump.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_quickjump.ascx.cs
@@ -98,7 +98,8 @@ namespace DotNetNuke.Modules.ActiveForums
                     fi.ForumName.Length > 30 ? $"{fi.ForumName.Substring(0, 27)}..." : fi.ForumName,
                     $"FORUMJUMP:{fi.ForumID}"));
                 index += 1;
-            });
+            },
+            includeHiddenForums: false);
 
             if (this.GetViewType != null)
             {

--- a/Dnn.CommunityForums/controls/af_searchadvanced.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_searchadvanced.ascx.cs
@@ -455,8 +455,8 @@ namespace DotNetNuke.Modules.ActiveForums
                 fi =>
                 {
                     this.lbForums.Items.Add(new ListItem($"--{fi.ForumName}", $"F{fi.ForumID}G{fi.ForumGroupId}") { Selected = forumsToSearch.Contains(fi.ForumID) || this.ForumId == fi.ForumID });
-                }
-                );
+                },
+                includeHiddenForums: false);
         }
 
         #endregion

--- a/Dnn.CommunityForums/controls/htmlcontrols/movetopic.ascx
+++ b/Dnn.CommunityForums/controls/htmlcontrols/movetopic.ascx
@@ -21,7 +21,7 @@
             <select id="drpForums"></select>
         </div>
         <ul class="dnnActions dnnClear">
-            <li><a href="#" onclick="amaf_moveTopic(); return false;" class="dnnPrimaryAction">[RESX:Save]</a></li>
+            <li><a href="#" onclick="amaf_moveTopic(); return false;" class="dnnPrimaryAction">[RESX:Move]</a></li>
             <li><a href="#" onclick="am.UI.CloseDiv('aftopicmove'); return false;" class="dnnSecondaryAction">
             [RESX:Cancel]</a></li>
         </ul>


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
User should be able to move a topic to a hidden forum as long as they have access to that forum.

## Changes made
- Show hidden forums in move to forum list
- Change 'Save' button to 'Move'

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install
![image](https://github.com/user-attachments/assets/e97c7b98-83d5-4d89-9dee-161f5fb4848f)

## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1089