### PR TITLE
TASK: replace forum group delete stored procedure with DAL2

### DIFF
--- a/Dnn.CommunityForums/Controllers/ForumController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumController.cs
@@ -242,7 +242,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             {
                 DataContext.Instance().Execute(System.Data.CommandType.Text, "DELETE FROM {databaseOwner}{objectQualifier}activeforums_Settings WHERE ModuleId = @0 AND GroupKey = @1", fi.ModuleId, $"F:{fi.ForumID}");
             }
-            
+
             // for new forum not using group features, set defaults
             if (isNew && useGroupFeatures == false)
             {
@@ -260,14 +260,17 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             // Clear the caches
             DotNetNuke.Modules.ActiveForums.DataCache.ClearSettingsCache(fi.ModuleId);
             return forumId;
-        }
+        } 
 
-        public void Forums_Delete(int portalId, int forumId, int moduleId)
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
+        public void Forums_Delete(int portalId, int forumId, int moduleId) => Forums_Delete(forumId: forumId, moduleId: moduleId)
+
+        internal void Forums_Delete(int forumId, int moduleId)
         {
             var parentForumId = this.GetById(forumId, moduleId).ParentForumId;
             new DotNetNuke.Modules.ActiveForums.Controllers.ForumTopicController().DeleteForForum(forumId);
             new DotNetNuke.Modules.ActiveForums.Controllers.SubscriptionController().DeleteForForum(forumId);
-            base.DeleteById(forumId);
+            this.DeleteById(forumId);
             DataContext.Instance().Execute(System.Data.CommandType.StoredProcedure, "{databaseOwner}{objectQualifier}activeforums_Forums_RepairSort", forumId, parentForumId);
             DotNetNuke.Modules.ActiveForums.DataCache.ClearSettingsCache(moduleId);
         }

--- a/Dnn.CommunityForums/Providers/DataProviders/SqlDataProvider/SqlDataProvider.cs
+++ b/Dnn.CommunityForums/Providers/DataProviders/SqlDataProvider/SqlDataProvider.cs
@@ -217,6 +217,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
         #endregion
         #region Groups
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. No longer used.")]
         public override void Groups_Delete(int ModuleID, int ForumGroupID)
         {
             SqlHelper.ExecuteNonQuery(this.ConnectionString, this.DatabaseOwner + this.ObjectQualifier + "activeforums_Groups_Delete", ModuleID, ForumGroupID);
@@ -239,9 +240,15 @@ namespace DotNetNuke.Modules.ActiveForums
             SqlHelper.ExecuteNonQuery(this.ConnectionString, this.DatabaseOwner + this.ObjectQualifier + "activeforums_Groups_MoveGroup", ModuleId, ForumGroupId, SortDirection);
         }
 
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. No longer used.")]
         public override int Groups_Save(int PortalId, int ModuleId, int ForumGroupId, string GroupName, int SortOrder, bool Active, bool Hidden, int PermissionsId, string PrefixURL)
         {
-            return Convert.ToInt32(SqlHelper.ExecuteScalar(this.ConnectionString, this.DatabaseOwner + this.ObjectQualifier + "activeforums_Groups_Save", PortalId, ModuleId, ForumGroupId, GroupName, SortOrder, Active, Hidden, PermissionsId, PrefixURL));
+            return Convert.ToInt32(SqlHelper.ExecuteScalar(this.ConnectionString, this.DatabaseOwner + this.ObjectQualifier + "activeforums_Groups_Save", PortalId, ModuleId, ForumGroupId, GroupName, SortOrder, Active, Hidden, PermissionsId, PrefixURL, $"G:{ForumGroupId}"));
+        }
+
+        public override int Groups_Save(int PortalId, int ModuleId, int ForumGroupId, string GroupName, int SortOrder, bool Active, bool Hidden, int PermissionsId, string PrefixURL, string GroupSettingsKey)
+        {
+            return Convert.ToInt32(SqlHelper.ExecuteScalar(this.ConnectionString, this.DatabaseOwner + this.ObjectQualifier + "activeforums_Groups_Save", PortalId, ModuleId, ForumGroupId, GroupName, SortOrder, Active, Hidden, PermissionsId, PrefixURL, GroupSettingsKey));
         }
 
         #endregion

--- a/Dnn.CommunityForums/class/DataProvider.cs
+++ b/Dnn.CommunityForums/class/DataProvider.cs
@@ -91,6 +91,7 @@ namespace DotNetNuke.Modules.ActiveForums
         #endregion
 
         #region Groups
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
         public abstract void Groups_Delete(int moduleID, int forumGroupID);
 
         [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. No longer used.")]
@@ -101,7 +102,10 @@ namespace DotNetNuke.Modules.ActiveForums
 
         public abstract void Groups_Move(int moduleId, int forumGroupId, int sortDirection);
 
+        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
         public abstract int Groups_Save(int portalId, int moduleId, int forumGroupId, string groupName, int sortOrder, bool active, bool hidden, int permissionsId, string prefixURL);
+
+        public abstract int Groups_Save(int portalId, int moduleId, int forumGroupId, string groupName, int sortOrder, bool active, bool hidden, int permissionsId, string prefixURL, string groupSettingsKey);
         #endregion
 
         #region Polls

--- a/Dnn.CommunityForums/controls/admin_manageforums_forumeditor.ascx.cs
+++ b/Dnn.CommunityForums/controls/admin_manageforums_forumeditor.ascx.cs
@@ -338,7 +338,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 case "deleteforum":
                     {
                         var forumId = Utilities.SafeConvertInt(e.Parameters[1]);
-                        new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().Forums_Delete(portalId: this.PortalId, moduleId: this.ModuleId, forumId: forumId);
+                        new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().Forums_Delete(moduleId: this.ModuleId, forumId: forumId);
                         break;
                     }
 

--- a/Dnn.CommunityForums/sql/08.02.00.SqlDataProvider
+++ b/Dnn.CommunityForums/sql/08.02.00.SqlDataProvider
@@ -2196,3 +2196,62 @@ GO
 /* issue 1156 - end - deleting a forum should remove subscriptions */
 
 /* --------------------- */
+
+/* issue 1162 - begin - pass group setting key to Groups_Save */
+
+/* activeforums_Groups_Save -- pass group setting key to Groups_Save */
+IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_Groups_Save]') AND type in (N'P', N'PC'))
+DROP PROCEDURE {databaseOwner}[{objectQualifier}activeforums_Groups_Save]
+GO
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}activeforums_Groups_Save]
+@PortalId int,
+@ModuleId int,
+@ForumGroupId int,
+@GroupName nvarchar(150),
+@SortOrder int,
+@Active bit,
+@Hidden bit,
+@PermissionsId int,
+@PrefixURL nvarchar(50),
+@GroupSettingsKey varchar(255) = ''
+AS
+IF @PrefixURL <> '' AND @ForumGroupId >0
+	BEGIN
+		DECLARE @currURL nvarchar(1000)
+		SET @currURL = {databaseOwner}{objectQualifier}fn_activeforums_GetURL(@ModuleId,@ForumGroupId, -1,-1,-1,-1)
+		DECLARE @newURL nvarchar(1000)
+		SET @currURL = {databaseOwner}{objectQualifier}fn_activeforums_GetURL(@ModuleId,-1, -1,-1,-1,-1) + @PrefixURL + '/'
+	IF LTRIM(RTRIM(LOWER(@newURL))) <> LTRIM(RTRIM(LOWER(@currURL)))
+		BEGIN
+			exec {databaseOwner}{objectQualifier}activeforums_URL_Archive @PortalId,@ForumGroupId, -1, -1, @currURL
+		END
+	END
+IF EXISTS(Select ForumGroupId FROM {databaseOwner}{objectQualifier}activeforums_Groups WHERE ForumGroupId = @ForumGroupId AND ModuleId = @ModuleId)
+	UPDATE {databaseOwner}{objectQualifier}activeforums_Groups
+	SET GroupName=@GroupName, Active=@Active,Hidden=@Hidden, PermissionsId = @PermissionsId,PrefixURL = @PrefixURL
+	WHERE ForumGroupId = @ForumGroupId and ModuleId = @ModuleId
+ELSE
+	BEGIN
+		BEGIN
+			SELECT @SortOrder = Max(SortOrder) + 1 From {databaseOwner}{objectQualifier}activeforums_Groups WHERE ModuleID=@ModuleID
+				If @SortOrder IS NULL 
+					SET @SortOrder = 1
+			END
+		INSERT INTO {databaseOwner}{objectQualifier}activeforums_Groups
+		(ModuleId, GroupName, SortOrder,GroupSettingsKey,Active,Hidden, PermissionsId,PrefixURL)
+		VALUES
+		(@ModuleId, @GroupName, @SortOrder,'',@Active,@Hidden, @PermissionsId,@PrefixURL)
+		SET @ForumGroupId = SCOPE_IDENTITY()
+        BEGIN
+			IF @GroupSettingsKey = ''
+				UPDATE {databaseOwner}{objectQualifier}activeforums_Groups SET GroupSettingsKey = 'G:' + CAST(@ForumGroupId as varchar(50)) WHERE ForumGroupId = @ForumGroupId
+			ELSE
+				UPDATE {databaseOwner}{objectQualifier}activeforums_Groups SET GroupSettingsKey = GroupSettingsKey WHERE ForumGroupId = @ForumGroupId
+		END
+	END
+SELECT @ForumGroupId
+GO
+
+/* issue 1162 - end - adds group setting key to Groups_Save */
+
+/* --------------------- */


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Move some forum group table CRUD methods from stored procedures to use DAL2 controller/object

## Changes made
- Update code using sproc methods to use DAL2 controller/object
- Pass group settings key to `Groups_Save` rather than calculate it in stored procedure
- Mark for deprecation
   - `Groups_Delete`

NOTE: Leaving `Groups_Save` for future.

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
local install

## PR Template Checklist

- [ ] Fixes Bug
- [ ] Feature solution
- [X] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1162