### PR TITLE
ENH: Use token replacement for like buttons

### DIFF
--- a/Dnn.CommunityForums/App_LocalResources/LegacyTokenResources.resx
+++ b/Dnn.CommunityForums/App_LocalResources/LegacyTokenResources.resx
@@ -408,4 +408,13 @@
   <data name="[USERPMLINK].Text" xml:space="preserve">
     <value>&lt;img class='ComposeMessage' data-recipient='{{ "id": "user-{0}", "name": "[FORUMUSER:DISPLAYNAMEFORJSON]" }}' src='[FORUM:THEMELOCATION]images/icon_pm.png' alt="[RESX:SendPM]" title="[RESX:SendPM]" border="0" /&gt;</value>
   </data>
+  <data name="[LIKESx1].Text" xml:space="preserve">
+    <value>&lt;i id="af-topicview-likes-[FORUMPOST:CONTENTID]" class="fa [FORUMPOST:ISLIKED|fa-thumbs-o-up|fa-thumbs-up]" style="cursor: pointer" onclick="{0}"&gt; [FORUMPOST:LIKECOUNT]&lt;/i&gt;|&lt;i id="af-topicview-likes" class="fa [FORUMPOST:ISLIKED|fa-thumbs-o-up|fa-thumbs-up] fa-2x"&gt; [FORUMPOST:LIKECOUNT]&lt;/i&gt;</value>
+  </data>
+  <data name="[LIKESx2].Text" xml:space="preserve">
+    <value>&lt;i id="af-topicview-likes-[FORUMPOST:CONTENTID]" class="fa [FORUMPOST:ISLIKED|fa-thumbs-o-up|fa-thumbs-up] fa-2x" style="cursor: pointer" onclick="{0}"&gt; [FORUMPOST:LIKECOUNT]&lt;/i&gt;|&lt;i id="af-topicview-likes" class="fa [FORUMPOST:ISLIKED|fa-thumbs-o-up|fa-thumbs-up] fa-2x"&gt; [FORUMPOST:LIKECOUNT]&lt;/i&gt;</value>
+  </data>
+  <data name="[LIKESx3].Text" xml:space="preserve">
+    <value>&lt;i id="af-topicview-likes-[FORUMPOST:CONTENTID]" class="fa [FORUMPOST:ISLIKED|fa-thumbs-o-up|fa-thumbs-up] fa-3x" style="cursor: pointer" onclick="{0}"&gt; [FORUMPOST:LIKECOUNT]&lt;/i&gt;|&lt;i id="af-topicview-likes" class="fa [FORUMPOST:ISLIKED|fa-thumbs-o-up|fa-thumbs-up] fa-2x"&gt; [FORUMPOST:LIKECOUNT]&lt;/i&gt;</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/Controllers/LikeController.cs
+++ b/Dnn.CommunityForums/Controllers/LikeController.cs
@@ -18,21 +18,16 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
-using DotNetNuke.Data;
-
 namespace DotNetNuke.Modules.ActiveForums.Controllers
 {
+    using System.Collections.Generic;
+    using System.Linq;
+
     internal partial class LikeController : RepositoryControllerBase<DotNetNuke.Modules.ActiveForums.Entities.LikeInfo>
     {
-        public LikeController() : base() { }
-
         public bool GetForUser(int userId, int postId)
         {
-            return this.Find("WHERE PostId = @0 AND UserId = @1 AND Checked = 1", postId, userId).Any();
+            return userId > 0 && this.Find("WHERE PostId = @0 AND UserId = @1 AND Checked = 1", postId, userId).Any();
         }
 
         public (int count, bool liked) Get(int userId, int postId)
@@ -82,6 +77,11 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
 
 namespace DotNetNuke.Modules.ActiveForums
 {
+    using System;
+    using System.Collections.Generic;
+
+    using DotNetNuke.Data;
+
     [Obsolete("Deprecated in Community Forums. Scheduled removal in 09.00.00. Replace with DotNetNuke.Modules.ActiveForums.Controllers.LikeController")]
     class LikesController : DotNetNuke.Modules.ActiveForums.Controllers.LikeController
     {

--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
@@ -61,7 +61,6 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
         private int pageSize = 20;
         private int rowCount;
         private bool isTrusted;
-        private bool allowLikes;
         private bool isSubscribedTopic;
         private string defaultSort;
         private string tags = string.Empty;
@@ -326,7 +325,6 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
             this.topicTemplateId = Utilities.SafeConvertInt(this.drForum["TopicTemplateId"]);
             this.tags = this.drForum["Tags"].ToString();
-            this.allowLikes = Utilities.SafeConvertBool(this.drForum["AllowLikes"]);
             this.rowCount = Utilities.SafeConvertInt(this.drForum["ReplyCount"]) + 1;
             this.isSubscribedTopic = new DotNetNuke.Modules.ActiveForums.Controllers.SubscriptionController().Subscribed(this.PortalId, this.ForumModuleId, this.UserId, this.ForumInfo.ForumID, this.TopicId);
 
@@ -932,6 +930,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             sTopicTemplate = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.MapLegacyUserTokenSynonyms(new StringBuilder(sTopicTemplate), this.PortalSettings, this.MainSettings, this.ForumUser.UserInfo?.Profile?.PreferredLocale).ToString();
             sTopicTemplate = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.MapLegacyAuthorTokenSynonyms(new StringBuilder(sTopicTemplate), this.PortalSettings, this.MainSettings, this.ForumUser.UserInfo?.Profile?.PreferredLocale).ToString();
             sTopicTemplate = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.MapLegacyTopicTokenSynonyms(new StringBuilder(sTopicTemplate), this.PortalSettings, this.ForumUser.UserInfo?.Profile?.PreferredLocale).ToString();
+            sTopicTemplate = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.MapLegacyPostTokenSynonyms(new StringBuilder(sTopicTemplate), this.PortalSettings, this.ForumUser.UserInfo?.Profile?.PreferredLocale).ToString();
             sReplyTemplate = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.MapLegacyPostTokenSynonyms(new StringBuilder(sReplyTemplate), this.PortalSettings, this.ForumUser.UserInfo?.Profile?.PreferredLocale).ToString();
 
 #endregion "Backward compatilbility -- remove in v10.00.00"
@@ -1070,35 +1069,6 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 sbOutput.Replace("[POSTINFOCSS]", "afpostinfo afpostinfo2");
                 sbOutput.Replace("[POSTREPLYCSS]", "afpostreply afpostreply2");
             }
-
-            #region "likes"
-
-            if (this.allowLikes)
-            {
-                (int count, bool liked) likes = new DotNetNuke.Modules.ActiveForums.Controllers.LikeController().Get(this.UserId, (reply.ReplyId > 0 ? reply.ContentId : this.topic.ContentId));
-                string image = likes.liked ? "fa-thumbs-o-up" : "fa-thumbs-up";
-
-                if (this.CanReply)
-                {
-                    sbOutput = sbOutput.Replace("[LIKES]", "<i id=\"af-topicview-likes1-" + (reply.ReplyId > 0 ? reply.ContentId : this.topic.ContentId) + "\" class=\"fa " + image + "\" style=\"cursor:pointer\" onclick=\"amaf_likePost(" + this.ModuleId + "," + this.ForumId + "," + (reply.ReplyId > 0 ? reply.ContentId : this.topic.ContentId) + ")\" > " + likes.count.ToString() + "</i>");
-                    sbOutput = sbOutput.Replace("[LIKESx2]", "<i id=\"af-topicview-likes2-" + (reply.ReplyId > 0 ? reply.ContentId : this.topic.ContentId) + "\" class=\"fa " + image + " fa-2x\" style=\"cursor:pointer\" onclick=\"amaf_likePost(" + this.ModuleId + "," + this.ForumId + "," + (reply.ReplyId > 0 ? reply.ContentId : this.topic.ContentId) + ")\" > " + likes.count.ToString() + "</i>");
-                    sbOutput = sbOutput.Replace("[LIKESx3]", "<i id=\"af-topicview-likes3-" + (reply.ReplyId > 0 ? reply.ContentId : this.topic.ContentId) + "\" class=\"fa " + image + " fa-3x\" style=\"cursor:pointer\" onclick=\"amaf_likePost(" + this.ModuleId + "," + this.ForumId + "," + (reply.ReplyId > 0 ? reply.ContentId : this.topic.ContentId) + ")\" > " + likes.count.ToString() + "</i>");
-                }
-                else
-                {
-                    sbOutput = sbOutput.Replace("[LIKES]", "<i id=\"af-topicview-likes1\" class=\"fa " + image + "\" style=\"cursor:default\" > " + likes.count.ToString() + "</i>");
-                    sbOutput = sbOutput.Replace("[LIKESx2]", "<i id=\"af-topicview-likes2\" class=\"fa " + image + " fa-2x\" style=\"cursor:default\" > " + likes.count.ToString() + "</i>");
-                    sbOutput = sbOutput.Replace("[LIKESx3]", "<i id=\"af-topicview-likes3\" class=\"fa " + image + " fa-3x\" style=\"cursor:default\" > " + likes.count.ToString() + "</i>");
-                }
-            }
-            else
-            {
-                sbOutput = sbOutput.Replace("[LIKES]", string.Empty);
-                sbOutput = sbOutput.Replace("[LIKESx2]", string.Empty);
-                sbOutput = sbOutput.Replace("[LIKESx3]", string.Empty);
-            }
-
-            #endregion "likes"
 
             // Poll Results
             if (sOutput.Contains("[POLLRESULTS]"))

--- a/Dnn.CommunityForums/Entities/IPostInfo.cs
+++ b/Dnn.CommunityForums/Entities/IPostInfo.cs
@@ -50,6 +50,8 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
 
         string RawUrl { get; set; }
 
+        int LikeCount { get; }
+
         DotNetNuke.Modules.ActiveForums.Entities.AuthorInfo Author { get; set; }
 
         DotNetNuke.Modules.ActiveForums.Entities.ContentInfo Content { get; set; }
@@ -57,6 +59,8 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         DotNetNuke.Modules.ActiveForums.Entities.ForumInfo Forum { get; set; }
 
         DotNetNuke.Modules.ActiveForums.Entities.TopicInfo Topic { get; }
+
+        bool IsLikedByUser(DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo forumUser);
 
         DotNetNuke.Modules.ActiveForums.Enums.PostStatus GetPostStatusForUser(DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo forumUser);
 

--- a/Dnn.CommunityForums/scripts/afcommon.js
+++ b/Dnn.CommunityForums/scripts/afcommon.js
@@ -282,9 +282,12 @@ function amaf_likePost(mid, fid, cid) {
         url: dnn.getVar("sf_siteRoot", "/") + 'API/ActiveForums/Like/Like',
         beforeSend: sf.setModuleHeaders
     }).done(function (data) {
+        $('#af-topicview-likes-' + cid).toggleClass('fa-thumbs-up').toggleClass('fa-thumbs-o-up').text(" " + data);
+        /* these are for backward compatibility and can be remove in v10 */
         $('#af-topicview-likes1-' + cid).toggleClass('fa-thumbs-up').toggleClass('fa-thumbs-o-up').text(" " + data);
         $('#af-topicview-likes2-' + cid).toggleClass('fa-thumbs-up').toggleClass('fa-thumbs-o-up').text(" " + data);
         $('#af-topicview-likes3-' + cid).toggleClass('fa-thumbs-up').toggleClass('fa-thumbs-o-up').text(" " + data);
+        /* these are for backward compatibility and can be remove in v10 */
     }).fail(function (xhr, status) {
         alert('error liking post');
     });

--- a/Dnn.CommunityForums/themes/community-bootstrap/templates/TopicView.ascx
+++ b/Dnn.CommunityForums/themes/community-bootstrap/templates/TopicView.ascx
@@ -95,10 +95,10 @@
 									<div class="dcf-col-50">
                                         [FORUMPOST:MODEDITDATE]
 									</div>
-									<div class="dcf-col-50 text-right text-end dcf-post-likes">
-										[LIKESx2]
-									</div>
-								</div>
+                                    <div class="dcf-col-50 text-right text-end dcf-post-likes">
+                                        [FORUMPOST:LIKEONCLICK|<i id="af-topicview-likes-[FORUMPOST:CONTENTID]" class="fa [FORUMPOST:ISLIKED|fa-thumbs-o-up|fa-thumbs-up] fa-2x" style="cursor: pointer" onclick="{0}"> [FORUMPOST:LIKECOUNT]</i>|<i id="af-topicview-likes" class="fa [FORUMPOST:ISLIKED|fa-thumbs-o-up|fa-thumbs-up] fa-2x"> [FORUMPOST:LIKECOUNT]</i>]
+                                    </div>
+                                </div>
 							</footer>
 						</div>
 					</div>
@@ -145,9 +145,9 @@
 									<div class="dcf-col-50">
                                         [FORUMPOST:MODEDITDATE]
 									</div>
-									<div class="dcf-col-50 text-right text-end dcf-post-likes">
-										[LIKESx2]
-									</div>
+                                    <div class="dcf-col-50 text-right text-end dcf-post-likes">
+                                        [FORUMPOST:LIKEONCLICK|<i id="af-topicview-likes-[FORUMPOST:CONTENTID]" class="fa [FORUMPOST:ISLIKED|fa-thumbs-o-up|fa-thumbs-up] fa-2x" style="cursor: pointer" onclick="{0}"> [FORUMPOST:LIKECOUNT]</i>|<i id="af-topicview-likes" class="fa [FORUMPOST:ISLIKED|fa-thumbs-o-up|fa-thumbs-up] fa-2x"> [FORUMPOST:LIKECOUNT]</i>]
+                                    </div>
 								</div>
 							</footer>
 						</div>

--- a/Dnn.CommunityForums/themes/community-default/templates/TopicView.ascx
+++ b/Dnn.CommunityForums/themes/community-default/templates/TopicView.ascx
@@ -101,9 +101,9 @@
 									<div class="dcf-col-50">
                                         [FORUMPOST:MODEDITDATE]
 									</div>
-									<div class="dcf-col-50 dcf-text-end dcf-post-likes">
-										[LIKESx2]
-									</div>
+                                    <div class="dcf-col-50 dcf-text-end dcf-post-likes">
+                                        [FORUMPOST:LIKEONCLICK|<i id="af-topicview-likes-[FORUMPOST:CONTENTID]" class="fa [FORUMPOST:ISLIKED|fa-thumbs-o-up|fa-thumbs-up] fa-2x" style="cursor: pointer" onclick="{0}"> [FORUMPOST:LIKECOUNT]</i>|<i id="af-topicview-likes" class="fa [FORUMPOST:ISLIKED|fa-thumbs-o-up|fa-thumbs-up] fa-2x"> [FORUMPOST:LIKECOUNT]</i>]
+                                    </div>
 								</div>
 							</footer>
 						</div>
@@ -156,9 +156,9 @@
 									<div class="dcf-col-50">
                                         [FORUMPOST:MODEDITDATE]
 									</div>
-									<div class="dcf-col-50 dcf-text-end dcf-post-likes">
-										[LIKESx2]
-									</div>
+                                    <div class="dcf-col-50 dcf-text-end dcf-post-likes">
+                                        [FORUMPOST:LIKEONCLICK|<i id="af-topicview-likes-[FORUMPOST:CONTENTID]" class="fa [FORUMPOST:ISLIKED|fa-thumbs-o-up|fa-thumbs-up] fa-2x" style="cursor: pointer" onclick="{0}"> [FORUMPOST:LIKECOUNT]</i>|<i id="af-topicview-likes" class="fa [FORUMPOST:ISLIKED|fa-thumbs-o-up|fa-thumbs-up] fa-2x"> [FORUMPOST:LIKECOUNT]</i>]
+                                    </div>
 								</div>
 							</footer>
 						</div>


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Use token replacement for like buttons

## Changes made
- Add tokens:
  - `[FORUMPOST:LIKEONCLICK]` (inject UI code when like icon is clicked)
  - `[FORUMPOST:ISLIKED]` (to inject content if topic is/is not liked by user)
  - `[FORUMPOST:LIKECOUNT]` (to inject number of likes)
- Move HTML markup from C# code to delivered community templates
- Add legacy token mapping for `[LIKES], [LIKESx2], [LIKESx3]`

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1142