### PR TITLE
ENH: Token replacement for email template

### DIFF
--- a/Dnn.CommunityForums/App_LocalResources/LegacyTokenResources.resx
+++ b/Dnn.CommunityForums/App_LocalResources/LegacyTokenResources.resx
@@ -154,10 +154,10 @@
     <value>&lt;a href="{0}" class="dcf-forums-link"&gt;[RESX:ForumMain]&lt;/a&gt;</value>
   </data>
   <data name="[ICONLINK-LASTREAD].Text" xml:space="preserve">
-    <value>&lt;a href="{0}" rel="nofollow"&gt;&lt;img src="[FORUM:THEMELOCATION]/images/miniarrow_down.png" style="vertical-align:middle;" alt="[RESX:JumpToLastRead]" border="0" class="afminiarrow" /&gt;&lt;/a&gt;</value>
+    <value>&lt;a href="{0}" rel="nofollow"&gt;&lt;img src="[FORUM:THEMELOCATION]images/miniarrow_down.png" style="vertical-align:middle;" alt="[RESX:JumpToLastRead]" border="0" class="afminiarrow" /&gt;&lt;/a&gt;</value>
   </data>
   <data name="[ICONLINK-LASTREPLY].Text" xml:space="preserve">
-    <value>&lt;a href="{0}" rel="nofollow"&gt;&lt;img src="[FORUM:THEMELOCATION]/images/miniarrow_right.png" style="vertical-align:middle;" alt="[RESX:JumpToLastReply]" border="0" class="afminiarrow" /&gt;&lt;/a&gt;</value>
+    <value>&lt;a href="{0}" rel="nofollow"&gt;&lt;img src="[FORUM:THEMELOCATION]images/miniarrow_right.png" style="vertical-align:middle;" alt="[RESX:JumpToLastReply]" border="0" class="afminiarrow" /&gt;&lt;/a&gt;</value>
   </data>
   <data name="[ICONLOCK]-HideIcon.Text" xml:space="preserve">
     <value>&amp;nbsp;&amp;nbsp;&lt;i id="af-topicsview-lock-{0}" class="fa fa-fw fa-red"&gt;&lt;/i&gt;</value>
@@ -392,5 +392,20 @@
   </data>
   <data name="[AF:TB:Unresolved].Text" xml:space="preserve">
     <value>&lt;a href="{0}"&gt;&lt;i class="fa fa-question fa-fw fa-blue"&gt;&lt;/i&gt;&lt;span class="dcf-link-text"&gt;[RESX:Unresolved]&lt;/span&gt;&lt;/a&gt;</value>
+  </data>
+  <data name="[LINK].Text" xml:space="preserve">
+    <value>&lt;a href="{0}"&gt;{0}  target="_blank"&lt;/a&gt;</value>
+  </data>
+  <data name="[AUTHORPMLINK].Text" xml:space="preserve">
+    <value>&lt;img class='ComposeMessage' data-recipient='{{ "id": "user-{0}", "name": "[FORUMAUTHOR:DISPLAYNAMEFORJSON]" }}' src='[FORUM:THEMELOCATION]images/icon_pm.png' alt="[RESX:SendPM]" title="[RESX:SendPM]" border="0" /&gt;</value>
+  </data>
+  <data name="[EDITAUTHORLINK].Text" xml:space="preserve">
+    <value>&lt;button class='af-button af-button-edituser' data-id="{0}" data-name="[FORUMAUTHOR:DISPLAYNAMEFORJSON]"&gt;[RESX:Edit]&lt;/button&gt;</value>
+  </data>
+  <data name="[EDITUSERLINK].Text" xml:space="preserve">
+    <value>&lt;button class='af-button af-button-edituser' data-id="{0}" data-name="[FORUMUSER:DISPLAYNAMEFORJSON]"&gt;[RESX:Edit]&lt;/button&gt;</value>
+  </data>
+  <data name="[USERPMLINK].Text" xml:space="preserve">
+    <value>&lt;img class='ComposeMessage' data-recipient='{{ "id": "user-{0}", "name": "[FORUMUSER:DISPLAYNAMEFORJSON]" }}' src='[FORUM:THEMELOCATION]images/icon_pm.png' alt="[RESX:SendPM]" title="[RESX:SendPM]" border="0" /&gt;</value>
   </data>
 </root>

--- a/Dnn.CommunityForums/Controllers/ReplyController.cs
+++ b/Dnn.CommunityForums/Controllers/ReplyController.cs
@@ -178,7 +178,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
 
             if (forum.ModApproveTemplateId > 0 & reply.Author.AuthorId > 0)
             {
-                DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(forum.ModApproveTemplateId, portalId, moduleId, tabId, forumId, topicId, replyId, string.Empty, reply.Author);
+                DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(forum.ModApproveTemplateId, portalId, moduleId, tabId, forumId, topicId, replyId, reply.Author);
             }
 
             DotNetNuke.Modules.ActiveForums.Controllers.ReplyController.QueueApprovedReplyAfterAction(portalId, tabId, moduleId, forum.ForumGroupId, forumId, topicId, replyId, reply.Content.AuthorId);

--- a/Dnn.CommunityForums/Controllers/TopicController.cs
+++ b/Dnn.CommunityForums/Controllers/TopicController.cs
@@ -142,7 +142,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
 
             if (ti.Forum.ModApproveTemplateId > 0 & ti.Author.AuthorId > 0)
             {
-                DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(ti.Forum.ModApproveTemplateId, ti.PortalId, ti.ModuleId, ti.Forum.TabId, ti.ForumId, topicId, 0, string.Empty, ti.Author);
+                DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(ti.Forum.ModApproveTemplateId, ti.PortalId, ti.ModuleId, ti.Forum.TabId, ti.ForumId, topicId, 0, ti.Author);
             }
 
             DotNetNuke.Modules.ActiveForums.Controllers.TopicController.QueueApprovedTopicAfterAction(ti.PortalId, ti.Forum.TabId, ti.Forum.ModuleId, ti.Forum.ForumGroupId, ti.ForumId, topicId, -1, ti.Content.AuthorId);
@@ -182,7 +182,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
 
             if (oldForum.ModMoveTemplateId > 0 & ti?.Author?.AuthorId > 0)
             {
-                DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(oldForum.ModMoveTemplateId, ti.PortalId, ti.ModuleId, ti.Forum.TabId, forumId: ti.Forum.ForumID, ti.TopicId, -1, string.Empty, ti.Author);
+                DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(oldForum.ModMoveTemplateId, ti.PortalId, ti.ModuleId, ti.Forum.TabId, forumId: ti.Forum.ForumID, topicId: ti.TopicId, replyId: -1, author: ti.Author);
             }
 
             new DotNetNuke.Modules.ActiveForums.Controllers.ProcessQueueController().Add(ProcessType.UpdateForumLastUpdated, ti.PortalId, tabId: -1, moduleId: ti.ModuleId, forumGroupId: oldForum.ForumGroupId, forumId: oldForum.ForumID, topicId: topicId, replyId: -1, authorId: ti.Content.AuthorId, requestUrl: null);

--- a/Dnn.CommunityForums/CustomControls/UserControls/ForumView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/ForumView.cs
@@ -150,8 +150,12 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
 
                 StringBuilder stringBuilder = new StringBuilder(sTemplate);
+#region "Backward compatilbility -- remove in v10.00.00"
                 stringBuilder = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.RemoveObsoleteTokens(stringBuilder);
+                stringBuilder = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.MapLegacyUserTokenSynonyms(stringBuilder, this.PortalSettings, this.MainSettings, this.ForumUser.UserInfo?.Profile?.PreferredLocale);
                 stringBuilder = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.MapLegacyForumTokenSynonyms(stringBuilder, this.PortalSettings, this.ForumUser.UserInfo?.Profile?.PreferredLocale);
+#endregion "Backward compatilbility -- remove in v10.00.00"
+
                 stringBuilder.Replace("[JUMPTO]", "<asp:placeholder id=\"plhQuickJump\" runat=\"server\" />");
                 stringBuilder.Replace("[STATISTICS]", "<am:Stats id=\"amStats\" MID=\"" + this.ModuleId + "\" PID=\"" + this.PortalId.ToString() + "\" runat=\"server\" />");
                 stringBuilder.Replace("[WHOSONLINE]", this.MainSettings.UsersOnlineEnabled ? "<asp:placeholder id=\"plhUsersOnline\" runat=\"server\" />" : string.Empty);
@@ -179,7 +183,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     string sForumTemp = TemplateUtils.GetTemplateSection(sTemplate, "[FORUMS]", "[/FORUMS]");
                     string tmpGroup = string.Empty;
 
-                    #region "backward compatibilty - remove when removing ForumTable property"
+#region "backward compatibilty - remove when removing ForumTable property"
 #pragma warning disable CS0618
                     /* this is for backward compatibility -- remove when removing ForumTable property in 10.00.00 */
                     if (this.ForumTable != null)
@@ -193,7 +197,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                             this.Forums.Add(new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().GetById(Utilities.SafeConvertInt(dr["ForumId"]), this.ForumModuleId));
                         }
                     }
-                    #endregion
+#endregion "backward compatibilty - remove when removing ForumTable property"
 
                     if (this.Forums == null)
                     {

--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
@@ -934,8 +934,14 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             // Process topic and reply templates.
             var sTopicTemplate = TemplateUtils.GetTemplateSection(sOutput, "[TOPIC]", "[/TOPIC]");
             var sReplyTemplate = TemplateUtils.GetTemplateSection(sOutput, "[REPLIES]", "[/REPLIES]");
+
+#region "Backward compatilbility -- remove in v10.00.00"
+            sTopicTemplate = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.MapLegacyUserTokenSynonyms(new StringBuilder(sTopicTemplate), this.PortalSettings, this.MainSettings, this.ForumUser.UserInfo?.Profile?.PreferredLocale).ToString();
+            sTopicTemplate = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.MapLegacyAuthorTokenSynonyms(new StringBuilder(sTopicTemplate), this.PortalSettings, this.MainSettings, this.ForumUser.UserInfo?.Profile?.PreferredLocale).ToString();
             sTopicTemplate = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.MapLegacyTopicTokenSynonyms(new StringBuilder(sTopicTemplate), this.PortalSettings, this.ForumUser.UserInfo?.Profile?.PreferredLocale).ToString();
             sReplyTemplate = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.MapLegacyPostTokenSynonyms(new StringBuilder(sReplyTemplate), this.PortalSettings, this.ForumUser.UserInfo?.Profile?.PreferredLocale).ToString();
+
+#endregion "Backward compatilbility -- remove in v10.00.00"
 
             var sTemp = string.Empty;
             var i = 0;
@@ -1122,7 +1128,6 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 sbOutput = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.ReplacePostTokens(sbOutput, this.topic, this.PortalSettings, this.MainSettings, new Services.URLNavigator().NavigationManager(), this.ForumUser, HttpContext.Current.Request.Url.ToString());
             }
 
-            sbOutput = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.ReplaceUserTokens(sbOutput, this.PortalSettings, this.MainSettings, author.ForumUser, this.ForumUser, this.ForumModuleId);
             sOutput = sbOutput.ToString();
 
             // Legacy attachment functionality, uses "attachid"

--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicsView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicsView.cs
@@ -65,7 +65,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
         public string MetaKeywords { get; set; } = string.Empty;
 
         public string ForumUrl { get; set; } = string.Empty;
-     
+
         #region Controls
         protected af_quickjump ctlForumJump = new af_quickjump();
 
@@ -138,6 +138,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 }
 
                 topicsTemplate = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.RemoveObsoleteTokens(new StringBuilder(topicsTemplate)).ToString();
+                topicsTemplate = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.MapLegacyUserTokenSynonyms(new StringBuilder(topicsTemplate), this.PortalSettings, this.MainSettings, this.ForumUser.UserInfo?.Profile?.PreferredLocale).ToString();
+                topicsTemplate = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.MapLegacyAuthorTokenSynonyms(new StringBuilder(topicsTemplate), this.PortalSettings, this.MainSettings, this.ForumUser.UserInfo?.Profile?.PreferredLocale).ToString();
                 topicsTemplate = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.MapLegacyForumTokenSynonyms(new StringBuilder(topicsTemplate), this.PortalSettings, this.ForumUser.UserInfo?.Profile?.PreferredLocale).ToString();
                 topicsTemplate = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.MapLegacyTopicTokenSynonyms(new StringBuilder(topicsTemplate), this.PortalSettings, this.ForumUser.UserInfo?.Profile?.PreferredLocale).ToString();
                 topicsTemplate = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.MapLegacyTopicActionTokenSynonyms(new StringBuilder(topicsTemplate), this.PortalSettings, this.ForumUser.UserInfo?.Profile?.PreferredLocale, this.useListActions).ToString();
@@ -634,7 +636,6 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 }
 
                 stringBuilder = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.ReplaceTopicTokens(stringBuilder, topicInfo, this.PortalSettings, this.MainSettings, new Services.URLNavigator().NavigationManager(), this.ForumUser, HttpContext.Current.Request.Url.ToString());
-                stringBuilder = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.ReplaceUserTokens(stringBuilder, this.PortalSettings, this.MainSettings, topicInfo.Author.ForumUser, this.ForumUser, this.ForumModuleId);
                 stringBuilder.Replace("[LASTPOST]", string.Empty).Replace("[/LASTPOST]", string.Empty);
                 stringBuilder.Replace("[ROWCSS]", this.GetRowCSS(UserLastTopicRead, UserLastReplyRead, topicInfo.TopicId, topicInfo.LastReplyId, rowcount));
 

--- a/Dnn.CommunityForums/Entities/ForumGroupInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumGroupInfo.cs
@@ -504,7 +504,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                 case "forumgrouplink":
                     return PropertyAccess.FormatString(new ControlUtils().BuildUrl(
                             this.PortalSettings.PortalId,
-                            this.PortalSettings.ActiveTab.TabID,
+                            this.GetTabId(),
                             this.ModuleId,
                             this.PrefixURL,
                             string.Empty,
@@ -528,6 +528,11 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
 
             propertyNotFound = true;
             return string.Empty;
+        }
+
+        private int GetTabId()
+        {
+            return this.PortalSettings.ActiveTab.TabID == -1 || this.PortalSettings.ActiveTab.TabID == this.PortalSettings.HomeTabId ? this.TabId : this.PortalSettings.ActiveTab.TabID;
         }
     }
 }

--- a/Dnn.CommunityForums/Entities/ForumInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumInfo.cs
@@ -833,7 +833,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                 case "forumgrouplink":
                     return PropertyAccess.FormatString(new ControlUtils().BuildUrl(
                             this.PortalSettings.PortalId,
-                            this.PortalSettings.ActiveTab.TabID,
+                            this.GetTabId(),
                             this.ModuleId,
                             this.ForumGroup.PrefixURL,
                             string.Empty,
@@ -851,7 +851,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                     return PropertyAccess.FormatString(
                         new ControlUtils().BuildUrl(
                             this.PortalSettings.PortalId,
-                            this.PortalSettings.ActiveTab.TabID,
+                            this.GetTabId(),
                             this.ModuleId,
                             this.ForumGroup.PrefixURL,
                             this.PrefixURL,
@@ -867,7 +867,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                 case "parentforumlink":
                     return PropertyAccess.FormatString(new ControlUtils().BuildUrl(
                             this.PortalSettings.PortalId,
-                            this.PortalSettings.ActiveTab.TabID,
+                            this.GetTabId(),
                             this.ModuleId,
                             this.ForumGroup.PrefixURL,
                             this.ParentForumUrlPrefix,
@@ -904,7 +904,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                 case "lastpostsubject":
                     return this.LastPostID < 1
                         ? string.Empty
-                        : PropertyAccess.FormatString(DotNetNuke.Modules.ActiveForums.Controllers.ForumController.GetLastPostSubjectLinkTag(this.LastPost, length > 0 ? length : this.LastPostSubject.Length, this, this.PortalSettings.ActiveTab.TabID), format);
+                        : PropertyAccess.FormatString(DotNetNuke.Modules.ActiveForums.Controllers.ForumController.GetLastPostSubjectLinkTag(this.LastPost, length > 0 ? length : this.LastPostSubject.Length, this, this.GetTabId()), format);
                 case "lastpostdate":
                     return this.LastPostID < 1
                         ? string.Empty
@@ -988,6 +988,11 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
 
             propertyNotFound = true;
             return string.Empty;
+        }
+
+        private int GetTabId()
+        {
+            return this.PortalSettings.ActiveTab.TabID == -1 || this.PortalSettings.ActiveTab.TabID == this.PortalSettings.HomeTabId ? this.TabId : this.PortalSettings.ActiveTab.TabID;
         }
     }
 }

--- a/Dnn.CommunityForums/Entities/ForumInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumInfo.cs
@@ -18,9 +18,6 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System.Web;
-using DotNetNuke.Entities.Modules;
-
 namespace DotNetNuke.Modules.ActiveForums.Entities
 {
     using System;
@@ -31,12 +28,8 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Entities.Portals;
     using Enums;
-    using Services.Tokens;
     using DotNetNuke.Services.Log.EventLog;
-    using DotNetNuke.Entities.Modules;
-    using DotNetNuke.Entities.Portals;
     using DotNetNuke.Services.Tokens;
-    using Services;
 
 
     [TableName("activeforums_Forums")]
@@ -54,7 +47,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         private DotNetNuke.Modules.ActiveForums.SettingsInfo mainSettings;
         private PortalSettings portalSettings;
         private ModuleInfo moduleInfo;
-        private int? subscriberCount = 0;
+        private int? subscriberCount;
         private string rssLink;
         private List<PropertyInfo> properties;
         private string lastPostSubject;

--- a/Dnn.CommunityForums/Entities/ForumUserInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumUserInfo.cs
@@ -411,21 +411,11 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             switch (propertyName)
             {
                 case "avatar":
-                    return PropertyAccess.FormatString(
-                        !this.PrefBlockAvatars && !this.AvatarDisabled ? DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetAvatar(
-                            this.UserId, this.MainSettings.AvatarWidth, this.MainSettings.AvatarHeight) : string.Empty, format);
+                    return PropertyAccess.FormatString(!this.PrefBlockAvatars && !this.AvatarDisabled ? DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetAvatar(this.UserId, this.MainSettings.AvatarWidth, this.MainSettings.AvatarHeight) : string.Empty, format);
                 case "usercaption":
                     return PropertyAccess.FormatString(this.UserCaption, format);
                 case "displayname":
-                    return PropertyAccess.FormatString(
-                        DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetDisplayName(this.PortalSettings, this.MainSettings,
-                        isMod: new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(
-                            portalId: accessingUser.PortalID,
-                            userId: accessingUser.UserID).GetIsMod(this.ModuleId),
-                        isAdmin: new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(
-                            portalId: accessingUser.PortalID,
-                            userId: accessingUser.UserID).IsAdmin,
-                        this.UserId, this.Username, this.FirstName, this.LastName, this.DisplayName), format);
+                    return PropertyAccess.FormatString(DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetDisplayName(this.PortalSettings, this.MainSettings, isMod: new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(portalId: accessingUser.PortalID, userId: accessingUser.UserID).GetIsMod(this.ModuleId), isAdmin: new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(portalId: accessingUser.PortalID, userId: accessingUser.UserID).IsAdmin, this.UserId, this.Username, this.FirstName, this.LastName, this.DisplayName), format);
                 case "datecreated":
                     return Utilities.GetUserFormattedDateTime((DateTime?)this.DateCreated, formatProvider, accessingUser.Profile.PreferredTimeZone.GetUtcOffset(DateTime.UtcNow));
                 case "dateupdated":
@@ -449,45 +439,13 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                 case "rewardpoints":
                     return PropertyAccess.FormatString(this.MainSettings.EnablePoints && this.UserId > 0 ? this.RewardPoints.ToString() : string.Empty, format);
                 case "totalpoints":
-                    return PropertyAccess.FormatString(
-                        this.MainSettings.EnablePoints && this.UserId > 0 ?
-                       ((this.TopicCount * this.MainSettings.TopicPointValue) +
-                        (this.ReplyCount * this.MainSettings.ReplyPointValue) +
-                        (this.AnswerCount * this.MainSettings.AnswerPointValue) + this.RewardPoints).ToString() : string.Empty, format);
+                    return PropertyAccess.FormatString(this.MainSettings.EnablePoints && this.UserId > 0 ? ((this.TopicCount * this.MainSettings.TopicPointValue) + (this.ReplyCount * this.MainSettings.ReplyPointValue) + (this.AnswerCount * this.MainSettings.AnswerPointValue) + this.RewardPoints).ToString() : string.Empty, format);
                 case "rankdisplay":
-                    return PropertyAccess.FormatString(
-                        this.UserId > 0
-                            ? DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetUserRank(
-                                this.ModuleId,
-                                this,
-                                0)
-                            : string.Empty,
-                        format);
+                    return PropertyAccess.FormatString(this.UserId > 0 ? DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetUserRank(this.ModuleId, this, 0) : string.Empty, format);
                 case "rankname":
-                    return PropertyAccess.FormatString(
-                        this.UserId > 0
-                            ? DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetUserRank(
-                                this.ModuleId,
-                                this,
-                                1)
-                            : string.Empty,
-                        format);
+                    return PropertyAccess.FormatString(this.UserId > 0 ? DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetUserRank(this.ModuleId, this, 1) : string.Empty, format);
                 case "userprofilelink":
-                    return PropertyAccess.FormatString(
-                        DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.CanLinkToProfile(
-                            this.PortalSettings,
-                            this.MainSettings,
-                            this.ModuleId,
-                            new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(
-                                accessingUser.PortalID,
-                                accessingUser.UserID),
-                            this)
-                            ? Utilities.NavigateURL(
-                                this.PortalSettings.UserTabId,
-                                string.Empty,
-                                new[] { $"userId={this.UserId}" })
-                            : string.Empty,
-                        format);
+                    return PropertyAccess.FormatString(DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.CanLinkToProfile(this.PortalSettings, this.MainSettings, this.ModuleId, new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(accessingUser.PortalID, accessingUser.UserID), this) ? Utilities.NavigateURL(this.PortalSettings.UserTabId, string.Empty, new[] { $"userId={this.UserId}" }) : string.Empty, format);
                 case "signature":
                     var sSignature = string.Empty;
                     if (this.MainSettings.AllowSignatures != 0 && !this.PrefBlockSignatures && !this.SignatureDisabled)
@@ -512,13 +470,15 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
 
                     return PropertyAccess.FormatString(sSignature, format);
                 case "userstatus":
-                    return PropertyAccess.FormatString(this.MainSettings.UsersOnlineEnabled && this.UserId > 0 ?
-                        DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.GetTokenFormatString(this.IsUserOnline ? "[FORUMUSER-USERONLINE]" :
-                            "[FORUMUSER-USEROFFLINE]", this.PortalSettings, accessingUser.Profile.PreferredLocale) : string.Empty, format);
+                    return PropertyAccess.FormatString(this.MainSettings.UsersOnlineEnabled && this.UserId > 0 ? DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.GetTokenFormatString(this.IsUserOnline ? "[FORUMUSER-USERONLINE]" : "[FORUMUSER-USEROFFLINE]", this.PortalSettings, accessingUser.Profile.PreferredLocale) : string.Empty, format);
                 case "userstatuscss":
-                    return PropertyAccess.FormatString(this.MainSettings.UsersOnlineEnabled && this.UserId > 0 ?
-                            DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.GetTokenFormatString(this.IsUserOnline ? "[FORUMUSER-USERONLINECSS]" : "[FORUMUSER-USEROFFLINECSS]", this.PortalSettings, accessingUser.Profile.PreferredLocale) :
-                            string.Empty, format);
+                    return PropertyAccess.FormatString(this.MainSettings.UsersOnlineEnabled && this.UserId > 0 ? DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.GetTokenFormatString(this.IsUserOnline ? "[FORUMUSER-USERONLINECSS]" : "[FORUMUSER-USEROFFLINECSS]", this.PortalSettings, accessingUser.Profile.PreferredLocale) : string.Empty, format);
+                case "pmlink":
+                    return PropertyAccess.FormatString((accessingUser.IsAdmin || accessingUser.IsSuperUser) && this.UserId > 0 ? this.UserId.ToString() : string.Empty, format);
+                case "editlink":
+                    return PropertyAccess.FormatString((accessingUser.IsAdmin || accessingUser.IsSuperUser) && this.UserId > 0 ? this.UserId.ToString() : string.Empty, format);
+                case "displaynameforjson":
+                    return PropertyAccess.FormatString(Utilities.JSON.EscapeJsonString(this.DisplayName), format);
             }
 
             propertyNotFound = true;

--- a/Dnn.CommunityForums/Entities/ReplyInfo.cs
+++ b/Dnn.CommunityForums/Entities/ReplyInfo.cs
@@ -302,7 +302,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
 
                 case "subjectlink":
                 {
-                        string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, this.Forum.PortalSettings.ActiveTab.TabID, this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.Topic.TopicUrl, -1, -1, string.Empty, 1,this.ContentId, this.Forum.SocialGroupId);
+                        string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, GetTabId(), this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.Topic.TopicUrl, -1, -1, string.Empty, 1,this.ContentId, this.Forum.SocialGroupId);
                         string sPollImage = (this.Topic.TopicType == TopicTypes.Poll ? DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.GetTokenFormatString("[POLLIMAGE]", this.Forum.PortalSettings, accessingUser.Profile.PreferredLocale) : string.Empty);
                         string subject = Utilities.StripHTMLTag(HttpUtility.HtmlDecode(this.Subject)).Replace("\"", string.Empty).Replace("#", string.Empty).Replace("%", string.Empty).Replace("+", string.Empty); ;
                         string sBodyTitle = GetTopicTitle(this.Content.Body);
@@ -330,7 +330,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                                 @params.Add($"{ParamKeys.TopicId}={this.TopicId}");
                             }
 
-                            slink = "<a title=\"" + sBodyTitle + "\" href=\"" + Utilities.NavigateURL(this.Forum.PortalSettings.ActiveTab.TabID, string.Empty, @params.ToArray()) + "\">" + subject + "</a>";
+                            slink = "<a title=\"" + sBodyTitle + "\" href=\"" + Utilities.NavigateURL(GetTabId(), string.Empty, @params.ToArray()) + "\">" + subject + "</a>";
                         }
                         else
                         {
@@ -346,7 +346,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                     return PropertyAccess.FormatString(length > 0 && this.Content.Body.Length > length ? this.Content.Body.Substring(0, length) : this.Content.Body, format);
                 case "link":
                 {
-                    string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, this.Forum.PortalSettings.ActiveTab.TabID, this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.Topic.TopicUrl, -1, -1, string.Empty, 1, this.ContentId, this.Forum.SocialGroupId);
+                    string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, GetTabId(), this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.Topic.TopicUrl, -1, -1, string.Empty, 1, this.ContentId, this.Forum.SocialGroupId);
                     string subject = Utilities.StripHTMLTag(HttpUtility.HtmlDecode(this.Subject)).Replace("\"", string.Empty).Replace("#", string.Empty).Replace("%", string.Empty).Replace("+", string.Empty); ;
                     string sBodyTitle = GetTopicTitle(this.Content.Body);
                     string slink;
@@ -374,7 +374,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                             @params.Add($"{ParamKeys.ContentJumpId}={this.ReplyId}");
                         }
 
-                        slink = "<a title=\"" + sBodyTitle + "\" href=\"" + Utilities.NavigateURL(this.Forum.PortalSettings.ActiveTab.TabID, string.Empty, @params.ToArray()) + "\">" + subject + "</a>";
+                        slink = "<a title=\"" + sBodyTitle + "\" href=\"" + Utilities.NavigateURL(GetTabId(), string.Empty, @params.ToArray()) + "\">" + subject + "</a>";
                     }
                     else
                     {
@@ -489,7 +489,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                             }
 
                             return PropertyAccess.FormatString(
-                                Utilities.NavigateURL(this.Forum.PortalSettings.ActiveTab.TabID, string.Empty, editParams.ToArray()),
+                                Utilities.NavigateURL(GetTabId(), string.Empty, editParams.ToArray()),
                                 format);
                         }
 
@@ -530,7 +530,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                             }
 
                             return PropertyAccess.FormatString(
-                                Utilities.NavigateURL(this.Forum.PortalSettings.ActiveTab.TabID, string.Empty, @params.ToArray()),
+                                Utilities.NavigateURL(GetTabId(), string.Empty, @params.ToArray()),
                                 format);
                         }
                     }
@@ -570,7 +570,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                             }
 
                             return PropertyAccess.FormatString(
-                                Utilities.NavigateURL(this.Forum.PortalSettings.ActiveTab.TabID, string.Empty, @params.ToArray()),
+                                Utilities.NavigateURL(GetTabId(), string.Empty, @params.ToArray()),
                                 format);
                         }
                     }
@@ -611,7 +611,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                             }
 
                             return PropertyAccess.FormatString(
-                                Utilities.NavigateURL(this.Forum.PortalSettings.ActiveTab.TabID, string.Empty, editParams.ToArray()),
+                                Utilities.NavigateURL(GetTabId(), string.Empty, editParams.ToArray()),
                                 format);
                         }
                     }
@@ -637,7 +637,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                             };
 
                             return PropertyAccess.FormatString(
-                                Utilities.NavigateURL(this.Forum.PortalSettings.ActiveTab.TabID, string.Empty, @params.ToArray()),
+                                Utilities.NavigateURL(GetTabId(), string.Empty, @params.ToArray()),
                                 format);
                         }
                     }
@@ -687,7 +687,12 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             propertyNotFound = true;
             return string.Empty;
         }
-        
+
+        private int GetTabId()
+        {
+            return this.Forum.PortalSettings.ActiveTab.TabID == -1 || this.Forum.PortalSettings.ActiveTab.TabID == this.Forum.PortalSettings.HomeTabId ? this.Forum.TabId : this.Forum.PortalSettings.ActiveTab.TabID;
+        }
+
         private static string GetTopicTitle(string body)
         {
             if (!string.IsNullOrEmpty(body))

--- a/Dnn.CommunityForums/Entities/TopicInfo.cs
+++ b/Dnn.CommunityForums/Entities/TopicInfo.cs
@@ -543,7 +543,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
 
                 case "subjectlink":
                     {
-                        string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, this.Forum.PortalSettings.ActiveTab.TabID, this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.TopicUrl, -1, -1, string.Empty, 1, -1, this.Forum.SocialGroupId);
+                        string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, GetTabId(), this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.TopicUrl, -1, -1, string.Empty, 1, -1, this.Forum.SocialGroupId);
                         string sPollImage = (this.Topic.TopicType == TopicTypes.Poll ? DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.GetTokenFormatString("[POLLIMAGE]", this.Forum.PortalSettings, accessingUser.Profile.PreferredLocale) : string.Empty);
                         string subject = Utilities.StripHTMLTag(HttpUtility.HtmlDecode(this.Subject)).Replace("\"", string.Empty).Replace("#", string.Empty).Replace("%", string.Empty).Replace("+", string.Empty); ;
                         string sBodyTitle = GetTopicTitle(this.Content.Body);
@@ -571,7 +571,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                                 @params.Add($"{ParamKeys.TopicId}={this.TopicId}");
                             }
 
-                            slink = "<a title=\"" + sBodyTitle + "\" href=\"" + Utilities.NavigateURL(this.Forum.PortalSettings.ActiveTab.TabID, string.Empty, @params.ToArray()) + "\">" + subject + "</a>";
+                            slink = "<a title=\"" + sBodyTitle + "\" href=\"" + Utilities.NavigateURL(GetTabId(), string.Empty, @params.ToArray()) + "\">" + subject + "</a>";
                         }
                         else
                         {
@@ -595,7 +595,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                         }
 
                         string sLastReadURL = string.Empty;
-                        string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, this.Forum.PortalSettings.ActiveTab.TabID, this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.TopicUrl, -1, -1, string.Empty, 1, -1, this.Forum.SocialGroupId);
+                        string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, GetTabId(), this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.TopicUrl, -1, -1, string.Empty, 1, -1, this.Forum.SocialGroupId);
                         int? userLastReplyRead = new Controllers.ForumUserController(this.ModuleId).GetByUserId(
                             accessingUser.PortalID,
                             accessingUser.UserID).GetLastReplyRead(this);
@@ -613,7 +613,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                                 @params.Add($"{Literals.GroupId}={this.Forum.SocialGroupId}");
                             }
 
-                            sLastReadURL = Utilities.NavigateURL(this.Forum.PortalSettings.ActiveTab.TabID,
+                            sLastReadURL = Utilities.NavigateURL(GetTabId(),
                                 string.Empty,
                                 @params.ToArray());
                         }
@@ -630,7 +630,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                                 @params.Add($"{Literals.GroupId}={this.Forum.SocialGroupId}");
                             }
 
-                            sLastReadURL = Utilities.NavigateURL(this.Forum.PortalSettings.ActiveTab.TabID, string.Empty, @params.ToArray());
+                            sLastReadURL = Utilities.NavigateURL(GetTabId(), string.Empty, @params.ToArray());
                         }
 
                         if (sTopicURL.EndsWith("/"))
@@ -656,8 +656,8 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                             @params.Add($"{Literals.GroupId}={this.Forum.SocialGroupId}");
                         }
 
-                        string sLastReplyURL = Utilities.NavigateURL(this.Forum.PortalSettings.ActiveTab.TabID, string.Empty, @params.ToArray());
-                        string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, this.Forum.PortalSettings.ActiveTab.TabID, this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.TopicUrl, -1, -1, string.Empty, 1, -1, this.Forum.SocialGroupId);
+                        string sLastReplyURL = Utilities.NavigateURL(GetTabId(), string.Empty, @params.ToArray());
+                        string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, GetTabId(), this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.TopicUrl, -1, -1, string.Empty, 1, -1, this.Forum.SocialGroupId);
                         if (!(string.IsNullOrEmpty(sTopicURL)))
                         {
                             if (sTopicURL.EndsWith("/"))
@@ -729,7 +729,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                         }
 
                         return PropertyAccess.FormatString(
-                            Utilities.NavigateURL(this.Forum.PortalSettings.ActiveTab.TabID,
+                            Utilities.NavigateURL(GetTabId(),
                                 string.Empty,
                                 @params.ToArray()),
                             format);
@@ -753,7 +753,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                         }
 
                         return PropertyAccess.FormatString(
-                            Utilities.NavigateURL(this.Forum.PortalSettings.ActiveTab.TabID,
+                            Utilities.NavigateURL(GetTabId(),
                                 string.Empty,
                                 @params.ToArray()),
                             format);
@@ -768,8 +768,8 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                     return PropertyAccess.FormatString(this.ForumURL, format);
                 case "link":
                     {
-                        string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, this.Forum.PortalSettings.ActiveTab.TabID, this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.TopicUrl, -1, -1, string.Empty, 1, -1, this.Forum.SocialGroupId);
-                        string subject = Utilities.StripHTMLTag(HttpUtility.HtmlDecode(this.Subject)).Replace("\"", string.Empty).Replace("#", string.Empty).Replace("%", string.Empty).Replace("+", string.Empty); ;
+                        string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, GetTabId(), this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.TopicUrl, -1, -1, string.Empty, 1, -1, this.Forum.SocialGroupId);
+                        string subject = Utilities.StripHTMLTag(HttpUtility.HtmlDecode(this.Subject)).Replace("\"", string.Empty).Replace("#", string.Empty).Replace("%", string.Empty).Replace("+", string.Empty);
                         string sBodyTitle = GetTopicTitle(this.Content.Body);
                         string slink;
                         var @params = new List<string>
@@ -795,7 +795,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                                 @params.Add($"{ParamKeys.TopicId}={this.TopicId}");
                             }
 
-                            slink = "<a title=\"" + sBodyTitle + "\" href=\"" + Utilities.NavigateURL(this.Forum.PortalSettings.ActiveTab.TabID, string.Empty, @params.ToArray()) + "\">" + subject + "</a>";
+                            slink = "<a title=\"" + sBodyTitle + "\" href=\"" + Utilities.NavigateURL(GetTabId(), string.Empty, @params.ToArray()) + "\">" + subject + "</a>";
                         }
                         else
                         {
@@ -959,7 +959,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                             PageSize = 10;
                         }
 
-                        return PropertyAccess.FormatString(Utilities.GetLastPostSubject(this.LastReply.ReplyId, this.TopicId, this.ForumId, this.Forum.PortalSettings.ActiveTab.TabID, this.LastReply.Content.Subject, length, pageSize: PageSize, replyCount: this.ReplyCount, canRead: true), format);
+                        return PropertyAccess.FormatString(Utilities.GetLastPostSubject(this.LastReply.ReplyId, this.TopicId, this.ForumId, GetTabId(), this.LastReply.Content.Subject, length, pageSize: PageSize, replyCount: this.ReplyCount, canRead: true), format);
                     }
 
                 case "lastpostauthordisplaynamelink":
@@ -1059,7 +1059,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                             }
 
                             return PropertyAccess.FormatString(
-                                Utilities.NavigateURL(this.Forum.PortalSettings.ActiveTab.TabID, string.Empty, @params.ToArray()),
+                                Utilities.NavigateURL(GetTabId(), string.Empty, @params.ToArray()),
                                 format);
                         }
 
@@ -1100,7 +1100,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                             }
 
                             return PropertyAccess.FormatString(
-                                Utilities.NavigateURL(this.Forum.PortalSettings.ActiveTab.TabID, string.Empty, @params.ToArray()),
+                                Utilities.NavigateURL(GetTabId(), string.Empty, @params.ToArray()),
                                 format);
                         }
 
@@ -1141,7 +1141,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                             }
 
                             return PropertyAccess.FormatString(
-                                Utilities.NavigateURL(this.Forum.PortalSettings.ActiveTab.TabID, string.Empty, @params.ToArray()),
+                                Utilities.NavigateURL(GetTabId(), string.Empty, @params.ToArray()),
                                 format);
                         }
 
@@ -1298,7 +1298,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                             }
 
                             return PropertyAccess.FormatString(
-                                Utilities.NavigateURL(this.Forum.PortalSettings.ActiveTab.TabID, string.Empty, editParams.ToArray()),
+                                Utilities.NavigateURL(GetTabId(), string.Empty, editParams.ToArray()),
                                 format);
                         }
 
@@ -1324,7 +1324,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                             };
 
                             return PropertyAccess.FormatString(
-                                Utilities.NavigateURL(this.Forum.PortalSettings.ActiveTab.TabID, string.Empty, @params.ToArray()),
+                                Utilities.NavigateURL(GetTabId(), string.Empty, @params.ToArray()),
                                 format);
                         }
                         return string.Empty;
@@ -1338,6 +1338,10 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             return string.Empty;
         }
 
+        private int GetTabId()
+        {
+            return this.Forum.PortalSettings.ActiveTab.TabID == -1 || this.Forum.PortalSettings.ActiveTab.TabID == this.Forum.PortalSettings.HomeTabId ? this.Forum.TabId : this.Forum.PortalSettings.ActiveTab.TabID;
+        }
 
         private static string GetTopicTitle(string body)
         {

--- a/Dnn.CommunityForums/Entities/TopicInfo.cs
+++ b/Dnn.CommunityForums/Entities/TopicInfo.cs
@@ -84,7 +84,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         private int forumId = -1;
         private string tags = string.Empty;
         private string selectedcategories;
-        private int? subscriberCount = 0;
+        private int? subscriberCount;
 
         public int TopicId { get; set; }
 

--- a/Dnn.CommunityForums/Services/ModerationService.cs
+++ b/Dnn.CommunityForums/Services/ModerationService.cs
@@ -145,7 +145,7 @@ namespace DotNetNuke.Modules.ActiveForums
                         LastName = ui.LastName,
                         Username = ui.Username,
                     };
-                    DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(fi.ModRejectTemplateId, this.PortalSettings.PortalId, this.moduleId, this.tabId, this.forumId, this.topicId, this.replyId, string.Empty, au);
+                    DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(fi.ModRejectTemplateId, this.PortalSettings.PortalId, this.moduleId, this.tabId, this.forumId, this.topicId, this.replyId, au);
                 }
             }
 
@@ -185,7 +185,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 rc.Reply_Delete(this.PortalSettings.PortalId, this.forumId, this.topicId, this.replyId, ms.DeleteBehavior);
                 if (fi.ModDeleteTemplateId > 0 && reply?.Content?.AuthorId > 0)
                 {
-                    DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(fi.ModDeleteTemplateId, fi.PortalId, fi.ModuleId, fi.TabId, fi.ForumID, this.topicId, this.replyId, string.Empty, reply.Author);
+                    DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(fi.ModDeleteTemplateId, fi.PortalId, fi.ModuleId, fi.TabId, fi.ForumID, this.topicId, this.replyId, reply.Author);
                 }
             }
             else
@@ -198,7 +198,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 new DotNetNuke.Modules.ActiveForums.Controllers.TopicController().DeleteById(this.topicId);
                 if (fi.ModDeleteTemplateId > 0 && ti?.Content?.AuthorId > 0)
                 {
-                    DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(fi.ModDeleteTemplateId, fi.PortalId, fi.ModuleId, fi.TabId, fi.ForumID, this.topicId, this.replyId, string.Empty, ti.Author);
+                    DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(fi.ModDeleteTemplateId, fi.PortalId, fi.ModuleId, fi.TabId, fi.ForumID, this.topicId, this.replyId, ti.Author);
                 }
             }
 

--- a/Dnn.CommunityForums/Services/Tokens/TokenReplacer.cs
+++ b/Dnn.CommunityForums/Services/Tokens/TokenReplacer.cs
@@ -46,6 +46,10 @@ using DotNetNuke.Services.Tokens;
         private const string PropertySource_user = "user";
         private const string PropertySource_profile = "profile";
         private const string PropertySource_membership = "membership";
+        private const string PropertySource_forumauthor = "forumauthor";
+        private const string PropertySource_forumauthoruser = "forumauthoruser";
+        private const string PropertySource_forumauthorprofile = "forumauthorprofile";
+        private const string PropertySource_forumauthormembership = "forumauthormembership";
         private const string PropertySource_tab = "tab";
         private const string PropertySource_module = "module";
         private const string PropertySource_portal = "portal";
@@ -58,7 +62,7 @@ using DotNetNuke.Services.Tokens;
         public TokenReplacer(PortalSettings portalSettings, ForumUserInfo forumUser, ForumInfo forumInfo)
         {
             this.PropertySource[PropertySource_resx] = new ResourceStringTokenReplacer();
-            this.PropertySource[PropertySource_dcf] = new ForumsModuleTokenReplacer(portalSettings, forumInfo.TabId, forumInfo.ModuleId, portalSettings.ActiveTab.TabID == -1 ? forumInfo.TabId : portalSettings.ActiveTab.TabID, portalSettings.ActiveTab.ModuleID == -1 ? forumInfo.ModuleId : portalSettings.ActiveTab.ModuleID);
+            this.PropertySource[PropertySource_dcf] = new ForumsModuleTokenReplacer(portalSettings, forumInfo.TabId, forumInfo.ModuleId, portalSettings.ActiveTab.TabID == -1 || portalSettings.ActiveTab.TabID == portalSettings.HomeTabId ? forumInfo.TabId : portalSettings.ActiveTab.TabID, portalSettings.ActiveTab.ModuleID == -1 ? forumInfo.ModuleId : portalSettings.ActiveTab.ModuleID);
             this.PropertySource[PropertySource_forum] = forumInfo;
             this.PropertySource[PropertySource_forumgroup] = forumInfo.ForumGroup;
             this.PropertySource[PropertySource_forumuser] = forumUser;
@@ -75,7 +79,7 @@ using DotNetNuke.Services.Tokens;
         public TokenReplacer(PortalSettings portalSettings, ForumUserInfo forumUser, ForumGroupInfo forumGroupInfo)
         {
             this.PropertySource[PropertySource_resx] = new ResourceStringTokenReplacer();
-            this.PropertySource[PropertySource_dcf] = new ForumsModuleTokenReplacer(portalSettings, forumGroupInfo.TabId, forumGroupInfo.ModuleId, portalSettings.ActiveTab.TabID == -1 ? forumGroupInfo.TabId : portalSettings.ActiveTab.TabID, portalSettings.ActiveTab.ModuleID == -1 ? forumGroupInfo.ModuleId : portalSettings.ActiveTab.ModuleID);
+            this.PropertySource[PropertySource_dcf] = new ForumsModuleTokenReplacer(portalSettings, forumGroupInfo.TabId, forumGroupInfo.ModuleId, portalSettings.ActiveTab.TabID == -1 || portalSettings.ActiveTab.TabID == portalSettings.HomeTabId? forumGroupInfo.TabId : portalSettings.ActiveTab.TabID, portalSettings.ActiveTab.ModuleID == -1 ? forumGroupInfo.ModuleId : portalSettings.ActiveTab.ModuleID);
             this.PropertySource[PropertySource_forumgroup] = forumGroupInfo;
             this.PropertySource[PropertySource_forumuser] = forumUser;
             this.PropertySource[PropertySource_user] = forumUser.UserInfo;
@@ -91,15 +95,19 @@ using DotNetNuke.Services.Tokens;
         public TokenReplacer(PortalSettings portalSettings, ForumUserInfo forumUser, TopicInfo topicInfo)
         {
             this.PropertySource[PropertySource_resx] = new ResourceStringTokenReplacer();
-            this.PropertySource[PropertySource_dcf] = new ForumsModuleTokenReplacer(portalSettings, topicInfo.Forum.TabId, topicInfo.Forum.ModuleId, portalSettings.ActiveTab.TabID == -1 ? topicInfo.Forum.TabId : portalSettings.ActiveTab.TabID, portalSettings.ActiveTab.ModuleID == -1 ? topicInfo.Forum.ModuleId : portalSettings.ActiveTab.ModuleID);
+            this.PropertySource[PropertySource_dcf] = new ForumsModuleTokenReplacer(portalSettings, topicInfo.Forum.TabId, topicInfo.Forum.ModuleId, portalSettings.ActiveTab.TabID == -1 || portalSettings.ActiveTab.TabID == portalSettings.HomeTabId ? topicInfo.Forum.TabId : portalSettings.ActiveTab.TabID, portalSettings.ActiveTab.ModuleID == -1 ? topicInfo.Forum.ModuleId : portalSettings.ActiveTab.ModuleID);
             this.PropertySource[PropertySource_forum] = topicInfo.Forum;
             this.PropertySource[PropertySource_forumgroup] = topicInfo.Forum.ForumGroup;
             this.PropertySource[PropertySource_forumtopic] = topicInfo;
             this.PropertySource[PropertySource_forumtopicaction] = topicInfo;
-            this.PropertySource[PropertySource_forumuser] = topicInfo.Author.ForumUser;
-            this.PropertySource[PropertySource_user] = topicInfo.Author.ForumUser.UserInfo;
-            this.PropertySource[PropertySource_profile] = new ProfilePropertyAccess(topicInfo.Author.ForumUser.UserInfo);
-            this.PropertySource[PropertySource_membership] = new MembershipPropertyAccess(topicInfo.Author.ForumUser.UserInfo);
+            this.PropertySource[PropertySource_forumuser] = forumUser;
+            this.PropertySource[PropertySource_user] = forumUser.UserInfo;
+            this.PropertySource[PropertySource_profile] = new ProfilePropertyAccess(forumUser.UserInfo);
+            this.PropertySource[PropertySource_membership] = new MembershipPropertyAccess(forumUser.UserInfo);
+            this.PropertySource[PropertySource_forumauthor] = topicInfo.Author.ForumUser;
+            this.PropertySource[PropertySource_forumauthoruser] = topicInfo.Author.ForumUser.UserInfo;
+            this.PropertySource[PropertySource_forumauthorprofile] = new ProfilePropertyAccess(topicInfo.Author.ForumUser.UserInfo);
+            this.PropertySource[PropertySource_forumauthormembership] = new MembershipPropertyAccess(topicInfo.Author.ForumUser.UserInfo);
             this.PropertySource[PropertySource_tab] = portalSettings.ActiveTab;
             this.PropertySource[PropertySource_module] = topicInfo.Forum.ModuleInfo;
             this.PropertySource[PropertySource_portal] = portalSettings;
@@ -110,16 +118,20 @@ using DotNetNuke.Services.Tokens;
         public TokenReplacer(PortalSettings portalSettings, ForumUserInfo forumUser, IPostInfo postInfo)
         {
             this.PropertySource[PropertySource_resx] = new ResourceStringTokenReplacer();
-            this.PropertySource[PropertySource_dcf] = new ForumsModuleTokenReplacer(portalSettings, postInfo.Forum.TabId, postInfo.Forum.ModuleId, portalSettings.ActiveTab.TabID == -1 ? postInfo.Forum.TabId : portalSettings.ActiveTab.TabID, portalSettings.ActiveTab.ModuleID == -1 ? postInfo.Forum.ModuleId : portalSettings.ActiveTab.ModuleID);
+            this.PropertySource[PropertySource_dcf] = new ForumsModuleTokenReplacer(portalSettings, postInfo.Forum.TabId, postInfo.Forum.ModuleId, portalSettings.ActiveTab.TabID == -1 || portalSettings.ActiveTab.TabID == portalSettings.HomeTabId ? postInfo.Forum.TabId : portalSettings.ActiveTab.TabID, portalSettings.ActiveTab.ModuleID == -1 ? postInfo.Forum.ModuleId : portalSettings.ActiveTab.ModuleID);
             this.PropertySource[PropertySource_forum] = postInfo.Forum;
             this.PropertySource[PropertySource_forumgroup] = postInfo.Forum.ForumGroup;
             this.PropertySource[PropertySource_forumtopic] = postInfo.Topic;
             this.PropertySource[PropertySource_forumpost] = postInfo;
             this.PropertySource[PropertySource_forumpostaction] = postInfo;
-            this.PropertySource[PropertySource_forumuser] = postInfo.Author.ForumUser;
-            this.PropertySource[PropertySource_user] = postInfo.Author.ForumUser.UserInfo;
-            this.PropertySource[PropertySource_profile] = new ProfilePropertyAccess(postInfo.Author.ForumUser.UserInfo);
-            this.PropertySource[PropertySource_membership] = new MembershipPropertyAccess(postInfo.Author.ForumUser.UserInfo);
+            this.PropertySource[PropertySource_forumuser] = forumUser;
+            this.PropertySource[PropertySource_user] = forumUser.UserInfo;
+            this.PropertySource[PropertySource_profile] = new ProfilePropertyAccess(forumUser.UserInfo);
+            this.PropertySource[PropertySource_membership] = new MembershipPropertyAccess(forumUser.UserInfo);
+            this.PropertySource[PropertySource_forumauthor] = postInfo.Author.ForumUser;
+            this.PropertySource[PropertySource_forumauthoruser] = postInfo.Author.ForumUser.UserInfo;
+            this.PropertySource[PropertySource_forumauthorprofile] = new ProfilePropertyAccess(postInfo.Author.ForumUser.UserInfo);
+            this.PropertySource[PropertySource_forumauthormembership] = new MembershipPropertyAccess(postInfo.Author.ForumUser.UserInfo);
             this.PropertySource[PropertySource_tab] = portalSettings.ActiveTab;
             this.PropertySource[PropertySource_module] = postInfo.Forum.ModuleInfo;
             this.PropertySource[PropertySource_portal] = portalSettings;
@@ -141,13 +153,17 @@ using DotNetNuke.Services.Tokens;
             this.CurrentAccessLevel = Scope.DefaultSettings;
         }
 
-        public TokenReplacer(PortalSettings portalSettings, ForumUserInfo forumUser, AuthorInfo author)
+        public TokenReplacer(PortalSettings portalSettings, AuthorInfo author, ForumUserInfo forumUser)
         {
             this.PropertySource[PropertySource_resx] = new ResourceStringTokenReplacer();
             this.PropertySource[PropertySource_forumuser] = forumUser;
-            this.PropertySource[PropertySource_user] = author.ForumUser.UserInfo;
-            this.PropertySource[PropertySource_profile] = new ProfilePropertyAccess(author.ForumUser.UserInfo);
-            this.PropertySource[PropertySource_membership] = new MembershipPropertyAccess(author.ForumUser.UserInfo);
+            this.PropertySource[PropertySource_user] = forumUser.UserInfo;
+            this.PropertySource[PropertySource_profile] = new ProfilePropertyAccess(forumUser.UserInfo);
+            this.PropertySource[PropertySource_membership] = new MembershipPropertyAccess(forumUser.UserInfo);
+            this.PropertySource[PropertySource_forumauthor] = author.ForumUser;
+            this.PropertySource[PropertySource_forumauthoruser] = author.ForumUser.UserInfo;
+            this.PropertySource[PropertySource_forumauthorprofile] = new ProfilePropertyAccess(author.ForumUser.UserInfo);
+            this.PropertySource[PropertySource_forumauthormembership] = new MembershipPropertyAccess(author.ForumUser.UserInfo);
             this.PropertySource[PropertySource_tab] = portalSettings.ActiveTab;
             this.PropertySource[PropertySource_module] = forumUser.ModuleInfo;
             this.PropertySource[PropertySource_portal] = portalSettings;
@@ -217,13 +233,21 @@ using DotNetNuke.Services.Tokens;
             return template;
         }
 
+        internal static StringBuilder ReplaceAuthorTokens(StringBuilder template, PortalSettings portalSettings, SettingsInfo mainSettings, AuthorInfo author, ForumUserInfo accessingUser, int forumModuleId)
+        {
+            template = ResourceStringTokenReplacer.ReplaceResourceTokens(template);
+            var tokenReplacer = new TokenReplacer(portalSettings, author, accessingUser) { CurrentAccessLevel = Scope.DefaultSettings, AccessingUser = accessingUser?.UserInfo, };
+            template = new StringBuilder(tokenReplacer.ReplaceEmbeddedTokens(template.ToString()));
+            template = new StringBuilder(tokenReplacer.ReplaceTokens(template.ToString()));
+
+            return template;
+        }
+
         internal static StringBuilder ReplaceUserTokens(StringBuilder template, PortalSettings portalSettings, SettingsInfo mainSettings, ForumUserInfo forumUser, ForumUserInfo accessingUser, int forumModuleId)
         {
             var language = accessingUser?.UserInfo?.Profile?.PreferredLocale ?? portalSettings?.DefaultLanguage;
-            var dateFormat = Globals.DefaultDateFormat;
 
             template = RemoveObsoleteTokens(template);
-            template = MapLegacyUserTokenSynonyms(template, portalSettings, language);
 
             template = ResourceStringTokenReplacer.ReplaceResourceTokens(template);
             var tokenReplacer = new TokenReplacer(portalSettings, forumUser) { CurrentAccessLevel = Scope.DefaultSettings, AccessingUser = forumUser.UserInfo, };
@@ -348,7 +372,7 @@ using DotNetNuke.Services.Tokens;
 
             return template;
         }
-
+        
         internal static StringBuilder RemoveObsoleteTokens(StringBuilder template)
         {
             // no longer using this
@@ -380,6 +404,23 @@ using DotNetNuke.Services.Tokens;
                 "[AF:TB:MemberList]",
             };
 
+            return RemoveObsoleteTokensFromTemplate(template, tokens);
+        }
+
+        internal static StringBuilder RemoveObsoleteEmailNotificationTokens(StringBuilder template)
+        {
+            // no longer using these
+            string[] tokens =
+            {
+                "[COMMENTS]",
+                "[REASON]",
+            };
+
+            return RemoveObsoleteTokensFromTemplate(template, tokens);
+        }
+
+        private static StringBuilder RemoveObsoleteTokensFromTemplate(StringBuilder template, string[] tokens)
+        {
             if (tokens.Length > 0)
             {
                 tokens.ToList().ForEach(t => template = RemoveObsoleteToken(template, t));
@@ -485,7 +526,6 @@ using DotNetNuke.Services.Tokens;
             return template;
         }
 
-
         internal static StringBuilder MapLegacyForumTokenSynonyms(StringBuilder template, PortalSettings portalSettings, string language)
         {
             template = RemoveObsoleteTokens(template);
@@ -534,16 +574,15 @@ using DotNetNuke.Services.Tokens;
             template = ReplaceTokenSynonym(template, "[FORUMGROUPID]", "[FORUMGROUP:FORUMGROUPID]");
             template = ReplaceTokenSynonym(template, "[GROUPCOLLAPSE]", "[FORUMGROUP:GROUPCOLLAPSE]");
 
-
             template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[GROUPNAME]", "[FORUMGROUP:FORUMGROUPLINK", "[FORUMGROUPLINK]");
             template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[FORUMGROUPLINK]", "[FORUMGROUP:FORUMGROUPLINK", "[FORUMGROUPLINK]");
             return template;
         }
 
-        internal static StringBuilder MapLegacyUserTokenSynonyms(StringBuilder template, PortalSettings portalSettings, string language)
+        internal static StringBuilder MapLegacyUserTokenSynonyms(StringBuilder template, PortalSettings portalSettings, SettingsInfo mainSettings, string language)
         {
             template = ReplaceTokenSynonym(template, "[SENDERUSERNAME]", "[USER:USERNAME]");
-            template = ReplaceTokenSynonym(template, "[SENDERFIRSTNAME", "[USER:FIRSTNAME]");
+            template = ReplaceTokenSynonym(template, "[SENDERFIRSTNAME]", "[USER:FIRSTNAME]");
             template = ReplaceTokenSynonym(template, "[SENDERLASTNAME]", "[USER:LASTNAME]");
             template = ReplaceTokenSynonym(template, "[SENDERDISPLAYNAME]", "[USER:DISPLAYNAME]");
 
@@ -607,6 +646,104 @@ using DotNetNuke.Services.Tokens;
 
             template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[DISPLAYNAME]", "[FORUMUSER:USERPROFILELINK", "[DISPLAYNAMELINK]", "[FORUMUSER:DISPLAYNAME]");
             template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[AF:PROFILE:DISPLAYNAME]", "[FORUMUSER:USERPROFILELINK", "[DISPLAYNAMELINK]", "[FORUMUSER:DISPLAYNAME]");
+
+            template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[AF:BUTTON:EDITUSER]", "[FORUMUSER:EDITLINK", "[EDITUSERLINK]");
+
+            if (mainSettings.PMType == PMTypes.Disabled)
+            {
+                template.Replace("[AF:PROFILE:PMLINK]", string.Empty);
+                template.Replace("[AF:PROFILE:PMURL]", string.Empty);
+            }
+            else if (mainSettings.PMType == PMTypes.Core)
+            {
+                template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[AF:PROFILE:PMLINK]", "[FORUMUSER:PMLINK", "[USERPMLINK]");
+                template.Replace("[AF:PROFILE:PMURL]", string.Empty);
+            }
+
+            return template;
+        }
+
+        internal static StringBuilder MapLegacyAuthorTokenSynonyms(StringBuilder template, PortalSettings portalSettings, SettingsInfo mainSettings, string language)
+        {
+            template = ReplaceTokenSynonym(template, "[SENDERUSERNAME]", "[FORUMAUTHOR:USERNAME]");
+            template = ReplaceTokenSynonym(template, "[SENDERFIRSTNAME]", "[FORUMAUTHOR:FIRSTNAME]");
+            template = ReplaceTokenSynonym(template, "[SENDERLASTNAME]", "[FORUMAUTHOR:LASTNAME]");
+            template = ReplaceTokenSynonym(template, "[SENDERDISPLAYNAME]", "[FORUMAUTHOR:DISPLAYNAME]");
+
+            template = ReplaceTokenSynonym(template, "[USERNAME]", "[FORUMAUTHOR:USERNAME]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:USERNAME]", "[FORUMAUTHOR:USERNAME]");
+
+            template = ReplaceTokenSynonym(template, "[USERID]", "[FORUMAUTHOR:USERID]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:USERID]", "[FORUMAUTHOR:USERID]");
+
+            template = ReplaceTokenSynonym(template, "[EMAIL]", "[FORUMAUTHOR:EMAIL]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:EMAIL]", "[FORUMAUTHOR:EMAIL]");
+
+            template = ReplaceTokenSynonym(template, "[FIRSTNAME]", "[FORUMAUTHOR:FIRSTNAME]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:FIRSTNAME]", "[FORUMAUTHOR:FIRSTNAME]");
+            template = ReplaceTokenSynonym(template, "[LASTNAME]", "[FORUMAUTHOR:LASTNAME]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:LASTNAME]", "[FORUMAUTHOR:FIRSTNAME]");
+
+            template = ReplaceTokenSynonym(template, "[SIGNATURE]", "[FORUMAUTHOR:SIGNATURE]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:SIGNATURE]", "[FORUMAUTHOR:SIGNATURE]");
+
+            template = ReplaceTokenSynonym(template, "[AVATAR]", "[FORUMAUTHOR:AVATAR]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:AVATAR]", "[FORUMAUTHOR:AVATAR]");
+
+            template = ReplaceTokenSynonym(template, "[RANKNAME]", "[FORUMAUTHOR:RANKNAME]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:RANKNAME]", "[FORUMAUTHOR:RANKNAME]");
+
+            template = ReplaceTokenSynonym(template, "[RANKDISPLAY]", "[FORUMAUTHOR:RANKDISPLAY]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:RANKDISPLAY]", "[FORUMAUTHOR:RANKDISPLAY]");
+
+            template = ReplaceTokenSynonym(template, "[MEMBERSINCE]", "[FORUMAUTHOR:DATECREATED]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:DATECREATED]", "[FORUMAUTHOR:DATECREATED]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:MEMBERSINCE]", "[FORUMAUTHOR:DATECREATED]");
+
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:LASTACTIVE]", "[FORUMAUTHOR:DATELASTACTIVITY]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:DATELASTACTIVITY]", "[FORUMAUTHOR:DATELASTACTIVITY]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:DATELASTPOST]", "[FORUMAUTHOR:DATELASTPOST]");
+
+            template = ReplaceTokenSynonym(template, "[USERCAPTION]", "[FORUMAUTHOR:USERCAPTION]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:USERCAPTION]", "[FORUMAUTHOR:USERCAPTION]");
+
+            template = ReplaceTokenSynonym(template, "[USERSTATUS]", "[FORUMAUTHOR:USERSTATUS]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:USERSTATUS]", "[FORUMAUTHOR:USERSTATUS]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:USERSTATUS:CSS]", "[FORUMAUTHOR:USERSTATUSCSS]");
+
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:TOTALPOINTS]", "[FORUMAUTHOR:TOTALPOINTS]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:VIEWCOUNT]", "[FORUMAUTHOR:VIEWCOUNT]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:ANSWERCOUNT]", "[FORUMAUTHOR:ANSWERCOUNT]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:REWARDPOINTS]", "[FORUMAUTHOR:REWARDPOINTS]");
+
+            template = ReplaceTokenSynonym(template, "[POSTS]", "[FORUMAUTHOR:POSTS]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:POSTS]", "[FORUMAUTHOR:POSTS]");
+
+            template = ReplaceTokenSynonym(template, "[POSTCOUNT]", "[FORUMAUTHOR:POSTCOUNT]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:POSTCOUNT]", "[FORUMAUTHOR:POSTCOUNT]");
+
+            template = ReplaceTokenSynonym(template, "[AF:POINTS:TOPICCOUNT]", "[FORUMAUTHOR:TOPICCOUNT]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:TOPICCOUNT]", "[FORUMAUTHOR:TOPICCOUNT]");
+
+            template = ReplaceTokenSynonym(template, "[AF:POINTS:REPLYCOUNT]", "[FORUMAUTHOR:REPLYCOUNT]");
+            template = ReplaceTokenSynonym(template, "[AF:PROFILE:REPLYCOUNT]", "[FORUMAUTHOR:REPLYCOUNT]");
+
+            template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[DISPLAYNAME]", "[FORUMAUTHOR:USERPROFILELINK", "[DISPLAYNAMELINK]", "[FORUMAUTHOR:DISPLAYNAME]");
+            template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[AF:PROFILE:DISPLAYNAME]", "[FORUMAUTHOR:USERPROFILELINK", "[DISPLAYNAMELINK]", "[FORUMAUTHOR:DISPLAYNAME]");
+
+            template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[AF:BUTTON:EDITUSER]", "[FORUMAUTHOR:EDITLINK", "[EDITAUTHORLINK]");
+
+            if (mainSettings.PMType == PMTypes.Disabled)
+            {
+                template.Replace("[AF:PROFILE:PMLINK]", string.Empty);
+                template.Replace("[AF:PROFILE:PMURL]", string.Empty);
+            }
+            else if (mainSettings.PMType == PMTypes.Core)
+            {
+                template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[AF:PROFILE:PMLINK]", "[FORUMAUTHOR:PMLINK", "[AUTHORPMLINK]");
+                template.Replace("[AF:PROFILE:PMURL]", string.Empty);
+            }
+
             return template;
         }
 
@@ -705,6 +842,32 @@ using DotNetNuke.Services.Tokens;
             return template;
         }
 
+        internal static StringBuilder MapLegacyEmailNotificationTokenSynonyms(StringBuilder template, PortalSettings portalSettings, string language)
+        {
+            template = ReplaceTokenSynonym(template, "[DISPLAYNAME]", "[FORUMAUTHOR:DISPLAYNAME]");
+            template = ReplaceTokenSynonym(template, "[USERNAME]", "[FORUMAUTHOR:USERNAME]");
+            template = ReplaceTokenSynonym(template, "[USERID]", "[FORUMAUTHOR:USERID]");
+            template = ReplaceTokenSynonym(template, "[PORTALID]", "[PORTAL:PORTALID]");
+            template = ReplaceTokenSynonym(template, "[FIRSTNAME]", "[FORUMAUTHOR:FIRSTNAME]");
+            template = ReplaceTokenSynonym(template, "[LASTNAME]", "[FORUMAUTHOR:LASTNAME]");
+            template = ReplaceTokenSynonym(template, "[FULLNAME]", "[FORUMAUTHOR:FIRSTNAME] [FORUMAUTHOR:LASTNAME]");
+            template = ReplaceTokenSynonym(template, "[GROUPNAME]", "[FORUMGROUP:GROUPNAME]");
+            template = ReplaceTokenSynonym(template, "[POSTDATE]", "[FORUMPOST:DATECREATED]");
+            template = ReplaceTokenSynonym(template, "[PORTALNAME]", "[PORTAL:PORTALNAME]");
+            template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[MODLINK]", "[FORUM:MODLINK", "[MODLINK]");
+            template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[LINK]", "[FORUMPOST:LINK", "[LINK]");
+            template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[HYPERLINK]", "[FORUMPOST:LINK", "[LINK]");
+            template = ReplaceTokenSynonym(template, "[LINKURL]", "[FORUMPOST:LINK]");
+            template = ReplaceTokenSynonym(template, "[FORUMLINK]", "[FORUM:FORUMLINK]");
+
+            template = ReplaceTokenSynonym(template, "[SENDERUSERNAME]", "[FORUMAUTHOR:USERNAME]");
+            template = ReplaceTokenSynonym(template, "[SENDERFIRSTNAME", "[FORUMAUTHOR:FIRSTNAME]");
+            template = ReplaceTokenSynonym(template, "[SENDERLASTNAME]", "[FORUMAUTHOR:LASTNAME]");
+            template = ReplaceTokenSynonym(template, "[SENDERDISPLAYNAME]", "[FORUMAUTHOR:DISPLAYNAME]");
+
+            return template;
+        }
+
         internal static StringBuilder MapLegacyPostTokenSynonyms(StringBuilder template, PortalSettings portalSettings, string language)
         {
             template = ReplaceTokenSynonym(template, "[POSTID]", "[FORUMPOST:POSTID]");
@@ -730,7 +893,9 @@ using DotNetNuke.Services.Tokens;
                 template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[ICONUNPINNED]", "[FORUMPOST:ICONUNPINNED", "[ICONPIN]-HideIcon");
             }
 
-            template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[POSTICON]", "[FORUMPOST:POSTICON", "[POSTICON]");
+            template = ReplaceTokenSynonym(template, "[LINKURL]", "[FORUMPOST:LINK]");
+            template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[LINK]", "[FORUMPOST:LINK", "[LINK]");
+            template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[HYPERLINK]", "[FORUMPOST:LINK", "[LINK]");
 
             return template;
         }

--- a/Dnn.CommunityForums/class/Subscriptions.cs
+++ b/Dnn.CommunityForums/class/Subscriptions.cs
@@ -139,7 +139,7 @@ namespace DotNetNuke.Modules.ActiveForums
             if (subs.Count > 0)
             {
                 var author = new DotNetNuke.Modules.ActiveForums.Entities.AuthorInfo(portalId, moduleId, authorId);
-                DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendTemplatedEmail(templateId, portalId, topicId, replyId, moduleId, tabId, string.Empty, author, fi, subs, requestUrl);
+                DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendTemplatedEmail(templateId, portalId, topicId, replyId, moduleId, tabId, author, fi, subs, requestUrl);
             }
         }
 

--- a/Dnn.CommunityForums/class/TemplateUtils.cs
+++ b/Dnn.CommunityForums/class/TemplateUtils.cs
@@ -45,113 +45,58 @@ namespace DotNetNuke.Modules.ActiveForums
         public static List<DotNetNuke.Modules.ActiveForums.Entities.SubscriptionInfo> lstSubscriptionInfo { get; set; }
         
         #region "Deprecated Methods"
+
         [Obsolete("Deprecated in Community Forums. Remove in 10.00.00. Not Used.")]
-        public static string ShowIcon(bool canView, int forumID, int userId, DateTime dateAdded, DateTime lastRead, int lastPostId)
-        {
-            if (!canView)
-            {
-                return "folder_forbidden.png";
-            }
-
-            if (lastPostId == 0 || userId == -1)
-            {
-                return "folder_closed.png";
-            }
-
-            if (lastRead == DateTime.MinValue)
-            {
-                lastRead = Utilities.NullDate();
-            }
-
-            if (dateAdded != Utilities.NullDate())
-            {
-                return dateAdded > lastRead ? "folder_new.png" : "folder.png";
-            }
-
-            return "folder.png";
-        }
+        public static string ShowIcon(bool canView, int forumID, int userId, DateTime dateAdded, DateTime lastRead, int lastPostId) => throw new NotImplementedException();
 
         [Obsolete("Deprecated in Community Forums. Scheduled removal in 09.00.00. Not Used.")]
-        public static void LoadTemplateCache(int moduleID)
-        {
-            var tc = new TemplateController();
-            foreach (var ti in tc.Template_List(-1, moduleID))
-            {
-                DataCache.SettingsCacheStore(moduleID, ti.Title + moduleID, ti.Template);
-                DataCache.SettingsCacheStore(moduleID, ti.Subject + "_Subject_" + moduleID, ti.Subject);
-            }
-        }
-
-        #endregion
-        #region Email
-        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
-        public static string ParseEmailTemplate(string template, string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, int timeZoneOffset)
-        => ParseEmailTemplate(template, templateName, portalID, moduleID, tabID, forumID, topicId, replyId, string.Empty, null, -1, Utilities.GetCultureInfoForUser(portalID, -1), new TimeSpan(hours: 0, minutes: timeZoneOffset, seconds: 0), false);
+        public static void LoadTemplateCache(int moduleID) => throw new NotImplementedException();
 
         [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
-        public static string ParseEmailTemplate(string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, int timeZoneOffset)
-        => ParseEmailTemplate(string.Empty, templateName, portalID, moduleID, tabID, forumID, topicId, replyId, string.Empty, null, -1, Utilities.GetCultureInfoForUser(portalID, -1), new TimeSpan(hours: 0, minutes: timeZoneOffset, seconds: 0), false);
+        public static string ParseEmailTemplate(string template, string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, int timeZoneOffset) => throw new NotImplementedException();
 
         [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
-        public static string ParseEmailTemplate(string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, string comments, int timeZoneOffset)
-        => ParseEmailTemplate(string.Empty, templateName, portalID, moduleID, tabID, forumID, topicId, replyId, comments, null, -1, Utilities.GetCultureInfoForUser(portalID, -1), new TimeSpan(hours: 0, minutes: timeZoneOffset, seconds: 0), false);
+        public static string ParseEmailTemplate(string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, int timeZoneOffset) => throw new NotImplementedException();
 
         [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
-        public static string ParseEmailTemplate(string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, DotNetNuke.Entities.Users.UserInfo user, int timeZoneOffset)
-        => ParseEmailTemplate(string.Empty, templateName, portalID, moduleID, tabID, forumID, topicId, replyId, string.Empty, user, -1, Utilities.GetCultureInfoForUser(portalID, -1), new TimeSpan(hours: 0, minutes: timeZoneOffset, seconds: 0), false);
+        public static string ParseEmailTemplate(string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, string comments, int timeZoneOffset) => throw new NotImplementedException();
 
         [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
-        public static string ParseEmailTemplate(string template, string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, string comments, int userId, int timeZoneOffset)
-        {
-            var uc = new DotNetNuke.Entities.Users.UserController();
-            var usr = uc.GetUser(portalID, userId);
-            return ParseEmailTemplate(template, templateName, portalID, moduleID, tabID, forumID, topicId, replyId, comments, usr, userId, Utilities.GetCultureInfoForUser(portalID, userId), new TimeSpan(hours: 0, minutes: timeZoneOffset, seconds: 0), false);
-        }
+        public static string ParseEmailTemplate(string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, DotNetNuke.Entities.Users.UserInfo user, int timeZoneOffset) => throw new NotImplementedException();
 
         [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
-        public static string ParseEmailTemplate(string template, string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, string comments, DotNetNuke.Entities.Users.UserInfo user, int userId, int timeZoneOffset)
-        => ParseEmailTemplate(template, templateName, portalID, moduleID, tabID, forumID, topicId: topicId, replyId: replyId, comments: comments, user: user, userId: userId, userCulture: Utilities.GetCultureInfoForUser(portalID, userId), timeZoneOffset: new TimeSpan(hours: 0, minutes: timeZoneOffset, seconds: 0), topicSubscriber: false);
+        public static string ParseEmailTemplate(string template, string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, string comments, int userId, int timeZoneOffset) => throw new NotImplementedException();
 
         [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
-        public static string ParseEmailTemplate(string template, string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, CultureInfo userCulture, TimeSpan timeZoneOffset)
-        => ParseEmailTemplate(template, templateName: templateName, portalID: portalID, moduleID: moduleID, tabID: tabID, forumID: forumID, topicId: topicId, replyId: replyId, comments: string.Empty, userId: 0, userCulture: userCulture, timeZoneOffset: timeZoneOffset, topicSubscriber: false);
+        public static string ParseEmailTemplate(string template, string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, string comments, DotNetNuke.Entities.Users.UserInfo user, int userId, int timeZoneOffset) => throw new NotImplementedException();
 
         [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
-        public static string ParseEmailTemplate(string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, CultureInfo userCulture, TimeSpan timeZoneOffset)
-        => ParseEmailTemplate(template: string.Empty, templateName: templateName, portalID: portalID, moduleID: moduleID, tabID: tabID, forumID: forumID, topicId: topicId, replyId: replyId, comments: string.Empty, user: null, userId: -1, userCulture: userCulture, timeZoneOffset: timeZoneOffset, topicSubscriber: false);
+        public static string ParseEmailTemplate(string template, string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, CultureInfo userCulture, TimeSpan timeZoneOffset) => throw new NotImplementedException();
 
         [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
-        public static string ParseEmailTemplate(string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, string comments, CultureInfo userCulture, TimeSpan timeZoneOffset)
-        => ParseEmailTemplate(template: string.Empty, templateName: templateName, portalID: portalID, moduleID: moduleID, tabID: tabID, forumID: forumID, topicId: topicId, replyId: replyId, comments: comments, user: null, userId: -1, userCulture: userCulture, timeZoneOffset: timeZoneOffset, topicSubscriber: false);
+        public static string ParseEmailTemplate(string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, CultureInfo userCulture, TimeSpan timeZoneOffset) => throw new NotImplementedException();
 
         [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
-        public static string ParseEmailTemplate(string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, DotNetNuke.Entities.Users.UserInfo user, CultureInfo userCulture, TimeSpan timeZoneOffset)
-        => ParseEmailTemplate(string.Empty, templateName, portalID, moduleID, tabID, forumID: forumID, topicId: topicId, replyId: replyId, comments: string.Empty, user: user, userId: -1, userCulture: userCulture, timeZoneOffset: timeZoneOffset, topicSubscriber: false);
-
-        public static string ParseEmailTemplate(string template, string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, string comments, int userId, CultureInfo userCulture, TimeSpan timeZoneOffset)
-        {
-            var uc = new DotNetNuke.Entities.Users.UserController();
-            var usr = uc.GetUser(portalID, userId);
-            return ParseEmailTemplate(template, templateName, portalID, moduleID, tabID, forumID, topicId: topicId, replyId: replyId, comments: comments, user: usr, userId: userId, userCulture: userCulture, timeZoneOffset: timeZoneOffset, topicSubscriber: false);
-        }
+        public static string ParseEmailTemplate(string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, string comments, CultureInfo userCulture, TimeSpan timeZoneOffset) => throw new NotImplementedException();
 
         [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
-        public static string ParseEmailTemplate(string template, string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, string comments, int userId, CultureInfo userCulture, TimeSpan timeZoneOffset, bool topicSubscriber)
-        {
-            var user = new DotNetNuke.Entities.Users.UserController().GetUser(portalID, userId);
-            return ParseEmailTemplate(template, templateName, portalID, moduleID, tabID, forumID, topicId, replyId, comments, user, userId, userCulture, timeZoneOffset, topicSubscriber, new Services.URLNavigator().NavigationManager(), HttpContext.Current.Request.Url);
-        }
+        public static string ParseEmailTemplate(string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, DotNetNuke.Entities.Users.UserInfo user, CultureInfo userCulture, TimeSpan timeZoneOffset) => throw new NotImplementedException();
 
-        public static string ParseEmailTemplate(string template, string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, string comments, DotNetNuke.Entities.Users.UserInfo user, int userId, CultureInfo userCulture, TimeSpan timeZoneOffset, bool topicSubscriber)
-        { return ParseEmailTemplate(template, templateName, portalID, moduleID, tabID, forumID, topicId, replyId, comments, user, userId, userCulture, timeZoneOffset, topicSubscriber, new Services.URLNavigator().NavigationManager(), HttpContext.Current.Request.Url); }
-        
-        public static string ParseEmailTemplate(string template, string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, string comments, DotNetNuke.Entities.Users.UserInfo author, int userId, CultureInfo userCulture, TimeSpan timeZoneOffset, bool topicSubscriber, INavigationManager navigationManager, Uri requestUrl)
-        {
-            var author2 = new DotNetNuke.Modules.ActiveForums.Entities.AuthorInfo(portalID, moduleID, userId);
-            return ParseEmailTemplate(template, templateName, portalID, moduleID, tabID, forumID, topicId, replyId, comments, author2, userId, userCulture, timeZoneOffset, topicSubscriber, navigationManager, requestUrl);
-        }
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
+        public static string ParseEmailTemplate(string template, string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, string comments, int userId, CultureInfo userCulture, TimeSpan timeZoneOffset, bool topicSubscriber) => throw new NotImplementedException();
 
-        public static string ParseEmailTemplate(string template, string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, string comments, DotNetNuke.Modules.ActiveForums.Entities.AuthorInfo author, int userId, CultureInfo userCulture, TimeSpan timeZoneOffset, bool topicSubscriber, INavigationManager navigationManager, Uri requestUrl)
+        [Obsolete("Deprecated in Community Forums. Remove in 10.00.00. Not Used.")]
+        public static string ParseEmailTemplate(string template, string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, string comments, DotNetNuke.Entities.Users.UserInfo user, int userId, CultureInfo userCulture, TimeSpan timeZoneOffset, bool topicSubscriber) => throw new NotImplementedException();
+
+        [Obsolete("Deprecated in Community Forums. Remove in 10.00.00. Not Used.")]
+        public static string ParseEmailTemplate(string template, string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, string comments, DotNetNuke.Entities.Users.UserInfo author, int userId, CultureInfo userCulture, TimeSpan timeZoneOffset, bool topicSubscriber, INavigationManager navigationManager, Uri requestUrl) => throw new NotImplementedException();
+
+        [Obsolete("Deprecated in Community Forums. Remove in 10.00.00. Not Used.")]
+        public static string ParseEmailTemplate(string template, string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, string comments, int userId, CultureInfo userCulture, TimeSpan timeZoneOffset) => throw new NotImplementedException();
+
+        #endregion "Deprecated Methods"
+
+        internal static string ParseEmailTemplate(string template, string templateName, int portalID, int moduleID, int tabID, int forumID, int topicId, int replyId, DotNetNuke.Modules.ActiveForums.Entities.AuthorInfo author, DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo accessingUser, bool topicSubscriber, INavigationManager navigationManager, Uri requestUrl)
         {
             if (navigationManager == null)
             {
@@ -160,12 +105,11 @@ namespace DotNetNuke.Modules.ActiveForums
 
             PortalSettings portalSettings = DotNetNuke.Modules.ActiveForums.Utilities.GetPortalSettings(portalID);
             var moduleSettings = SettingsBase.GetModuleSettings(moduleID);
-            var accessingUser = new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(moduleID).GetByUserId(portalID, userId);
-            var forumInfo = new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().GetById(forumId: forumID, moduleId: moduleID);
             if (author == null)
             {
-                author = new DotNetNuke.Modules.ActiveForums.Entities.AuthorInfo(portalID, moduleID, userId);
+                author = new DotNetNuke.Modules.ActiveForums.Entities.AuthorInfo(portalID, moduleID, accessingUser.UserId);
             }
+
             // If we have a template name, load the template into sOut
             if (templateName != string.Empty)
             {
@@ -173,80 +117,17 @@ namespace DotNetNuke.Modules.ActiveForums
                 {
                     templateName = templateName.Replace(string.Concat("_Subject_", moduleID), string.Empty);
                 }
+
                 template = TemplateCache.GetCachedTemplate(moduleID, templateName, -1);
             }
 
-            // Load Subject and body from topic or reply
-            string subject = string.Empty;
-            string body = string.Empty;
-            DateTime dateCreated = Utilities.NullDate();
-
-            if (topicId > 0 && replyId > 0)
-            {
-                var ri = new DotNetNuke.Modules.ActiveForums.Controllers.ReplyController().GetById(replyId);
-                if (ri != null)
-                {
-                    subject = ri.Content.Subject;
-                    body = ri.Content.Body;
-                    dateCreated = ri.Content.DateCreated;
-                }
-            }
-            else
-            {
-                var ti = new DotNetNuke.Modules.ActiveForums.Controllers.TopicController().GetById(topicId);
-
-                if (ti != null)
-                {
-                    subject = ti.Content.Subject;
-                    body = ti.Content.Body;
-                    dateCreated = ti.Content.DateCreated;
-                }
-            }
-
-            body = Utilities.ManageImagePath(body, requestUrl);
-
-            // Build the topic link
-            string link;
-            if (string.IsNullOrEmpty(forumInfo.PrefixURL) || !Utilities.UseFriendlyURLs(moduleID))
-            {
-                if (replyId == 0)
-                    link = moduleSettings.UseShortUrls ? navigationManager.NavigateURL(tabID, portalSettings, string.Empty, new[] { $"{ParamKeys.TopicId}={topicId}" })
-                        : navigationManager.NavigateURL(tabID, portalSettings, string.Empty, new[] { $"{ParamKeys.ForumId}={forumID}", $"{ParamKeys.ViewType}={Views.Topic}", $"{ParamKeys.TopicId}={topicId}" });
-                else
-                    link = moduleSettings.UseShortUrls ? navigationManager.NavigateURL(tabID, portalSettings, string.Empty, new[] { $"{ParamKeys.TopicId}={topicId}", string.Concat(ParamKeys.ContentJumpId, "=", replyId) })
-                        : navigationManager.NavigateURL(tabID, portalSettings, string.Empty, new[] { $"{ParamKeys.ForumId}={forumID}", $"{ParamKeys.ViewType}={Views.Topic}", $"{ParamKeys.TopicId}={topicId}", $"{ParamKeys.ContentJumpId}={replyId}" });
-            }
-            else
-            {
-                var contentId = (replyId > 0) ? replyId : -1;
-                link = string.Concat(navigationManager.NavigateURL(tabID, portalSettings, string.Empty, (string[])null), "/", new Data.Common().GetUrl(moduleID, -1, forumID, topicId, -1, contentId));
-            }
-
-            if (!link.StartsWith("http"))
-            {
-                if (!link.StartsWith("/"))
-                {
-                    link = string.Concat("/", link);
-                }
-
-                if (HttpContext.Current != null && link.IndexOf(requestUrl.Host, StringComparison.Ordinal) == -1)
-                {
-                    link = Common.Globals.AddHTTP(requestUrl.Host) + link;
-                }
-            }
-
-            // Build the forum Url
-            string forumURL = DotNetNuke.Modules.ActiveForums.Controllers.UrlController.BuildForumUrl(navigationManager, portalSettings, moduleSettings, forumInfo);
-
             var templateStringbuilder = new StringBuilder(template);
+            templateStringbuilder = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.RemoveObsoleteEmailNotificationTokens(templateStringbuilder);
+            templateStringbuilder = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.MapLegacyEmailNotificationTokenSynonyms(templateStringbuilder, portalSettings, accessingUser?.UserInfo?.Profile?.PreferredLocale);
 
-
-            templateStringbuilder.Replace("[POSTDATE]", Utilities.GetUserFormattedDateTime(dateCreated, userCulture, timeZoneOffset));
-            templateStringbuilder.Replace("[COMMENTS]", comments);
-            templateStringbuilder.Replace("[LINK]", string.Concat("<a href=\"", link, "\">", link, "</a>"));
-            templateStringbuilder.Replace("[HYPERLINK]", string.Concat("<a href=\"", link, "\">", link, "</a>"));
-            templateStringbuilder.Replace("[LINKURL]", link);
-
+            // Load Subject and body from topic or reply
+            var postInfo = (topicId > 0 && replyId > 0) ? (IPostInfo)new DotNetNuke.Modules.ActiveForums.Controllers.ReplyController().GetById(replyId) : new DotNetNuke.Modules.ActiveForums.Controllers.TopicController().GetById(topicId);
+            string subject = postInfo.Content.Subject;
             templateStringbuilder.Replace("[POSTEDORREPLIEDTO]", (replyId <= 0 ? Utilities.GetSharedResource("[RESX:posted]") : Utilities.GetSharedResource("[RESX:repliedto]")));
             templateStringbuilder.Replace("[POSTEDTO]", (replyId <= 0 ? Utilities.GetSharedResource("[RESX:postedto]") : string.Empty));
             templateStringbuilder.Replace("[REPLIEDTO]", (replyId > 0 ? Utilities.GetSharedResource("[RESX:repliedto]") : string.Empty));
@@ -254,10 +135,10 @@ namespace DotNetNuke.Modules.ActiveForums
             templateStringbuilder.Replace("[NEWREPLY]", (replyId > 0 ? Utilities.GetSharedResource("[RESX:NewReply]") : string.Empty));
             templateStringbuilder.Replace("[SUBSCRIBEDTOPIC]", (topicSubscriber ? Utilities.GetSharedResource("[RESX:SubscribedTopic]") : string.Empty));
             templateStringbuilder.Replace("[SUBSCRIBEDTOPICSUBJECT]", (topicSubscriber ? string.Format(Utilities.GetSharedResource("[RESX:SubscribedTopicSubject]"), subject) : string.Empty));
-            templateStringbuilder.Replace("[SUBSCRIBEDTOPICFORUMNAME]", (topicSubscriber ? string.Format(Utilities.GetSharedResource("[RESX:SubscribedTopicForumName]"), arg0: subject, forumInfo.ForumName) : string.Empty));
+            templateStringbuilder.Replace("[SUBSCRIBEDTOPICFORUMNAME]", (topicSubscriber ? string.Format(Utilities.GetSharedResource("[RESX:SubscribedTopicForumName]"), arg0: subject, postInfo.Forum.ForumName) : string.Empty));
             templateStringbuilder.Replace("[SUBSCRIBEDFORUM]", (topicSubscriber ? string.Empty : "[RESX:SubscribedForum]"));
-            templateStringbuilder.Replace("[SUBSCRIBEDFORUMNAME]", (topicSubscriber ? string.Empty : string.Format(Utilities.GetSharedResource("[RESX:SubscribedForumName]"), forumInfo.ForumName)));
-            templateStringbuilder.Replace("[SUBSCRIBEDFORUMORTOPICSUBJECTFORUMNAME]", (topicSubscriber ? string.Format(Utilities.GetSharedResource("[RESX:SubscribedTopicForumName]"), subject, forumInfo.ForumName) : string.Format(Utilities.GetSharedResource("[RESX:SubscribedForumTopicForumName]"), subject, forumInfo.ForumName)));
+            templateStringbuilder.Replace("[SUBSCRIBEDFORUMNAME]", (topicSubscriber ? string.Empty : string.Format(Utilities.GetSharedResource("[RESX:SubscribedForumName]"), postInfo.Forum.ForumName)));
+            templateStringbuilder.Replace("[SUBSCRIBEDFORUMORTOPICSUBJECTFORUMNAME]", (topicSubscriber ? string.Format(Utilities.GetSharedResource("[RESX:SubscribedTopicForumName]"), subject, postInfo.Forum.ForumName) : string.Format(Utilities.GetSharedResource("[RESX:SubscribedForumTopicForumName]"), subject, postInfo.Forum.ForumName)));
 
             // Introduced for Active Forum Email Connector plug-in Starts
             if (templateStringbuilder.ToString().Contains("[EMAILCONNECTORITEMID]"))
@@ -270,16 +151,11 @@ namespace DotNetNuke.Modules.ActiveForums
                     templateStringbuilder.Replace("[EMAILCONNECTORITEMID]", itemID.ToString());
                 }
                 catch
-                { }
+                {
+                }
             }
 
-            templateStringbuilder.Replace("[SUBJECT]", subject);
-            templateStringbuilder.Replace("[BODY]", body);
-            templateStringbuilder.Replace("[Body]", body);
-            
-            //templateStringbuilder = DotNetNuke.Modules.ActiveForums.Controllers.TokenController.ReplaceUserTokens(templateStringbuilder, portalSettings, moduleSettings, author.ForumUser, accessingUser, moduleID);
-            //templateStringbuilder = DotNetNuke.Modules.ActiveForums.Controllers.TokenController.ReplaceForumTokens(templateStringbuilder, forumInfo, portalSettings, moduleSettings, navigationManager, author.ForumUser, HttpContext.Current.Request, tabID, CurrentUserTypes.Auth);
-            //templateStringbuilder = DotNetNuke.Modules.ActiveForums.Controllers.TokenController.ReplaceModuleTokens(templateStringbuilder, portalSettings, moduleSettings, author.ForumUser, tabID, moduleID);
+            templateStringbuilder = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.ReplacePostTokens(templateStringbuilder, postInfo, portalSettings, moduleSettings, navigationManager, accessingUser, requestUrl.ToString());
 
             return templateStringbuilder.ToString();
         }
@@ -333,9 +209,6 @@ namespace DotNetNuke.Modules.ActiveForums
 
             return itemID;
         }
-        #endregion
-
-        #region Profile
 
         #region "Deprecated Methods"
 
@@ -388,6 +261,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     DataCache.SettingsCacheStore(moduleId, cacheKey, myTemplate);
                 }
             }
+
             var author = new DotNetNuke.Modules.ActiveForums.Entities.AuthorInfo(user.PortalId, moduleId, user.UserId);
 
             myTemplate = ParseProfileTemplate(moduleId, myTemplate, author, imagePath, currentUserType, userPrefHideAvatar, false, ipAddress, currentUserId, timeZoneOffset);
@@ -480,12 +354,11 @@ namespace DotNetNuke.Modules.ActiveForums
                 var portalSettings = Utilities.GetPortalSettings(author.ForumUser.PortalId);
                 var mainSettings = SettingsBase.GetModuleSettings(moduleId);
                 var accessingUser = new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(moduleId).GetByUserId(author.ForumUser.PortalId, currentUserId);
-
-                var profileTemplateBuilder = new StringBuilder(profileTemplate);
-
+                var templateStringbuilder = new StringBuilder(profileTemplate);
+                templateStringbuilder = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.MapLegacyAuthorTokenSynonyms(templateStringbuilder, portalSettings, mainSettings, accessingUser?.UserInfo?.Profile?.PreferredLocale);
 
                 // Parse DNN profile fields if needed
-                var pt = profileTemplate;
+                var pt = templateStringbuilder.ToString();
                 if (pt.IndexOf("[DNN:PROFILE:", StringComparison.Ordinal) >= 0)
                 {
                     pt = ParseProfile(author.ForumUser, pt, currentUserType, currentUserId);
@@ -497,47 +370,29 @@ namespace DotNetNuke.Modules.ActiveForums
                     pt = ParseRoles(pt, (author.ForumUser.UserId == -1) ? string.Empty : author.ForumUser.UserRoles);
                 }
 
-                var result = new StringBuilder(pt);
-
-                // IP Address
-                result.Replace("[MODIPADDRESS]", accessingUser.IsAdmin || accessingUser.IsSuperUser || accessingUser.GetIsMod(moduleId) ? ipAddress : string.Empty);
-                result.Replace("[FORUMPOST:MODIPADDRESS]", accessingUser.IsAdmin || accessingUser.IsSuperUser || accessingUser.GetIsMod(moduleId) ? ipAddress : string.Empty);
-
-                // User Edit
-                result.Replace("[AF:BUTTON:EDITUSER]", (accessingUser.IsAdmin || accessingUser.IsSuperUser) && author.ForumUser.UserId > 0 ? string.Format("<button class='af-button af-button-edituser' data-id='{0}' data-name='{1}'>[RESX:Edit]</button>", author.ForumUser.UserId, Utilities.JSON.EscapeJsonString(author.DisplayName)) : string.Empty);
-
-
-                // PM Image/link
+#region "Backward compatilbility -- remove in v09.00.00"
                 var pmUrl = string.Empty;
                 var pmLink = string.Empty;
-                if (author.ForumUser.UserId > 0 && currentUserId >= 0 && author.ForumUser.UserId != currentUserId)
+                if (pt.Contains("[AF:PROFILE:PMURL]") && mainSettings.PMType == PMTypes.Ventrian)
                 {
-                    switch (mainSettings.PMType)
+                    if (author.ForumUser.UserId > 0 && currentUserId >= 0 && author.ForumUser.UserId != currentUserId)
                     {
-                        case PMTypes.Core:
-                            pmLink = string.Concat("<img class='ComposeMessage' data-recipient='{ \"id\": \"user-", author.ForumUser.UserId, "\", \"name\": \"", HttpUtility.JavaScriptStringEncode(author.DisplayName), "\"}' src='", imagePath, "/icon_pm.png' alt=\"[RESX:SendPM]\" title=\"[RESX:SendPM]\" border=\"0\" /></a>");
-                            break;
-
-                        case PMTypes.Ventrian:
-                            pmUrl = Utilities.NavigateURL(mainSettings.PMTabId, string.Empty, new[] { "type=compose", string.Concat("sendto=", author.ForumUser.UserId) });
-                            pmLink = string.Concat("<a href=\"", pmUrl, "\"><img src=\"", imagePath, "/icon_pm.png\" alt=\"[RESX:SendPM]\" border=\"0\" /></a>");
-                            break;
+                        pmUrl = Utilities.NavigateURL(mainSettings.PMTabId, string.Empty, new[] { "type=compose", string.Concat("sendto=", author.ForumUser.UserId) });
+                        pmLink = string.Concat("<a href=\"", pmUrl, "\"><img src=\"", imagePath, "/icon_pm.png\" alt=\"[RESX:SendPM]\" border=\"0\" /></a>");
                     }
                 }
 
-                result.Replace("[AF:PROFILE:PMLINK]", pmLink);
-                result.Replace("[AF:PROFILE:PMURL]", pmUrl);
+                pt = pt.Replace("[AF:PROFILE:PMLINK]", pmLink);
+                pt = pt.Replace("[AF:PROFILE:PMURL]", pmUrl);
+#endregion "Backward compatilbility -- remove in v09.00.00"
 
-                result = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.ReplaceUserTokens(result, portalSettings, mainSettings, author.ForumUser, accessingUser, moduleId);
-
-                return result.ToString();
+                return pt;
             }
             catch (Exception ex)
             {
                 return ex.Message;
             }
         }
-        #endregion
 
         public static string ParseRoles(string template, string userRoles)
         {
@@ -566,7 +421,6 @@ namespace DotNetNuke.Modules.ActiveForums
 
             return template;
         }
-
 
         public static string GetTemplateSection(string template, string startTag, string endTag, bool returnTemplateIfTagNotFound = true)
         {
@@ -610,12 +464,12 @@ namespace DotNetNuke.Modules.ActiveForums
                 var intSubTempLength = intSubTempEnd - intSubTempStart;
                 template = new StringBuilder(template.ToString().Substring(0, intStartTag) + subTemplate + template.ToString().Substring(intEndTag + endTag.Length));
             }
+
             return template;
         }
 
         [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Use ParseProfile(DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo user, string template, CurrentUserTypes currentUserType, int currentUserId)")]
-        public static string ParseProfile(int portalId, int userId, string template, CurrentUserTypes currentUserType, int currentUserId)
-            => ParseProfile(new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(-1).GetByUserId(portalId, userId), template, currentUserType, currentUserId);
+        public static string ParseProfile(int portalId, int userId, string template, CurrentUserTypes currentUserType, int currentUserId) => throw new NotImplementedException();
 
         internal static string ParseProfile(DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo user, string template, CurrentUserTypes currentUserType, int currentUserId)
         {
@@ -663,22 +517,19 @@ namespace DotNetNuke.Modules.ActiveForums
             return s;
         }
 
-        private static string GetTopicTemplate(int topicTemplateId, int moduleId)
-        {
-            return TemplateCache.GetCachedTemplate(moduleId, "TopicView", topicTemplateId);
-        }
+        #region "Deprecated Methods"
 
         [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Use string PreviewTopic(int topicTemplateID, DotNetNuke.Modules.ActiveForums.Entities.ForumInfo forumInfo, DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo user, string body, string imagePath,DateTime postDate, CurrentUserTypes currentUserType, int currentUserId, TimeSpan timeZoneOffset)")]
-        public static string PreviewTopic(int topicTemplateID, int portalId, int moduleId, int tabId, DotNetNuke.Modules.ActiveForums.Entities.ForumInfo forumInfo, int userId, string body, string imagePath, User up, DateTime postDate, CurrentUserTypes currentUserType, int currentUserId, int timeZoneOffset)
-                => PreviewTopic(topicTemplateID, forumInfo, new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(moduleId).GetByUserId(portalId, userId), body, imagePath, postDate, currentUserType, currentUserId, new TimeSpan(hours: 0, minutes: timeZoneOffset, seconds: 0));
+        public static string PreviewTopic(int topicTemplateID, int portalId, int moduleId, int tabId, DotNetNuke.Modules.ActiveForums.Entities.ForumInfo forumInfo, int userId, string body, string imagePath, User up, DateTime postDate, CurrentUserTypes currentUserType, int currentUserId, int timeZoneOffset) => throw new NotImplementedException();
 
         [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Use string PreviewTopic(int topicTemplateID, DotNetNuke.Modules.ActiveForums.Entities.ForumInfo forumInfo, DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo user, string body, string imagePath,DateTime postDate, CurrentUserTypes currentUserType, int currentUserId, TimeSpan timeZoneOffset)")]
-        public static string PreviewTopic(int topicTemplateID, int portalId, int moduleId, int tabId, DotNetNuke.Modules.ActiveForums.Entities.ForumInfo forumInfo, int userId, string body, string imagePath, User up, DateTime postDate, CurrentUserTypes currentUserType, int currentUserId, TimeSpan timeZoneOffset)
-                => PreviewTopic(topicTemplateID, forumInfo, new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(moduleId).GetByUserId(portalId, userId), body, imagePath, postDate, currentUserType, currentUserId, timeZoneOffset);
+        public static string PreviewTopic(int topicTemplateID, int portalId, int moduleId, int tabId, DotNetNuke.Modules.ActiveForums.Entities.ForumInfo forumInfo, int userId, string body, string imagePath, User up, DateTime postDate, CurrentUserTypes currentUserType, int currentUserId, TimeSpan timeZoneOffset) => throw new NotImplementedException();
+
+        #endregion  "Deprecated Methods"
 
         internal static string PreviewTopic(int topicTemplateID, DotNetNuke.Modules.ActiveForums.Entities.ForumInfo forumInfo, DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo user, string body, string imagePath,DateTime postDate, CurrentUserTypes currentUserType, int currentUserId, TimeSpan timeZoneOffset)
         {
-            var sTemplate = GetTopicTemplate(topicTemplateID, forumInfo.ModuleId);
+            var sTemplate = TemplateCache.GetCachedTemplate(forumInfo.ModuleId, "TopicView", topicTemplateID);
             try
             {
                 var mainSettings = SettingsBase.GetModuleSettings(forumInfo.ModuleId);

--- a/Dnn.CommunityForums/config/templates/SubscribedEmail.ascx
+++ b/Dnn.CommunityForums/config/templates/SubscribedEmail.ascx
@@ -1,8 +1,8 @@
-	<font face="tahoma" size="2">A message was posted to a forum you are tracking.<br /><br />
+<font face="tahoma" size="2">A message was posted to a forum you are tracking.<br /><br />
 <table width="90%" bordercolor="#666666" border="1" cellpadding="2" cellspacing="0"><tr><td valign="top" bgcolor="#dcdcdc" width="100">
-<font face="arial" size="2"><b>[DISPLAYNAME]</b></font>
-<font size="1" face="arial">Posted:[POSTDATE] </font></td><td valgin="top"><font face="arial" size=2><b>Subject:</b> [SUBJECT] <br />
-<br />[BODY]</font></td></tr></table><hr noshade size="1" />To view the complete thread and reply, please visit:
- [HYPERLINK]<br /><br /> Thank you,
- [PORTALNAME]
+<font face="arial" size="2"><b>[FORUMPOST:AUTHORDISPLAYNAMELINK|<a href="{0}" class="af-profile-link" rel="nofollow">[FORUMPOST:AUTHORDISPLAYNAME]</a>|[FORUMPOST:AUTHORDISPLAYNAME]]</b></font>
+<font size="1" face="arial">Posted:[FORUMPOST:DATECREATED] </font></td><td valgin="top"><font face="arial" size="2"><b>Subject:</b> [FORUMPOST:SUBJECT] <br />
+<br />[FORUMPOST:BODY]</font></td></tr></table><hr noshade size="1" />To view the complete thread and reply, please visit:
+[FORUMPOST:LINK]<br /><br /> Thank you,
+[PORTAL:PORTALNAME]
 </font>

--- a/Dnn.CommunityForums/controls/af_modtopics.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_modtopics.ascx.cs
@@ -111,7 +111,6 @@ namespace DotNetNuke.Modules.ActiveForums
                                                     tmpForumId,
                                                     tmpTopicId,
                                                     -1,
-                                                    string.Empty,
                                                     ti.Author);
                                             }
                                             catch (Exception ex)
@@ -139,7 +138,6 @@ namespace DotNetNuke.Modules.ActiveForums
                                                     tmpForumId,
                                                     tmpTopicId,
                                                     tmpReplyId,
-                                                    string.Empty,
                                                     ri.Author);
                                             }
                                             catch (Exception ex)
@@ -176,7 +174,7 @@ namespace DotNetNuke.Modules.ActiveForums
                                     au.FirstName = ui.FirstName;
                                     au.LastName = ui.LastName;
                                     au.Username = ui.Username;
-                                    DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(fi.ModRejectTemplateId, this.PortalId, this.ForumModuleId, this.TabId, tmpForumId, tmpTopicId, tmpReplyId, string.Empty, au);
+                                    DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(fi.ModRejectTemplateId, this.PortalId, this.ForumModuleId, this.TabId, tmpForumId, tmpTopicId, tmpReplyId, au);
                                 }
                             }
 
@@ -200,7 +198,7 @@ namespace DotNetNuke.Modules.ActiveForums
                                     // TODO: Add Audit log for who approved topic
                                     if (fi.ModApproveTemplateId > 0 & ti.Author.AuthorId > 0)
                                     {
-                                        DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(fi.ModApproveTemplateId, this.PortalId, this.ForumModuleId, this.TabId, tmpForumId, tmpTopicId, tmpReplyId, string.Empty, ti.Author);
+                                        DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(fi.ModApproveTemplateId, this.PortalId, this.ForumModuleId, this.TabId, tmpForumId, tmpTopicId, tmpReplyId, ti.Author);
                                     }
 
                                     DotNetNuke.Modules.ActiveForums.Controllers.ModerationController.RemoveModerationNotifications(this.ForumTabId, this.ForumModuleId, tmpForumId, tmpTopicId, tmpReplyId);
@@ -219,7 +217,7 @@ namespace DotNetNuke.Modules.ActiveForums
                                     // TODO: Add Audit log for who approved topic
                                     if (fi.ModApproveTemplateId > 0 & ri.Author.AuthorId > 0)
                                     {
-                                        DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(fi.ModApproveTemplateId, this.PortalId, this.ForumModuleId, this.TabId, tmpForumId, tmpTopicId, tmpReplyId, string.Empty, ri.Author);
+                                        DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(fi.ModApproveTemplateId, this.PortalId, this.ForumModuleId, this.TabId, tmpForumId, tmpTopicId, tmpReplyId, ri.Author);
                                     }
 
                                     DotNetNuke.Modules.ActiveForums.Controllers.ModerationController.RemoveModerationNotifications(this.ForumTabId, this.ForumModuleId, tmpForumId, tmpTopicId, tmpReplyId);

--- a/Dnn.CommunityForums/themes/community-bootstrap/templates/ProfileInfo.ascx
+++ b/Dnn.CommunityForums/themes/community-bootstrap/templates/ProfileInfo.ascx
@@ -1,31 +1,32 @@
 <div class="dcf-post-user d-inline-flex d-md-block align-items-center">
     <div class="dcf-user order-1">
-        [FORUMUSER:USERSTATUS] [FORUMUSER:USERPROFILELINK|<a href="{0}" class="af-profile-link" rel="nofollow">[FORUMUSER:DISPLAYNAME]</a>|[FORUMUSER:DISPLAYNAME]]
+        [FORUMAUTHOR:USERSTATUS] [FORUMAUTHOR:USERPROFILELINK|<a href="{0}" class="af-profile-link" rel="nofollow">[FORUMAUTHOR:DISPLAYNAME]</a>|[FORUMAUTHOR:DISPLAYNAME]]
     </div>
     <div class="dcf-avatar text-center">
         <div class="dcf-avatar-img-wrap order-0 pr-4 pr-md-0">
             <div class="dcf-avatar-img d-inline-block my-md-4 border border-primary">
-            [FORUMUSER:AVATAR]
+            [FORUMAUTHOR:AVATAR]
             </div>
         </div>
     </div>
 </div>
 <div class="dcf-post-user-data d-none d-md-block">
     <div class="dcf-post-user">
-    [FORUMUSER:USERCAPTION]
-    [FORUMUSER:RANKNAME]
-    [AF:PROFILE:PMLINK]
-    [AF:BUTTON:EDITUSER]
+        [FORUMAUTHOR:USERCAPTION]
+        [FORUMAUTHOR:RANKNAME]
+        [FORUMAUTHOR:PMLINK|<img class='ComposeMessage' data-recipient='{{ "id": "user-{0}", "name": "[FORUMAUTHOR:DISPLAYNAMEFORJSON]"}}' src='[FORUM:THEMELOCATION]/images/icon_pm.png' alt="[RESX:SendPM]" title="[RESX:SendPM]" border="0" />]
+        [FORUMAUTHOR:EDITLINK|
+        <button class='af-button af-button-edituser' data-id="{0}" data-name="[FORUMAUTHOR:DISPLAYNAMEFORJSON]">[RESX:Edit]</button>]
     </div>
     <div class="dcf-post-user-rank">
         <div class="dcf-user-posts">
-            [RESX:Posts]: [FORUMUSER:POSTCOUNT]
+            [RESX:Posts]: [FORUMAUTHOR:POSTCOUNT]
         </div>
         <div class="dcf-user-ipaddress">
             [FORUMPOST:MODIPADDRESS]
         </div>
         <div class="dcf-user-rank">
-            [AF:PROFILE:RANKDISPLAY]
+            [FORUMAUTHOR:RANKDISPLAY]
         </div>
     </div>
 </div>

--- a/Dnn.CommunityForums/themes/community-bootstrap/templates/TopicView.ascx
+++ b/Dnn.CommunityForums/themes/community-bootstrap/templates/TopicView.ascx
@@ -89,11 +89,6 @@
 								
 							</section>
 							<footer class="dcf-post-footer">
-                                <!--
-                                <div class="dcf-post-signature">
-                                    [SIGNATURE]
-                                </div>
-                                -->
                                 [FORUMUSER:SIGNATURE|<div class="dcf-post-signature">{0}</div>
                                 ]
 								<div class="dcf-post-footer-bottom">
@@ -144,11 +139,6 @@
 								
 							</section>
 							<footer class="dcf-post-footer">
-                                <!--
-                                <div class="dcf-post-signature">
-                                    [SIGNATURE]
-                                </div>
-                                -->
                                 [FORUMUSER:SIGNATURE|<div class="dcf-post-signature">{0}</div>
                                 ]
 								<div class="dcf-post-footer-bottom">

--- a/Dnn.CommunityForums/themes/community-bootstrap/templates/TopicsView.ascx
+++ b/Dnn.CommunityForums/themes/community-bootstrap/templates/TopicsView.ascx
@@ -161,7 +161,13 @@
 					</td>
 								<td class="dcf-col dcf-col-subject">
 									<div class="dcf-subject" title="[FORUMTOPIC:BODYTITLE]">
-										<h4 class="dcf-title h5 mt-0 mb-2">[FORUMTOPIC:SUBJECTLINK][FORUMTOPIC:LASTREADURL|<a href="{0}" rel="nofollow"><img src="[FORUM:THEMELOCATION]/images/miniarrow_down.png" style="vertical-align: middle;" alt="[RESX:JumpToLastRead]" border="0" class="afminiarrow" /></a>][ICONPIN][ICONLOCK]</h4>
+										<h4 class="dcf-title h5 mt-0 mb-2">[FORUMTOPIC:SUBJECTLINK][FORUMTOPIC:LASTREADURL|<a href="{0}" rel="nofollow"><img src="[FORUM:THEMELOCATION]/images/miniarrow_down.png" style="vertical-align: middle;" alt="[RESX:JumpToLastRead]" border="0" class="afminiarrow" /></a>]
+                                            [FORUMTOPIC:ICONPINNED|&nbsp;&nbsp;<i id="af-topicsview-pin-{0}" class="fa fa-thumb-tack fa-fw fa-red"></i>]
+                                            [FORUMTOPIC:ICONUNPINNED|&nbsp;&nbsp;<i id="af-topicsview-pin-{0}" class="fa fa-fw fa-red"></i>]
+                                            [FORUMTOPIC:ICONLOCKED|&nbsp;&nbsp;<i id="af-topicsview-lock-{0}" class="fa fa-lock fa-fw fa-red"></i>]
+                                            [FORUMTOPIC:ICONUNLOCKED|&nbsp;&nbsp;<i id="af-topicsview-lock-{0}" class="fa fa-fw fa-red"></i>]
+
+										</h4>
 										<div class="dcf-topic-started">[RESX:StartedHeader]
 											<i class="fa fa-user fa-blue"></i>&nbsp;[FORUMTOPIC:AUTHORDISPLAYNAMELINK|<a href="{0}" class="af-profile-link" rel="nofollow">[FORUMTOPIC:AUTHORDISPLAYNAME]</a>|[FORUMTOPIC:AUTHORDISPLAYNAME]][AF:UI:MINIPAGER]
 										</div>

--- a/Dnn.CommunityForums/themes/community-default/templates/ProfileInfo.ascx
+++ b/Dnn.CommunityForums/themes/community-default/templates/ProfileInfo.ascx
@@ -1,31 +1,32 @@
 <div class="dcf-post-user">
     <div class="dcf-user">
-        [FORUMUSER:USERSTATUS] [FORUMUSER:USERPROFILELINK|<a href="{0}" class="af-profile-link" rel="nofollow">[FORUMUSER:DISPLAYNAME]</a>|[FORUMUSER:DISPLAYNAME]]
+        [FORUMAUTHOR:USERSTATUS] [FORUMAUTHOR:USERPROFILELINK|<a href="{0}" class="af-profile-link" rel="nofollow">[FORUMAUTHOR:DISPLAYNAME]</a>|[FORUMAUTHOR:DISPLAYNAME]]
     </div>
     <div class="dcf-avatar">
         <div class="dcf-avatar-img-wrap">
             <div class="dcf-avatar-img">
-            [FORUMUSER:AVATAR]
+            [FORUMAUTHOR:AVATAR]
             </div>
         </div>
     </div>
 </div>
 <div class="dcf-post-user-data">
     <div class="dcf-post-user">
-    [FORUMUSER:USERCAPTION]
-    [FORUMUSER:RANKNAME]
-    [AF:PROFILE:PMLINK]
-    [AF:BUTTON:EDITUSER]
+    [FORUMAUTHOR:USERCAPTION]
+    [FORUMAUTHOR:RANKNAME]
+    [FORUMAUTHOR:PMLINK|<img class='ComposeMessage' data-recipient='{{ "id": "user-{0}", "name": "[FORUMAUTHOR:DISPLAYNAMEFORJSON]"}}' src='[FORUM:THEMELOCATION]/images/icon_pm.png' alt="[RESX:SendPM]" title="[RESX:SendPM]" border="0" />]
+    [FORUMAUTHOR:EDITLINK|
+        <button class='af-button af-button-edituser' data-id="{0}" data-name="[FORUMAUTHOR:DISPLAYNAMEFORJSON]">[RESX:Edit]</button>]
     </div>
     <div class="dcf-post-user-rank">
         <div class="dcf-user-posts">
-            [RESX:Posts]: [FORUMUSER:POSTCOUNT]
+            [RESX:Posts]: [FORUMAUTHOR:POSTCOUNT]
         </div>
         <div class="dcf-user-ipaddress">
             [FORUMPOST:MODIPADDRESS]
         </div>
         <div class="dcf-user-rank">
-            [FORUMUSER:RANKDISPLAY]
+            [FORUMAUTHOR:RANKDISPLAY]
         </div>
     </div>
 </div>

--- a/Dnn.CommunityForums/themes/community-default/templates/TopicView.ascx
+++ b/Dnn.CommunityForums/themes/community-default/templates/TopicView.ascx
@@ -95,12 +95,6 @@
 								
 							</section>
 							<footer class="dcf-post-footer">
-								<!--
-								<div class="dcf-post-signature">
-									[SIGNATURE]
-								</div>
-                                -->
-
                                 [FORUMUSER:SIGNATURE|<div class="dcf-post-signature">{0}</div>]
 
                                 <div class="dcf-cols dcf-post-footer-bottom">
@@ -156,11 +150,6 @@
 								
 							</section>
 							<footer class="dcf-post-footer">
-<!--								
-									<div class="dcf-post-signature">
-									[SIGNATURE]
-								</div>
--->								
                                 [FORUMUSER:SIGNATURE|<div class="dcf-post-signature">{0}</div>]
 
 								<div class="dcf-cols dcf-post-footer-bottom">

--- a/Dnn.CommunityForums/themes/community-default/templates/TopicsView.ascx
+++ b/Dnn.CommunityForums/themes/community-default/templates/TopicsView.ascx
@@ -73,7 +73,7 @@
 							<td class="dcf-col dcf-col-views">[FORUMTOPIC:SUBSCRIBERCOUNT]</td>
 							<td class="dcf-col dcf-col-last-post"><div class="dcf-_lastpost" style="white-space:nowrap;">
                                 [LASTPOST]
-                                    [RESX:BY] <i class="fa fa-user fa-blue"></i>&nbsp;[LASTPOSTDISPLAYNAME][FORUMTOPIC:LASTREPLYURL|<a href="{0}" rel="nofollow"><img src="[FORUM:THEMELOCATION]/images/miniarrow_right.png" style="vertical-align: middle;" alt="[RESX:JumpToLastReply]" border="0" class="afminiarrow" /></a>]<br />[FORUMTOPIC:LASTPOSTDATE]
+                                    [RESX:BY] <i class="fa fa-user fa-blue"></i>&nbsp;[FORUMTOPIC:LASTPOSTAUTHORDISPLAYNAMELINK|<a href="{0}" class="af-profile-link" rel="nofollow">[FORUMTOPIC:LASTPOSTAUTHORDISPLAYNAME]</a>|[FORUMTOPIC:LASTPOSTAUTHORDISPLAYNAME]][FORUMTOPIC:LASTREPLYURL|<a href="{0}" rel="nofollow"><img src="[FORUM:THEMELOCATION]/images/miniarrow_right.png" style="vertical-align: middle;" alt="[RESX:JumpToLastReply]" border="0" class="afminiarrow" /></a>]<br />[FORUMTOPIC:LASTPOSTDATE]
                                 [/LASTPOST]
                             </div></td>
 						</tr>
@@ -129,7 +129,12 @@
 					<td class="dcf-col dcf-col-subject">
 						<div class="dcf-subject" title="[FORUMTOPIC:BODYTITLE]">
 
-							<h4 class="dcf-title dcf-title-4">[FORUMTOPIC:SUBJECTLINK][FORUMTOPIC:LASTREADURL|<a href="{0}" rel="nofollow"><img src="[FORUM:THEMELOCATION]/images/miniarrow_down.png" style="vertical-align: middle;" alt="[RESX:JumpToLastRead]" border="0" class="afminiarrow" /></a>][ICONPIN][ICONLOCK]</h4>
+							<h4 class="dcf-title dcf-title-4">[FORUMTOPIC:SUBJECTLINK][FORUMTOPIC:LASTREADURL|<a href="{0}" rel="nofollow"><img src="[FORUM:THEMELOCATION]/images/miniarrow_down.png" style="vertical-align: middle;" alt="[RESX:JumpToLastRead]" border="0" class="afminiarrow" /></a>]
+                                [FORUMTOPIC:ICONPINNED|&nbsp;&nbsp;<i id="af-topicsview-pin-{0}" class="fa fa-thumb-tack fa-fw fa-red"></i>]
+                                [FORUMTOPIC:ICONUNPINNED|&nbsp;&nbsp;<i id="af-topicsview-pin-{0}" class="fa fa-fw fa-red"></i>]
+                                [FORUMTOPIC:ICONLOCKED|&nbsp;&nbsp;<i id="af-topicsview-lock-{0}" class="fa fa-lock fa-fw fa-red"></i>]
+                                [FORUMTOPIC:ICONUNLOCKED|&nbsp;&nbsp;<i id="af-topicsview-lock-{0}" class="fa fa-fw fa-red"></i>]
+							</h4>
 
 							<div class="dcf-topic-started">[RESX:StartedHeader] <i class="fa fa-user fa-blue"></i>&nbsp;[FORUMTOPIC:AUTHORDISPLAYNAMELINK|<a href="{0}" class="af-profile-link" rel="nofollow">[FORUMTOPIC:AUTHORDISPLAYNAME]</a>|[FORUMTOPIC:AUTHORDISPLAYNAME]][AF:UI:MINIPAGER]</div>
 


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Modernizes token replacement for email notifications to use DNN API and entity-based IPropertyAccess

## Changes made
- Add some new properties to be (edit user link, private message, etc.)
- Add new legacy mappings
- Add new \[FORUMAUTHOR:\*\] token support to mirror [FORUMUSER:*] but in context of an author
- Add new \[FORUMAUTHORUSER:\*\] token support to mirror [USER:*] but in context of an author
- Add new \[FORUMAUTHORMEMBERSHIP:\*\] token support to mirror [MEMBERSHIP:*] but in context of an author
- Add new \[FORUMAUTHORPROFILE:\*\] token support to mirror [PROFILE:*] but in context of an author
- Prevent HTML tags in email subject (#1127)


## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other
- [X] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1127 
Close #1128