### PR TITLE
TASK: Remove obsolete "hiddenstats"

### DIFF
--- a/Dnn.CommunityForums/config/templates/ForumView.ascx
+++ b/Dnn.CommunityForums/config/templates/ForumView.ascx
@@ -43,7 +43,6 @@
 										<table>
 											<tr>
 												<td rowspan="2" class="afsubject">
-													<span class="afhiddenstats">[TOTALTOPICS] [RESX:TOPICSHEADER] and [TOTALREPLIES] [RESX:REPLIESHEADER] and [FORUMSUBSCRIBERCOUNT] [RESX:SUBSCRIBERS]</span>
 													<span class="aftopictitle">[FORUMNAME]</span>
 													<span class="af-colstats_responsive">
 														<i class="fa fa-files-o fa-fw fa-grey"></i>&nbsp;[TOTALTOPICS] 
@@ -79,7 +78,6 @@
 														<tr>
 															<td rowspan="2" class="afsubject">
 															
-															<span class="afhiddenstats">[TOTALTOPICS] [RESX:TOPICS] and [TOTALREPLIES] [RESX:REPLIES] and [FORUMSUBSCRIBERCOUNT] [RESX:SUBSCRIBERS]</span>
 															<span class="aftopictitle">[FORUMICONSM][FORUMNAME]</span>
 															<span class="af-colstats_responsive">
 																<i class="fa fa-files-o fa-fw fa-grey"></i>&nbsp;[TOTALTOPICS] 

--- a/Dnn.CommunityForums/config/templates/TopicsView.ascx
+++ b/Dnn.CommunityForums/config/templates/TopicsView.ascx
@@ -39,7 +39,6 @@
 												<tr>
 													<td rowspan="2" class="afsubject">
 													
-													<span class="afhiddenstats">[TOTALTOPICS] [RESX:TOPICSHEADER] and [TOTALREPLIES] [RESX:REPLIESHEADER] and [FORUMSUBSCRIBERCOUNT] [RESX:SUBSCRIBERS]</span>
 													<span class="aftopictitle">[FORUMNAME]</span>
 													<span class="af-colstats_responsive">
 														<i class="fa fa-files-o fa-fw fa-grey"></i>&nbsp;[TOTALTOPICS] 
@@ -95,7 +94,6 @@
 										<td rowspan="2" class="afsubject" title="[BODYTITLE]">
 										
 										
-										<span class="afhiddenstats">[REPLIES] [RESX:REPLIESHEADER] and [VIEWS] [RESX:Views] and [TOPICSUBSCRIBERCOUNT] [RESX:SUBSCRIBERS]</span>
 										<span class="aftopictitle"><i class="fa fa-file-o fa-fw fa-grey"></i>&nbsp;[SUBJECTLINK][AF:ICONLINK:LASTREAD]</span> 
 										<span class="aftopicstarted">[RESX:StartedHeader] <i class="fa fa-user fa-fw fa-blue"></i>&nbsp;[STARTEDBY][AF:UI:MINIPAGER]</span>
 										
@@ -166,7 +164,6 @@
 										<td  rowspan="2" style="padding-top:5px; padding-right:7px;" class="[ROWCSS] af-posticon">[POSTICON]</td>
 											<td rowspan="2" class="afsubject" title="[BODYTITLE]">
 											
-											<span class="afhiddenstats">[REPLIES] [RESX:REPLIESHEADER] and [VIEWS] [RESX:Views] and [TOPICSUBSCRIBERCOUNT] [RESX:SUBSCRIBERS]</span>
 											<span class="aftopictitle">[SUBJECTLINK][AF:ICONLINK:LASTREAD][ICONPIN][ICONLOCK]</span> 
 											<span class="af-colstats_responsive">
 												<i class="fa fa-eye fa-fw fa-grey"></i>&nbsp;[VIEWS] 

--- a/Dnn.CommunityForums/module.css
+++ b/Dnn.CommunityForums/module.css
@@ -458,13 +458,7 @@ td.afprop-label {
 /* 26 -> */
 
 
-/* 27 Remove font sizes + styling -> */
-.afhiddenstats,
-.afhiddentime {
-	display: none;
-}
-
-/* /27 */
+/* 27 Remove font sizes + styling -> -- now completely removed */
 
 
 /* 28 ->  */
@@ -1364,12 +1358,6 @@ only screen and (max-device-width: 768px) {
 		float: left;
 	}
 
-	/*.afhiddenstats,*/
-	.afhiddentime {
-		display: inline-block;
-	}
-
-}
 
 @media only screen and (max-width: 490px),
 only screen and (max-device-width: 490px) {

--- a/Dnn.CommunityForums/themes/_legacy-module.css
+++ b/Dnn.CommunityForums/themes/_legacy-module.css
@@ -521,23 +521,7 @@
 
 
 
-/* 27 Remove font sizes + styling */
-	.afhiddenstats,
-	.afhiddentime {
-		font-size: 15px;
-		display: none;
-		font-weight: 400;
-		color: #888;
-		text-transform: lowercase;
-	}
-	.afhiddentime {
-		display: block;
-		float: right;
-		font-size: 11px;
-		color: #bbb;
-	}
-
-/* /27 */
+/* 27 Remove font sizes + styling -> now removed*/
 
 
 


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Prior versions had duplicated UI elements for topic / view / reply counts in forum and topics views. With theme/CSS improvements, these are no longer needed.

## Changes made
- remove "hidden stats" HTML elements
- remove CSS classes

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->

## PR Template Checklist

- [ ] Fixes Bug
- [ ] Feature solution
- [X] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #461 