### PR TITLE
Correct database integrity issues found during 8.2 testing against DN…

### DIFF
--- a/Dnn.CommunityForums/sql/08.02.00.SqlDataProvider
+++ b/Dnn.CommunityForums/sql/08.02.00.SqlDataProvider
@@ -28,6 +28,10 @@ GO
 IF  EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databaseOwner}[FK_{objectQualifier}activeforums_ForumTopics_Replies]') AND parent_object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_ForumTopics]'))
 ALTER TABLE {databaseOwner}[{objectQualifier}activeforums_ForumTopics] DROP CONSTRAINT [FK_{objectQualifier}activeforums_ForumTopics_Replies]
 GO
+
+UPDATE {databaseOwner}[{objectQualifier}activeforums_ForumTopics] SET [LastReplyId] = NULL WHERE [LastReplyId] = 0
+GO
+
 ALTER TABLE {databaseOwner}[{objectQualifier}activeforums_ForumTopics] WITH CHECK ADD CONSTRAINT [FK_{objectQualifier}activeforums_ForumTopics_Replies] FOREIGN KEY([LastReplyId])
 REFERENCES {databaseOwner}[{objectQualifier}activeforums_Replies] ([ReplyId])
 GO
@@ -1073,6 +1077,16 @@ IF EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'{databas
 ALTER TABLE {databaseOwner}[{objectQualifier}activeforums_UserProfiles] DROP CONSTRAINT 
 [FK_{objectQualifier}activeforums_UserProfiles_UserPortals]
 GO
+
+/* remove orphaned activeforums_UserProfiles records */
+DELETE up1 
+FROM {databaseOwner}[{objectQualifier}activeforums_UserProfiles] up1
+LEFT OUTER JOIN {databaseOwner}[{objectQualifier}UserPortals] up2 
+ON up2.PortalId = up1.PortalId
+and up2.UserId = up1.UserId
+WHERE up2.UserId IS NULL
+GO
+
 ALTER TABLE {databaseOwner}[{objectQualifier}activeforums_UserProfiles] ADD CONSTRAINT
 	[FK_{objectQualifier}activeforums_UserProfiles_UserPortals] FOREIGN KEY (UserId, PortalId) 
 	REFERENCES {databaseOwner}[{objectQualifier}UserPortals] (UserId, PortalId) 
@@ -1811,7 +1825,7 @@ ELSE
 GO
 
 /* backfill missing data */
-UPDATE ft SET MaxReplyRead = COALESCE(tt.LastReplyId,0), MaxTopicRead = COALESCE(tt.MaxTopicId,0)
+UPDATE ft SET MaxReplyRead = COALESCE(tt.LastReplyId,0), MaxTopicRead = tt.MaxTopicId
 FROM {databaseOwner}{objectQualifier}activeforums_Forums_Tracking ft
 LEFT OUTER JOIN (
 	SELECT UserId, ForumId, MAX(TopicId) AS MaxTopicId, MAX(LastReplyId) AS LastReplyId 
@@ -1820,7 +1834,7 @@ LEFT OUTER JOIN (
 	) tt
 	ON tt.UserId = ft.UserId 
     AND tt.ForumId = ft.forumId 
-
+    WHERE tt.UserId IS NOT NULL
 
 /* issue 1032 end - update forums_tracking */
 
@@ -1871,14 +1885,18 @@ BEGIN
 		SET TopicId = @NewTopicId
 		WHERE TopicId = @OldTopicId AND ReplyId in (SELECT id FROM @ReplyIds)
 		
-		SELECT @MaxReplyId = IsNull(Max(ReplyId),0),@TotalReplies = Count(ReplyId) FROM {databaseOwner}{objectQualifier}activeforums_Replies WHERE TopicId = @OldTopicId AND IsDeleted = 0 AND IsApproved = 1
+		SELECT @MaxReplyId = Max(ReplyId),@TotalReplies = Count(ReplyId) FROM {databaseOwner}{objectQualifier}activeforums_Replies WHERE TopicId = @OldTopicId AND IsDeleted = 0 AND IsApproved = 1
 		UPDATE {databaseOwner}{objectQualifier}activeforums_Topics
 			SET ReplyCount = @TotalReplies
 			WHERE TopicId = @OldTopicId
 		UPDATE {databaseOwner}{objectQualifier}activeforums_ForumTopics
 			SET LastReplyId = @MaxReplyId
+			WHERE TopicId = @OldTopicId 
+            AND @MaxReplyId <> 0
+		UPDATE {databaseOwner}{objectQualifier}activeforums_ForumTopics
+			SET LastReplyId = @MaxReplyId
 			WHERE TopicId = @OldTopicId     
-		SELECT @MaxReplyId = IsNull(Max(ReplyId),0),@TotalReplies = Count(ReplyId) FROM {databaseOwner}{objectQualifier}activeforums_Replies WHERE TopicId = @NewTopicId AND IsDeleted = 0 AND IsApproved = 1
+		SELECT @MaxReplyId = Max(ReplyId),@TotalReplies = Count(ReplyId) FROM {databaseOwner}{objectQualifier}activeforums_Replies WHERE TopicId = @NewTopicId AND IsDeleted = 0 AND IsApproved = 1
 		UPDATE {databaseOwner}{objectQualifier}activeforums_Topics
 			SET ReplyCount = @TotalReplies
 			WHERE TopicId = @NewTopicId


### PR DESCRIPTION


<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Correct database integrity issues found during 8.2 testing against DNN Community site.

## Changes made 
- `LastReplyId` in `activeforums_ForumTopics` should be NULL (not 0) in order to add constraint for foreign key relation to `activeforums_Replies`
- need to remove orphaned `activeforums_UserProfiles` (not found in core `UserPortals` table) in order to add constraint for foreign key relation from `activeforums_UserProfiles` to `UserPortals`, which will cascade user deletion from `UserPortals` to `activeforums_UserProfiles`


## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [ ] Fixes Bug
- [ ] Feature solution
- [X] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1092