### PR TITLE
FIX: Move old /sql/sql/ files to /sql/

### DIFF
--- a/Dnn.CommunityForums/08.02.00.txt
+++ b/Dnn.CommunityForums/08.02.00.txt
@@ -21,3 +21,5 @@ DesktopModules/ActiveForums/themes/community-bootstrap/templates/PostPending.asc
 DesktopModules/ActiveForums/themes/community-bootstrap/templates/PostRejected.ascx
 DesktopModules/ActiveForums/themes/community-bootstrap/templates/SubscribedEmail.ascx
 DesktopModules/ActiveForums/themes/community-bootstrap/templates/Toolbar.ascx
+DesktopModules/ActiveForums/app.config
+DesktopModules/ActiveForums/packages.config

--- a/Dnn.CommunityForums/BuildScripts/ModulePackage.targets
+++ b/Dnn.CommunityForums/BuildScripts/ModulePackage.targets
@@ -60,7 +60,7 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       <InstallInclude Include="**\*.jpg" Exclude="packages\**;**\node_modules\**;clientApp\**;.git\**;.vs\**" />
       <InstallInclude Include="**\*.bmp" Exclude="packages\**;**\node_modules\**;clientApp\**;.git\**;.vs\**" />
 		<InstallInclude Include="**\*.xml" Exclude="packages\**;**\node_modules\**;clientApp\**;bin\**;.git\**;.vs\**;*.GhostDoc*" />
-		<InstallInclude Include="**\*.config" Exclude="packages\**;**\node_modules\**;clientApp\**;.git\**;.vs\**" />
+		<InstallInclude Include="**\*.config" Exclude="packages\**;**\node_modules\**;clientApp\**;.git\**;.vs\**;**\app.config;**\packages.config" />
     </ItemGroup>
 
     <CreateItem Include="$(DNNFileName).dnn">

--- a/Dnn.CommunityForums/class/ForumsConfig.cs
+++ b/Dnn.CommunityForums/class/ForumsConfig.cs
@@ -675,5 +675,51 @@ namespace DotNetNuke.Modules.ActiveForums
                 DotNetNuke.Services.Exceptions.Exceptions.LogException(ex);
             }
         }
+
+        internal static void Upgrade_RelocateSqlFiles_080200()
+        {
+            try
+            {
+                DotNetNuke.Services.Log.EventLog.LogInfo log;
+                string message;
+
+                var di = new System.IO.DirectoryInfo(Utilities.MapPath($"{Globals.ModulePath}sql/sql/"));
+                System.IO.DirectoryInfo[] themeFolders = di.GetDirectories();
+                foreach (var fullFilePathName in System.IO.Directory.EnumerateFiles(path: di.FullName, searchPattern: "*.SqlDataProvider", searchOption: System.IO.SearchOption.TopDirectoryOnly))
+                {
+                    if (fullFilePathName.ToLowerInvariant().Contains("uninstall"))
+                    {
+                        System.IO.File.Delete(fullFilePathName);
+                        log = new DotNetNuke.Services.Log.EventLog.LogInfo { LogTypeKey = DotNetNuke.Abstractions.Logging.EventLogType.ADMIN_ALERT.ToString() };
+                        log.LogProperties.Add(new LogDetailInfo("Module", Globals.ModuleFriendlyName));
+                        message = $"During upgrade, removed old file {fullFilePathName}";
+                        log.AddProperty("Message", message);
+                        DotNetNuke.Services.Log.EventLog.LogController.Instance.AddLog(log);
+                    }
+                    else
+                    {
+                        System.IO.File.Copy(fullFilePathName, $"{Utilities.MapPath($"{Globals.ModulePath}sql/{new System.IO.FileInfo(fullFilePathName).Name}")}", true);
+                        System.IO.File.Delete(fullFilePathName);
+                        log = new DotNetNuke.Services.Log.EventLog.LogInfo { LogTypeKey = DotNetNuke.Abstractions.Logging.EventLogType.ADMIN_ALERT.ToString() };
+                        log.LogProperties.Add(new LogDetailInfo("Module", Globals.ModuleFriendlyName));
+                        message = $"During upgrade, moved {fullFilePathName} to {Utilities.MapPath($"{Globals.ModulePath}sql/{new System.IO.FileInfo(fullFilePathName).Name}")}";
+                        log.AddProperty("Message", message);
+                        DotNetNuke.Services.Log.EventLog.LogController.Instance.AddLog(log);
+                    }
+
+                }
+
+                di.Delete();
+                log = new DotNetNuke.Services.Log.EventLog.LogInfo { LogTypeKey = DotNetNuke.Abstractions.Logging.EventLogType.ADMIN_ALERT.ToString() };
+                log.LogProperties.Add(new LogDetailInfo("Module", Globals.ModuleFriendlyName));
+                message = $"During upgrade, removed {di.FullName}";
+                log.AddProperty("Message", message);
+                DotNetNuke.Services.Log.EventLog.LogController.Instance.AddLog(log);
+            }
+            catch (Exception ex)
+            {
+                DotNetNuke.Services.Exceptions.Exceptions.LogException(ex);
+            }
+        }
     }
 }

--- a/Dnn.CommunityForums/components/Topics/TopicsController.cs
+++ b/Dnn.CommunityForums/components/Topics/TopicsController.cs
@@ -290,6 +290,7 @@ namespace DotNetNuke.Modules.ActiveForums
                         ForumsConfig.Merge_Permissions_080200();
                         DotNetNuke.Modules.ActiveForums.Helpers.UpgradeModuleSettings.UpgradeSocialGroupForumConfigModuleSettings_080200();
                         ForumsConfig.Upgrade_EmailNotificationSubjectTokens_080200();
+                        ForumsConfig.Upgrade_RelocateSqlFiles_080200();
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
In some old versions, SqlDataProvider files were installed to /sql/sql/ rather than just /sql/.
This PR moves the files, removes the /sql/sql/ folder, and logs to admin log.


## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install;
![image](https://github.com/user-attachments/assets/5a4ccb45-a706-43ba-b09f-417b5dda399e)
![image](https://github.com/user-attachments/assets/73cd8a41-2dda-4310-9d5f-228290a7d283)

## PR Template Checklist

- [ ] Fixes Bug
- [ ] Feature solution
- [X] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #247