### PR TITLE
Add StripQuoteTag utility method and use it when posting to journal (…

### DIFF
--- a/Dnn.CommunityForums/ActiveForumViewerSettings.ascx.cs
+++ b/Dnn.CommunityForums/ActiveForumViewerSettings.ascx.cs
@@ -18,11 +18,10 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System.Linq;
-
 namespace DotNetNuke.Modules.ActiveForums
 {
     using System;
+    using System.Linq;
     using System.Linq;
     using System.Web.UI.WebControls;
 

--- a/Dnn.CommunityForums/Controllers/EmailController.cs
+++ b/Dnn.CommunityForums/Controllers/EmailController.cs
@@ -18,8 +18,6 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System.Runtime.CompilerServices;
-
 namespace DotNetNuke.Modules.ActiveForums.Controllers
 {
     using System;
@@ -28,6 +26,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
     using System.Linq;
     using System.Net.Mail;
     using System.Reflection;
+    using System.Runtime.CompilerServices;
     using System.Security.AccessControl;
     using System.Threading;
     using System.Web;

--- a/Dnn.CommunityForums/Controllers/ForumController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumController.cs
@@ -494,7 +494,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
 
         internal static string GetLastPostSubjectLinkTag(DotNetNuke.Modules.ActiveForums.Entities.IPostInfo lastPost, int length, DotNetNuke.Modules.ActiveForums.Entities.ForumInfo fi, int tabId)
         {
-            string subject = Utilities.StripHTMLTag(System.Web.HttpUtility.HtmlDecode(lastPost.Topic.Subject)).Replace("[", "&#91").Replace("]", "&#93");
+            string subject = Utilities.StripHTMLTag(System.Net.WebUtility.HtmlDecode(lastPost.Topic.Subject)).Replace("[", "&#91").Replace("]", "&#93");
             if (subject.Length > length & length > 0)
             {
                 subject = subject.Substring(0, length) + "...";
@@ -510,7 +510,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                 sURL += Utilities.UseFriendlyURLs(fi.ModuleId) ? $"#{lastPost.PostId}" : $"?{ParamKeys.ContentJumpId}={lastPost.PostId}";
             }
 
-            return $"<a href=\"{sURL}\">{System.Web.HttpUtility.HtmlEncode(subject)}</a>";
+            return $"<a href=\"{sURL}\">{System.Net.WebUtility.HtmlEncode(subject)}</a>";
         }
     }
 }

--- a/Dnn.CommunityForums/Controllers/ForumGroupController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumGroupController.cs
@@ -18,11 +18,11 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System.Linq;
-
 namespace DotNetNuke.Modules.ActiveForums.Controllers
 {
     using System.Collections;
+    using System.Linq;
+
     using DotNetNuke.Data;
     using DotNetNuke.Modules.ActiveForums.Entities;
 

--- a/Dnn.CommunityForums/Controllers/ForumTrackingController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumTrackingController.cs
@@ -18,11 +18,10 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System.Collections.Generic;
-
 namespace DotNetNuke.Modules.ActiveForums.Controllers
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
 
     internal class ForumTrackingController : DotNetNuke.Modules.ActiveForums.Controllers.RepositoryControllerBase<DotNetNuke.Modules.ActiveForums.Entities.ForumTrackingInfo>

--- a/Dnn.CommunityForums/Controllers/ForumUserController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumUserController.cs
@@ -405,7 +405,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             }
 
             var outputName = GetDisplayName(portalSettings, mainSettings, isMod, isAdmin, userId, username, firstName, lastName, displayName);
-            outputName = HttpUtility.HtmlEncode(outputName);
+            outputName = System.Net.WebUtility.HtmlEncode(outputName);
 
             return string.Format(outputTemplate, outputName);
         }
@@ -534,7 +534,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                 outputName = userId > 0 ? Utilities.GetSharedResource("[RESX:DeletedUser]") : Utilities.GetSharedResource("[RESX:Anonymous]");
             }
 
-            return HttpUtility.HtmlEncode(outputName);
+            return System.Net.WebUtility.HtmlEncode(outputName);
         }
 
         internal static string UserStatus(string themePath, bool isUserOnline, int userID, int moduleID)

--- a/Dnn.CommunityForums/Controllers/PropertyController.cs
+++ b/Dnn.CommunityForums/Controllers/PropertyController.cs
@@ -67,7 +67,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                 sb.Append(",");
                 sb.Append(Utilities.JSON.Pair("IsRequired", p.IsRequired.ToString().ToLowerInvariant()));
                 sb.Append(",");
-                sb.Append(Utilities.JSON.Pair("ValidationExpression", HttpUtility.UrlEncode(HttpUtility.HtmlEncode(p.ValidationExpression.ToString()))));
+                sb.Append(Utilities.JSON.Pair("ValidationExpression", System.Net.WebUtility.UrlEncode(System.Net.WebUtility.HtmlEncode(p.ValidationExpression.ToString()))));
                 sb.Append(",");
                 sb.Append(Utilities.JSON.Pair("ViewTemplate", p.ViewTemplate.ToString()));
                 sb.Append(",");
@@ -77,7 +77,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                 sb.Append(",");
                 sb.Append(Utilities.JSON.Pair("DefaultValue", p.DefaultValue.ToString()));
                 sb.Append(",");
-                sb.Append(Utilities.JSON.Pair("Label", HttpUtility.HtmlEncode("[RESX:" + p.Name + "]")));
+                sb.Append(Utilities.JSON.Pair("Label", System.Net.WebUtility.HtmlEncode("[RESX:" + p.Name + "]")));
                 sb.Append("},");
             }
 

--- a/Dnn.CommunityForums/Controllers/TokenController.cs
+++ b/Dnn.CommunityForums/Controllers/TokenController.cs
@@ -41,6 +41,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
     using System;
     using System.Collections.Generic;
     using System.Web;
+
     using DotNetNuke.Modules.ActiveForums.Entities;
 
 #pragma warning disable SA1402 // File may only contain a single type
@@ -85,11 +86,11 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                                 };
                                 if (xNodeList[i].Attributes["value"] != null)
                                 {
-                                    tk.TokenReplace = HttpUtility.HtmlDecode(xNodeList[i].Attributes["value"].Value);
+                                    tk.TokenReplace = System.Net.WebUtility.HtmlDecode(xNodeList[i].Attributes["value"].Value);
                                 }
                                 else
                                 {
-                                    tk.TokenReplace = HttpUtility.HtmlDecode(xNodeList[i].ChildNodes[0].InnerText);
+                                    tk.TokenReplace = System.Net.WebUtility.HtmlDecode(xNodeList[i].ChildNodes[0].InnerText);
                                 }
 
                                 li.Add(tk);

--- a/Dnn.CommunityForums/Controllers/TopicController.cs
+++ b/Dnn.CommunityForums/Controllers/TopicController.cs
@@ -32,6 +32,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
     using System.Web.Http.Controllers;
     using System.Xml.Linq;
 
+    using DotNetNuke.Common.Utilities;
     using DotNetNuke.Data;
     using DotNetNuke.Entities.Users;
     using DotNetNuke.Modules.ActiveForums.API;
@@ -102,23 +103,26 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
 
         public static void Replies_Split(int oldTopicId, int newTopicId, string listreplies, bool isNew)
         {
-            Regex rgx = new Regex(@"^\d+(\|\d+)*$");
-            if (oldTopicId > 0 && newTopicId > 0 && rgx.IsMatch(listreplies))
+            if (oldTopicId > 0 && newTopicId > 0)
             {
-                if (isNew)
+                var pattern = @"^\d+(\|\d+)*$";
+                if (RegexUtils.GetCachedRegex(pattern).IsMatch(listreplies))
                 {
-                    string[] slistreplies = listreplies.Split("|".ToCharArray(), 2);
-                    string str = string.Empty;
-                    if (slistreplies.Length > 1)
+                    if (isNew)
                     {
-                        str = slistreplies[1];
-                    }
+                        string[] slistreplies = listreplies.Split("|".ToCharArray(), 2);
+                        string str = string.Empty;
+                        if (slistreplies.Length > 1)
+                        {
+                            str = slistreplies[1];
+                        }
 
-                    DotNetNuke.Modules.ActiveForums.DataProvider.Instance().Replies_Split(oldTopicId, newTopicId, str, DateTime.Now, Convert.ToInt32(slistreplies[0]));
-                }
-                else
-                {
-                    DotNetNuke.Modules.ActiveForums.DataProvider.Instance().Replies_Split(oldTopicId, newTopicId, listreplies, DateTime.Now, 0);
+                        DotNetNuke.Modules.ActiveForums.DataProvider.Instance().Replies_Split(oldTopicId, newTopicId, str, DateTime.Now, Convert.ToInt32(slistreplies[0]));
+                    }
+                    else
+                    {
+                        DotNetNuke.Modules.ActiveForums.DataProvider.Instance().Replies_Split(oldTopicId, newTopicId, listreplies, DateTime.Now, 0);
+                    }
                 }
             }
         }
@@ -135,10 +139,10 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             DotNetNuke.Modules.ActiveForums.Controllers.TopicController.Save(ti);
             DotNetNuke.Modules.ActiveForums.Controllers.TopicController.SaveToForum(ti.ModuleId, ti.ForumId, topicId);
 
-            DataCache.ContentCacheClear(ti.ModuleId, string.Format(CacheKeys.ForumInfo, ti.ModuleId, ti.ForumId));
-            DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.ForumViewPrefix, ti.ModuleId));
-            DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.TopicViewPrefix, ti.ModuleId));
-            DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.TopicsViewPrefix, ti.ModuleId));
+            DotNetNuke.Modules.ActiveForums.DataCache.ContentCacheClear(ti.ModuleId, string.Format(CacheKeys.ForumInfo, ti.ModuleId, ti.ForumId));
+            DotNetNuke.Modules.ActiveForums.DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.ForumViewPrefix, ti.ModuleId));
+            DotNetNuke.Modules.ActiveForums.DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.TopicViewPrefix, ti.ModuleId));
+            DotNetNuke.Modules.ActiveForums.DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.TopicsViewPrefix, ti.ModuleId));
 
             if (ti.Forum.FeatureSettings.ModApproveTemplateId > 0 & ti.Author.AuthorId > 0)
             {
@@ -188,10 +192,10 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             new DotNetNuke.Modules.ActiveForums.Controllers.ProcessQueueController().Add(ProcessType.UpdateForumLastUpdated, ti.PortalId, tabId: -1, moduleId: ti.ModuleId, forumGroupId: oldForum.ForumGroupId, forumId: oldForum.ForumID, topicId: topicId, replyId: -1, authorId: ti.Content.AuthorId, requestUrl: null);
             new DotNetNuke.Modules.ActiveForums.Controllers.ProcessQueueController().Add(ProcessType.UpdateForumLastUpdated, ti.PortalId, tabId: -1, moduleId: ti.ModuleId, forumGroupId: newForum.ForumGroupId, forumId: newForum.ForumID, topicId: topicId, replyId: -1, authorId: ti.Content.AuthorId, requestUrl: null);
             Utilities.UpdateModuleLastContentModifiedOnDate(ti.ModuleId);
-            DataCache.ContentCacheClear(ti.ModuleId, string.Format(CacheKeys.ForumInfo, ti.ModuleId, ti.ForumId));
-            DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.ForumViewPrefix, ti.ModuleId));
-            DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.TopicViewPrefix, ti.ModuleId));
-            DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.TopicsViewPrefix, ti.ModuleId));
+            DotNetNuke.Modules.ActiveForums.DataCache.ContentCacheClear(ti.ModuleId, string.Format(CacheKeys.ForumInfo, ti.ModuleId, ti.ForumId));
+            DotNetNuke.Modules.ActiveForums.DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.ForumViewPrefix, ti.ModuleId));
+            DotNetNuke.Modules.ActiveForums.DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.TopicViewPrefix, ti.ModuleId));
+            DotNetNuke.Modules.ActiveForums.DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.TopicsViewPrefix, ti.ModuleId));
         }
 
         public static void SaveToForum(int moduleId, int forumId, int topicId, int lastReplyId = -1)
@@ -199,10 +203,10 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             DotNetNuke.Modules.ActiveForums.DataProvider.Instance().Topics_SaveToForum(forumId, topicId, lastReplyId);
             Utilities.UpdateModuleLastContentModifiedOnDate(moduleId);
             DotNetNuke.Modules.ActiveForums.Controllers.ForumController.UpdateForumLastUpdates(forumId);
-            DataCache.ContentCacheClear(moduleId, string.Format(CacheKeys.ForumInfo, moduleId, forumId));
-            DataCache.CacheClearPrefix(moduleId, string.Format(CacheKeys.ForumViewPrefix, moduleId));
-            DataCache.CacheClearPrefix(moduleId, string.Format(CacheKeys.TopicViewPrefix, moduleId));
-            DataCache.CacheClearPrefix(moduleId, string.Format(CacheKeys.TopicsViewPrefix, moduleId));
+            DotNetNuke.Modules.ActiveForums.DataCache.ContentCacheClear(moduleId, string.Format(CacheKeys.ForumInfo, moduleId, forumId));
+            DotNetNuke.Modules.ActiveForums.DataCache.CacheClearPrefix(moduleId, string.Format(CacheKeys.ForumViewPrefix, moduleId));
+            DotNetNuke.Modules.ActiveForums.DataCache.CacheClearPrefix(moduleId, string.Format(CacheKeys.TopicViewPrefix, moduleId));
+            DotNetNuke.Modules.ActiveForums.DataCache.CacheClearPrefix(moduleId, string.Format(CacheKeys.TopicsViewPrefix, moduleId));
         }
 
         public static int Save(DotNetNuke.Modules.ActiveForums.Entities.TopicInfo ti)
@@ -221,10 +225,10 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             
             DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.ClearCache(ti.Forum.PortalId, ti.Content.AuthorId);
             Utilities.UpdateModuleLastContentModifiedOnDate(ti.ModuleId);
-            DataCache.ContentCacheClear(ti.ModuleId, string.Format(CacheKeys.ForumInfo, ti.ModuleId, ti.ForumId));
-            DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.ForumViewPrefix, ti.ModuleId));
-            DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.TopicViewPrefix, ti.ModuleId));
-            DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.TopicsViewPrefix, ti.ModuleId));
+            DotNetNuke.Modules.ActiveForums.DataCache.ContentCacheClear(ti.ModuleId, string.Format(CacheKeys.ForumInfo, ti.ModuleId, ti.ForumId));
+            DotNetNuke.Modules.ActiveForums.DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.ForumViewPrefix, ti.ModuleId));
+            DotNetNuke.Modules.ActiveForums.DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.TopicViewPrefix, ti.ModuleId));
+            DotNetNuke.Modules.ActiveForums.DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.TopicsViewPrefix, ti.ModuleId));
 
             // if existing topic, update associated journal item
             if (ti.TopicId > 0)
@@ -246,10 +250,10 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
 
                 DotNetNuke.Modules.ActiveForums.DataProvider.Instance().Topics_Delete(ti.ForumId, topicId, SettingsBase.GetModuleSettings(ti.ModuleId).DeleteBehavior );
                 Utilities.UpdateModuleLastContentModifiedOnDate(ti.ModuleId);
-                DataCache.ContentCacheClear(ti.ModuleId, string.Format(CacheKeys.ForumInfo, ti.ModuleId, ti.ForumId));
-                DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.ForumViewPrefix, ti.ModuleId));
-                DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.TopicViewPrefix, ti.ModuleId));
-                DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.TopicsViewPrefix, ti.ModuleId));
+                DotNetNuke.Modules.ActiveForums.DataCache.ContentCacheClear(ti.ModuleId, string.Format(CacheKeys.ForumInfo, ti.ModuleId, ti.ForumId));
+                DotNetNuke.Modules.ActiveForums.DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.ForumViewPrefix, ti.ModuleId));
+                DotNetNuke.Modules.ActiveForums.DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.TopicViewPrefix, ti.ModuleId));
+                DotNetNuke.Modules.ActiveForums.DataCache.CacheClearPrefix(ti.ModuleId, string.Format(CacheKeys.TopicsViewPrefix, ti.ModuleId));
 
                 if (SettingsBase.GetModuleSettings(ti.ModuleId).DeleteBehavior != 0)
                 {

--- a/Dnn.CommunityForums/Controllers/TopicPropertyController.cs
+++ b/Dnn.CommunityForums/Controllers/TopicPropertyController.cs
@@ -74,8 +74,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                     int i = 0;
                     for (i = 0; i < xNodeList.Count; i++)
                     {
-                        string pName = System.Web.HttpUtility.HtmlDecode(xNodeList[i].ChildNodes[0].InnerText);
-                        string pValue = System.Web.HttpUtility.HtmlDecode(xNodeList[i].ChildNodes[1].InnerText);
+                        string pName = System.Net.WebUtility.HtmlDecode(xNodeList[i].ChildNodes[0].InnerText);
+                        string pValue = System.Net.WebUtility.HtmlDecode(xNodeList[i].ChildNodes[1].InnerText);
                         int pId = Convert.ToInt32(xNodeList[i].Attributes["id"].Value);
                         DotNetNuke.Modules.ActiveForums.Entities.TopicPropertyInfo p = new DotNetNuke.Modules.ActiveForums.Entities.TopicPropertyInfo();
                         p.Name = pName;

--- a/Dnn.CommunityForums/Controllers/TopicTrackingController.cs
+++ b/Dnn.CommunityForums/Controllers/TopicTrackingController.cs
@@ -18,16 +18,16 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System.Collections.Generic;
-using System.Xml;
-using DotNetNuke.Data;
-
 namespace DotNetNuke.Modules.ActiveForums.Controllers
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
+    using System.Xml;
+
+    using DotNetNuke.Data;
     using DotNetNuke.Data;
     using DotNetNuke.Modules.ActiveForums.Entities;
 

--- a/Dnn.CommunityForums/CustomControls/HTML/ControlPanel.cs
+++ b/Dnn.CommunityForums/CustomControls/HTML/ControlPanel.cs
@@ -18,14 +18,13 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System.Linq;
-
 namespace DotNetNuke.Modules.ActiveForums.Controls
 {
     using System;
     using System.Collections;
     using System.Collections.Generic;
     using System.Data;
+    using System.Linq;
     using System.Text;
 
     public class ControlPanel

--- a/Dnn.CommunityForums/CustomControls/ServerControls/Callback.cs
+++ b/Dnn.CommunityForums/CustomControls/ServerControls/Callback.cs
@@ -369,7 +369,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
         public string XSSFilter(string sText)
         {
-            sText = HttpUtility.UrlDecode(sText);
+            sText = System.Net.WebUtility.UrlDecode(sText);
             string pattern = "<script.*/*>|</script>|<[a-zA-Z][^>]*=['\"]+javascript:\\w+.*['\"]+>|<\\w+[^>]*\\son\\w+=.*[ /]*>";
             return RegexUtils.GetCachedRegex(pattern, RegexOptions.Compiled & RegexOptions.IgnoreCase, 2).Replace(sText, string.Empty).Replace("-->", string.Empty).Replace("<!--", string.Empty);
         }

--- a/Dnn.CommunityForums/CustomControls/ServerControls/ForumGroupRepeater.cs
+++ b/Dnn.CommunityForums/CustomControls/ServerControls/ForumGroupRepeater.cs
@@ -18,12 +18,11 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System.Linq;
-
 namespace DotNetNuke.Modules.ActiveForums.Controls
 {
     using System;
     using System.ComponentModel;
+    using System.Linq;
     using System.Linq;
     using System.Web.UI;
 

--- a/Dnn.CommunityForums/CustomControls/ServerControls/TagCloud.cs
+++ b/Dnn.CommunityForums/CustomControls/ServerControls/TagCloud.cs
@@ -94,7 +94,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 writer.Write("<a href=\"");
                 sURL = ctlUtils.BuildUrl(this.PortalId, this.TabId, this.ModuleId, string.Empty, string.Empty, -1, -1, int.Parse(dr["TagID"].ToString()), -1, Utilities.CleanName(tagName), 1, -1, -1);
                 writer.Write(sURL);
-                writer.Write("\" title=\"" + HttpUtility.HtmlAttributeEncode(tagName) + "\">" + tagName + "</a></span> ");
+                writer.Write("\" title=\"" + System.Net.WebUtility.HtmlEncode(tagName) + "\">" + tagName + "</a></span> ");
             }
 
             dr.Close();

--- a/Dnn.CommunityForums/CustomControls/UserControls/ForumView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/ForumView.cs
@@ -18,8 +18,6 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using DotNetNuke.Common.Utilities;
-
 namespace DotNetNuke.Modules.ActiveForums.Controls
 {
     using System;
@@ -32,6 +30,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
     using System.Web;
     using System.Web.UI;
     using System.Web.UI.WebControls;
+
+    using DotNetNuke.Common.Utilities;
 
     [DefaultProperty("Text"), ToolboxData("<{0}:ForumView runat=server></{0}:ForumView>")]
     public class ForumView : ForumBase
@@ -206,7 +206,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     if (this.Forums == null)
                     {
                         string cachekey = string.Format(CacheKeys.ForumViewForUser, this.ForumModuleId, this.ForumUser.UserId, this.ForumIds, HttpContext.Current?.Response?.Cookies["language"]?.Value);
-                        var obj = DataCache.ContentCacheRetrieve(this.ForumModuleId, cachekey);
+                        var obj = DotNetNuke.Modules.ActiveForums.DataCache.ContentCacheRetrieve(this.ForumModuleId, cachekey);
                         if (obj == null)
                         {
                             this.Forums = new DotNetNuke.Modules.ActiveForums.Entities.ForumCollection();
@@ -215,7 +215,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                                 this.Forums.Add(new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().GetById(Utilities.SafeConvertInt(forumId), this.ForumModuleId));
                             }
 
-                            DataCache.ContentCacheStore(this.ForumModuleId, cachekey, this.Forums);
+                            DotNetNuke.Modules.ActiveForums.DataCache.ContentCacheStore(this.ForumModuleId, cachekey, this.Forums);
                         }
                         else
                         {

--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
@@ -18,9 +18,6 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using DotNetNuke.Modules.ActiveForums.Entities;
-using DotNetNuke.Services.Localization;
-
 namespace DotNetNuke.Modules.ActiveForums.Controls
 {
     using System;
@@ -38,8 +35,10 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Instrumentation;
     using DotNetNuke.Modules.ActiveForums.Constants;
+    using DotNetNuke.Modules.ActiveForums.Entities;
     using DotNetNuke.Modules.ActiveForums.Extensions;
     using DotNetNuke.Services.Authentication;
+    using DotNetNuke.Services.Localization;
     using DotNetNuke.UI.Skins;
 
     [DefaultProperty("Text"), ToolboxData("<{0}:TopicView runat=server></{0}:TopicView>")]
@@ -306,8 +305,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             this.topic.NextTopic = Utilities.SafeConvertInt(this.drForum["NextTopic"]);
             this.topic.PrevTopic = Utilities.SafeConvertInt(this.drForum["PrevTopic"]);
             this.topic.Content = new DotNetNuke.Modules.ActiveForums.Entities.ContentInfo();
-            this.topic.Content.Subject = HttpUtility.HtmlDecode(this.drForum["Subject"].ToString());
-            this.topic.Content.Body = HttpUtility.HtmlDecode(this.drForum["Body"].ToString());
+            this.topic.Content.Subject = System.Net.WebUtility.HtmlDecode(this.drForum["Subject"].ToString());
+            this.topic.Content.Body = System.Net.WebUtility.HtmlDecode(this.drForum["Body"].ToString());
             this.topic.Content.AuthorId = Utilities.SafeConvertInt(this.drForum["AuthorId"]);
             this.topic.Content.AuthorName = this.drForum["TopicAuthor"].ToString();
             this.topic.Content.DateCreated = Utilities.SafeConvertDateTime(this.drForum["DateCreated"]);
@@ -452,8 +451,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                         var pl = DotNetNuke.Modules.ActiveForums.Controllers.TopicPropertyController.Deserialize(this.topic.TopicData);
                         foreach (var p in pl)
                         {
-                            var pName = HttpUtility.HtmlDecode(p.Name);
-                            var pValue = HttpUtility.HtmlDecode(p.Value);
+                            var pName = System.Net.WebUtility.HtmlDecode(p.Name);
+                            var pValue = System.Net.WebUtility.HtmlDecode(p.Value);
 
                             // This builds the replacement text for the properties template
                             var tmp = sPropTemplate.Replace("[AF:PROPERTY:LABEL]", "[RESX:" + pName + "]");
@@ -709,7 +708,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 const string pattern = @"(\[BANNER:(.+?)\])";
                 const string sBanner = "<dnn:BANNER runat=\"server\" BannerCount=\"1\" GroupName=\"$1\" EnableViewState=\"False\" />";
 
-                sOutput = Regex.Replace(sOutput, pattern, sBanner);
+                sOutput = RegexUtils.GetCachedRegex(pattern).Replace(sOutput, sBanner);
             }
 
             // Hide Toolbar
@@ -829,7 +828,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             }
 
             // Printer Friendly Link
-            var sURL = "<a rel=\"nofollow\" href=\"" + Utilities.NavigateURL(this.TabId, string.Empty, ParamKeys.ForumId + "=" + this.ForumId, ParamKeys.ViewType + "=" + Views.Topic, ParamKeys.TopicId + "=" + this.TopicId, "mid=" + this.ModuleId, "dnnprintmode=true") + "?skinsrc=" + HttpUtility.UrlEncode("[G]" + SkinController.RootSkin + "/" + Common.Globals.glbHostSkinFolder + "/" + "No Skin") + "&amp;containersrc=" + HttpUtility.UrlEncode("[G]" + SkinController.RootContainer + "/" + Common.Globals.glbHostSkinFolder + "/" + "No Container") + "\" target=\"_blank\">";
+            var sURL = "<a rel=\"nofollow\" href=\"" + Utilities.NavigateURL(this.TabId, string.Empty, ParamKeys.ForumId + "=" + this.ForumId, ParamKeys.ViewType + "=" + Views.Topic, ParamKeys.TopicId + "=" + this.TopicId, "mid=" + this.ModuleId, "dnnprintmode=true") + "?skinsrc=" + System.Net.WebUtility.UrlEncode("[G]" + SkinController.RootSkin + "/" + Common.Globals.glbHostSkinFolder + "/" + "No Skin") + "&amp;containersrc=" + System.Net.WebUtility.UrlEncode("[G]" + SkinController.RootContainer + "/" + Common.Globals.glbHostSkinFolder + "/" + "No Container") + "\" target=\"_blank\">";
 
             sURL += "<i class=\"fa fa-print fa-fw fa-blue\"></i></a>";
             sbOutput.Replace("[AF:CONTROL:PRINTER]", sURL);
@@ -1018,8 +1017,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             reply.ContentId = dr.GetInt("ContentId");
             reply.Content = new DotNetNuke.Modules.ActiveForums.Entities.ContentInfo();
             reply.Content.ContentId = dr.GetInt("ContentId");
-            reply.Content.Body = HttpUtility.HtmlDecode(dr.GetString("Body"));
-            reply.Content.Subject = HttpUtility.HtmlDecode(dr.GetString("Subject"));
+            reply.Content.Body = System.Net.WebUtility.HtmlDecode(dr.GetString("Body"));
+            reply.Content.Subject = System.Net.WebUtility.HtmlDecode(dr.GetString("Subject"));
             reply.Content.AuthorId = dr.GetInt("AuthorId");
             reply.Content.DateCreated = dr.GetDateTime("DateCreated");
             reply.Content.DateUpdated = dr.GetDateTime("DateUpdated");
@@ -1046,7 +1045,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                         tagList += ", ";
                     }
 
-                    tagList += "<a href=\"" + Utilities.NavigateURL(this.TabId, string.Empty, new[] { ParamKeys.ViewType + "=search", ParamKeys.Tags + "=" + HttpUtility.UrlEncode(tag) }) + "\">" + tag + "</a>";
+                    tagList += "<a href=\"" + Utilities.NavigateURL(this.TabId, string.Empty, new[] { ParamKeys.ViewType + "=search", ParamKeys.Tags + "=" + System.Net.WebUtility.UrlEncode(tag) }) + "\">" + tag + "</a>";
                 }
 
                 sOutput = sOutput.Replace("[AF:LABEL:TAGS]", tagList);
@@ -1115,7 +1114,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             {
                 var strHost = Common.Globals.AddHTTP(Common.Globals.GetDomainName(this.Request)) + "/";
                 const string pattern = "(&#91;IMAGE:(.+?)&#93;)";
-                sOutput = Regex.Replace(sOutput, pattern, match => "<img src=\"" + strHost + "DesktopModules/ActiveForums/viewer.aspx?portalid=" + this.PortalId + "&moduleid=" + this.ForumModuleId + "&attachid=" + match.Groups[2].Value + "\" border=\"0\" class=\"afimg\" />");
+                sOutput = RegexUtils.GetCachedRegex(pattern).Replace(sOutput, match => "<img src=\"" + strHost + "DesktopModules/ActiveForums/viewer.aspx?portalid=" + this.PortalId + "&moduleid=" + this.ForumModuleId + "&attachid=" + match.Groups[2].Value + "\" border=\"0\" class=\"afimg\" />");
             }
 
             // Legacy attachment functionality, uses "attachid"
@@ -1124,7 +1123,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             {
                 var strHost = Common.Globals.AddHTTP(Common.Globals.GetDomainName(this.Request)) + "/";
                 const string pattern = "(&#91;THUMBNAIL:(.+?)&#93;)";
-                sOutput = Regex.Replace(sOutput, pattern, match =>
+                sOutput = RegexUtils.GetCachedRegex(pattern).Replace(sOutput, match =>
                 {
                     var thumbId = match.Groups[2].Value.Split(':')[0];
                     var parentId = match.Groups[2].Value.Split(':')[1];
@@ -1168,7 +1167,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
                 var fileExtension = System.IO.Path.GetExtension(filename).TextOrEmpty().Replace(".", string.Empty);
 
-                filename = HttpUtility.HtmlEncode(DotNetNuke.Common.Utilities.RegexUtils.GetCachedRegex(@"^__\d+__\d+__", RegexOptions.Compiled & RegexOptions.IgnoreCase, 2).Replace(filename, string.Empty));
+                filename = System.Net.WebUtility.HtmlEncode(DotNetNuke.Common.Utilities.RegexUtils.GetCachedRegex(@"^__\d+__\d+__", RegexOptions.Compiled & RegexOptions.IgnoreCase, 2).Replace(filename, string.Empty));
                 sb.AppendFormat(itemTemplate, portalId, moduleId, attachId, fileExtension, filename);
             }
 

--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicsView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicsView.cs
@@ -18,14 +18,13 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System.Diagnostics;
-
 namespace DotNetNuke.Modules.ActiveForums.Controls
 {
     using System;
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.Data;
+    using System.Diagnostics;
     using System.Runtime.CompilerServices;
     using System.Text;
     using System.Text.RegularExpressions;
@@ -516,10 +515,10 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     TopicType = (TopicTypes)Enum.Parse(typeof(TopicTypes), Convert.ToInt32(drTopic["TopicType"]).ToString()),
                     Content = new DotNetNuke.Modules.ActiveForums.Entities.ContentInfo
                     {
-                        Subject = HttpUtility.HtmlDecode(Convert.ToString(drTopic["Subject"])),
-                        Summary = HttpUtility.HtmlDecode(Convert.ToString(drTopic["Summary"])),
+                        Subject = System.Net.WebUtility.HtmlDecode(Convert.ToString(drTopic["Subject"])),
+                        Summary = System.Net.WebUtility.HtmlDecode(Convert.ToString(drTopic["Summary"])),
                         DateCreated = Convert.ToDateTime(drTopic["DateCreated"]),
-                        Body = HttpUtility.HtmlDecode(Convert.ToString(drTopic["Body"])),
+                        Body = System.Net.WebUtility.HtmlDecode(Convert.ToString(drTopic["Body"])),
                         AuthorId = Convert.ToInt32(drTopic["AuthorId"]),
                         AuthorName = Convert.ToString(drTopic["AuthorName"]).ToString().Replace("&amp;#", "&#"),
                     },
@@ -539,8 +538,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                         TopicId = Convert.ToInt32(drTopic["TopicId"]),
                         Content = new DotNetNuke.Modules.ActiveForums.Entities.ContentInfo
                         {
-                            Subject = HttpUtility.HtmlDecode(Convert.ToString(drTopic["LastReplySubject"])),
-                            Summary = HttpUtility.HtmlDecode(Convert.ToString(drTopic["LastReplySummary"])),
+                            Subject = System.Net.WebUtility.HtmlDecode(Convert.ToString(drTopic["LastReplySubject"])),
+                            Summary = System.Net.WebUtility.HtmlDecode(Convert.ToString(drTopic["LastReplySummary"])),
                             DateCreated = Convert.ToDateTime(drTopic["LastReplyDate"]),
                             AuthorId = Convert.ToInt32(drTopic["LastReplyAuthorId"]),
                             AuthorName = Convert.ToString(drTopic["LastReplyAuthorName"]).ToString().Replace("&amp;#", "&#"),
@@ -584,8 +583,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     foreach (var p in pl)
                     {
                         string tmp = sPropTemplate;
-                        var pName = HttpUtility.HtmlDecode(p.Name);
-                        var pValue = HttpUtility.HtmlDecode(p.Value);
+                        var pName = System.Net.WebUtility.HtmlDecode(p.Name);
+                        var pValue = System.Net.WebUtility.HtmlDecode(p.Value);
                         tmp = tmp.Replace("[AF:PROPERTY:LABEL]", Utilities.GetSharedResource("[RESX:" + pName + "]"));
                         tmp = tmp.Replace("[AF:PROPERTY:VALUE]", pValue);
                         topicTemplate = topicTemplate.Replace("[AF:PROPERTY:" + pName + ":LABEL]", Utilities.GetSharedResource("[RESX:" + pName + "]"));

--- a/Dnn.CommunityForums/CustomControls/UserControls/UserProfile.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/UserProfile.cs
@@ -367,7 +367,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     {
                         user.Signature = Utilities.XSSFilter(this.txtSignature.Text, true);
                         user.Signature = Utilities.StripHTMLTag(user.Signature);
-                        user.Signature = HttpUtility.HtmlEncode(user.Signature);
+                        user.Signature = System.Net.WebUtility.HtmlEncode(user.Signature);
                     }
                     else if (this.MainSettings.AllowSignatures == 2)
                     {

--- a/Dnn.CommunityForums/CustomControls/UserControls/WhatsNewRSS.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/WhatsNewRSS.cs
@@ -212,7 +212,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
         private static string CleanXmlString(string xmlString)
         {
-            xmlString = HttpUtility.HtmlEncode(xmlString);
+            xmlString = System.Net.WebUtility.HtmlEncode(xmlString);
             return xmlString;
         }
 
@@ -377,7 +377,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 }
 
                 dr.Close();
-                sb.Append("<atom:link href=\"http://" + HttpContext.Current.Request.Url.Host + HttpUtility.HtmlEncode(HttpContext.Current.Request.RawUrl) + "\" rel=\"self\" type=\"application/rss+xml\" />");
+                sb.Append("<atom:link href=\"http://" + HttpContext.Current.Request.Url.Host + System.Net.WebUtility.HtmlEncode(HttpContext.Current.Request.RawUrl) + "\" rel=\"self\" type=\"application/rss+xml\" />");
                 sb.Append(WriteElement("/channel", 1));
                 sb.Append("</rss>");
                 sb.Replace("[LASTBUILDDATE]", lastBuildDate.ToString("r"));

--- a/Dnn.CommunityForums/CustomControls/Views/ForumDisplay.cs
+++ b/Dnn.CommunityForums/CustomControls/Views/ForumDisplay.cs
@@ -271,7 +271,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     sURL = Utilities.NavigateURL(this.PageId, string.Empty, new[] { ParamKeys.ForumId + "=" + fid, ParamKeys.ViewType + "=" + Views.Topic, ParamKeys.TopicId + "=" + parentPostID, ParamKeys.ContentJumpId + "=" + postId });
                 }
 
-                sOut = "<af:link id=\"hypLastPostSubject" + fid + "\" NavigateUrl=\"" + sURL + "\" Text=\"" + System.Web.HttpUtility.HtmlEncode(subject) + "\" runat=\"server\" />";
+                sOut = "<af:link id=\"hypLastPostSubject" + fid + "\" NavigateUrl=\"" + sURL + "\" Text=\"" + System.Net.WebUtility.HtmlEncode(subject) + "\" runat=\"server\" />";
             }
 
             return sOut;

--- a/Dnn.CommunityForums/Deprecated/Utilities.cs
+++ b/Dnn.CommunityForums/Deprecated/Utilities.cs
@@ -56,7 +56,7 @@ namespace DotNetNuke.Modules.ActiveForums
         public static string ParsePre(string strMessage)
         {
             var objRegEx = new System.Text.RegularExpressions.Regex("<pre>(.*?)</pre>");
-            strMessage = "<code>" + HttpUtility.HtmlDecode(objRegEx.Replace(strMessage, "$1")) + "</code>";
+            strMessage = "<code>" + System.Net.WebUtility.HtmlDecode(objRegEx.Replace(strMessage, "$1")) + "</code>";
             return strMessage;
         }
 
@@ -206,11 +206,11 @@ namespace DotNetNuke.Modules.ActiveForums
             }
         }
 
-        [Obsolete("Deprecated in Community Forums. Removed in 09.00.00. Use HttpUtility.HtmlEncode.")]
-        public static string HtmlEncode(string strMessage = "") => HttpUtility.HtmlEncode(strMessage);
+        [Obsolete("Deprecated in Community Forums. Removed in 09.00.00. Use System.Net.WebUtility.HtmlEncode.")]
+        public static string HtmlEncode(string strMessage = "") => System.Net.WebUtility.HtmlEncode(strMessage);
 
-        [Obsolete("Deprecated in Community Forums. Removed in 09.00.00. Use HttpUtility.HtmlDecode.")]
-        public static string HtmlDecode(string strMessage) => HttpUtility.HtmlDecode(strMessage);
+        [Obsolete("Deprecated in Community Forums. Removed in 09.00.00. Use System.Net.WebUtility.HtmlDecode.")]
+        public static string HtmlDecode(string strMessage) => System.Net.WebUtility.HtmlDecode(strMessage);
 
         [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used. Use Utilities.NavigateURL(int tabId) [Note URL in NavigateURL() is uppercase]")]
         public static string NavigateUrl(int tabId)

--- a/Dnn.CommunityForums/Entities/AuthorInfo.cs
+++ b/Dnn.CommunityForums/Entities/AuthorInfo.cs
@@ -18,10 +18,10 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using DotNetNuke.UI.UserControls;
-
 namespace DotNetNuke.Modules.ActiveForums.Entities
 {
+    using DotNetNuke.UI.UserControls;
+
     /// <summary>
     /// Author is really the same as a user. Just separated out to make code more understandable.
     /// </summary>

--- a/Dnn.CommunityForums/Entities/ForumUserInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumUserInfo.cs
@@ -18,17 +18,16 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-
-using DotNetNuke.Security.Permissions;
-
 namespace DotNetNuke.Modules.ActiveForums.Entities
 {
     using System;
     using System.Web;
+
     using DotNetNuke.ComponentModel.DataAnnotations;
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Users;
+    using DotNetNuke.Security.Permissions;
     using DotNetNuke.Services.Tokens;
     using DotNetNuke.UI.UserControls;
 
@@ -464,11 +463,11 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                             switch (this.MainSettings.AllowSignatures)
                             {
                                 case 1:
-                                    sSignature = System.Web.HttpUtility.HtmlEncode(sSignature);
+                                    sSignature = System.Net.WebUtility.HtmlEncode(sSignature);
                                     sSignature = sSignature.Replace(System.Environment.NewLine, "<br />");
                                     break;
                                 case 2:
-                                    sSignature = System.Web.HttpUtility.HtmlDecode(sSignature);
+                                    sSignature = System.Net.WebUtility.HtmlDecode(sSignature);
                                     break;
                             }
                         }

--- a/Dnn.CommunityForums/Entities/ReplyInfo.cs
+++ b/Dnn.CommunityForums/Entities/ReplyInfo.cs
@@ -18,15 +18,14 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System.Collections;
-using System.Web;
-
 namespace DotNetNuke.Modules.ActiveForums.Entities
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
     using System.Text;
+    using System.Web;
     using System.Web.Caching;
 
     using DotNetNuke.ComponentModel.DataAnnotations;
@@ -330,7 +329,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                     {
                         string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, GetTabId(), this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.Topic.TopicUrl, -1, -1, string.Empty, 1, this.ContentId, this.Forum.SocialGroupId);
                         string sPollImage = (this.Topic.TopicType == TopicTypes.Poll ? DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.GetTokenFormatString("[POLLIMAGE]", this.Forum.PortalSettings, accessingUser.Profile.PreferredLocale) : string.Empty);
-                        string subject = Utilities.StripHTMLTag(HttpUtility.HtmlDecode(this.Subject)).Replace("\"", string.Empty).Replace("#", string.Empty).Replace("%", string.Empty).Replace("+", string.Empty); ;
+                        string subject = Utilities.StripHTMLTag(System.Net.WebUtility.HtmlDecode(this.Subject)).Replace("\"", string.Empty).Replace("#", string.Empty).Replace("%", string.Empty).Replace("+", string.Empty); ;
                         string sBodyTitle = GetTopicTitle(this.Content.Body);
                         string slink;
                         var @params = new List<string>
@@ -373,7 +372,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                 case "link":
                     {
                         string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, GetTabId(), this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.Topic.TopicUrl, -1, -1, string.Empty, 1, this.ContentId, this.Forum.SocialGroupId);
-                        string subject = Utilities.StripHTMLTag(HttpUtility.HtmlDecode(this.Subject)).Replace("\"", string.Empty).Replace("#", string.Empty).Replace("%", string.Empty).Replace("+", string.Empty); ;
+                        string subject = Utilities.StripHTMLTag(System.Net.WebUtility.HtmlDecode(this.Subject)).Replace("\"", string.Empty).Replace("#", string.Empty).Replace("%", string.Empty).Replace("+", string.Empty); ;
                         string sBodyTitle = GetTopicTitle(this.Content.Body);
                         string slink;
                         var @params = new List<string>
@@ -742,7 +741,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             if (!string.IsNullOrEmpty(body))
             {
 
-                body = HttpUtility.HtmlDecode(body);
+                body = System.Net.WebUtility.HtmlDecode(body);
                 body = body.Replace("<br>", System.Environment.NewLine);
                 body = Utilities.StripHTMLTag(body);
                 body = body.Length > 500 ? body.Substring(0, 500) + "..." : body;

--- a/Dnn.CommunityForums/Entities/TopicInfo.cs
+++ b/Dnn.CommunityForums/Entities/TopicInfo.cs
@@ -35,22 +35,23 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
 #pragma warning restore SA1403 // File may only contain a single namespace
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
+    using System.Drawing.Printing;
     using System.Linq;
+    using System.Text;
+    using System.Text.RegularExpressions;
+    using System.Web;
+    using System.Web.UI;
+
     using Collections;
     using ComponentModel.DataAnnotations;
-    using DotNetNuke.Services.Tokens;
-    using DotNetNuke.Entities.Portals;
-    using DotNetNuke.Entities.Modules;
-    using System.Collections;
-    using DotNetNuke.Modules.ActiveForums.ViewModels;
-    using System.Text.RegularExpressions;
-    using System.Web.UI;
-    using DotNetNuke.Modules.ActiveForums.Data;
-    using System.Web;
     using DotNetNuke.Abstractions.Portals;
-    using System.Drawing.Printing;
-    using System.Text;
+    using DotNetNuke.Entities.Modules;
+    using DotNetNuke.Entities.Portals;
+    using DotNetNuke.Modules.ActiveForums.Data;
+    using DotNetNuke.Modules.ActiveForums.ViewModels;
+    using DotNetNuke.Services.Tokens;
 
     [TableName("activeforums_Topics")]
     [PrimaryKey("TopicId", AutoIncrement = true)]
@@ -572,7 +573,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                     {
                         string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, GetTabId(), this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.TopicUrl, -1, -1, string.Empty, 1, -1, this.Forum.SocialGroupId);
                         string sPollImage = (this.Topic.TopicType == TopicTypes.Poll ? DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.GetTokenFormatString("[POLLIMAGE]", this.Forum.PortalSettings, accessingUser.Profile.PreferredLocale) : string.Empty);
-                        string subject = Utilities.StripHTMLTag(HttpUtility.HtmlDecode(this.Subject)).Replace("\"", string.Empty).Replace("#", string.Empty).Replace("%", string.Empty).Replace("+", string.Empty); ;
+                        string subject = Utilities.StripHTMLTag(System.Net.WebUtility.HtmlDecode(this.Subject)).Replace("\"", string.Empty).Replace("#", string.Empty).Replace("%", string.Empty).Replace("+", string.Empty); ;
                         string sBodyTitle = GetTopicTitle(this.Content.Body);
                         string slink;
                         var @params = new List<string>
@@ -814,7 +815,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                 case "link":
                     {
                         string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, GetTabId(), this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.TopicUrl, -1, -1, string.Empty, 1, -1, this.Forum.SocialGroupId);
-                        string subject = Utilities.StripHTMLTag(HttpUtility.HtmlDecode(this.Subject)).Replace("\"", string.Empty).Replace("#", string.Empty).Replace("%", string.Empty).Replace("+", string.Empty);
+                        string subject = Utilities.StripHTMLTag(System.Net.WebUtility.HtmlDecode(this.Subject)).Replace("\"", string.Empty).Replace("#", string.Empty).Replace("%", string.Empty).Replace("+", string.Empty);
                         string sBodyTitle = GetTopicTitle(this.Content.Body);
                         string slink;
                         var @params = new List<string>
@@ -1393,7 +1394,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             if (!string.IsNullOrEmpty(body))
             {
 
-                body = HttpUtility.HtmlDecode(body);
+                body = System.Net.WebUtility.HtmlDecode(body);
                 body = body.Replace("<br>", System.Environment.NewLine);
                 body = Utilities.StripHTMLTag(body);
                 body = body.Length > 500 ? body.Substring(0, 500) + "..." : body;

--- a/Dnn.CommunityForums/Services/AdminServiceController.cs
+++ b/Dnn.CommunityForums/Services/AdminServiceController.cs
@@ -18,10 +18,9 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System;
-
 namespace DotNetNuke.Modules.ActiveForums
 {
+    using System;
     using System.Net;
     using System.Net.Http;
     using System.Text;

--- a/Dnn.CommunityForums/Services/Controllers/LikeController.cs
+++ b/Dnn.CommunityForums/Services/Controllers/LikeController.cs
@@ -18,10 +18,9 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System;
-
 namespace DotNetNuke.Modules.ActiveForums.Services.Controllers
 {
+    using System;
     using System.Net;
     using System.Net.Http;
     using System.Web.Http;

--- a/Dnn.CommunityForums/Services/ProcessQueue.cs
+++ b/Dnn.CommunityForums/Services/ProcessQueue.cs
@@ -18,8 +18,6 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using DotNetNuke.Services.Log.EventLog;
-
 namespace DotNetNuke.Modules.ActiveForums.Services.ProcessQueue
 {
     using System;
@@ -28,6 +26,7 @@ namespace DotNetNuke.Modules.ActiveForums.Services.ProcessQueue
 
     using DotNetNuke.Modules.ActiveForums.DAL2;
     using DotNetNuke.Modules.ActiveForums.Data;
+    using DotNetNuke.Services.Log.EventLog;
     using DotNetNuke.Services.Scheduling;
 
     public class Scheduler : DotNetNuke.Services.Scheduling.SchedulerClient

--- a/Dnn.CommunityForums/Services/ServicesHelper.cs
+++ b/Dnn.CommunityForums/Services/ServicesHelper.cs
@@ -18,10 +18,10 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System;
-
 namespace DotNetNuke.Modules.ActiveForums.Services
 {
+    using System;
+
     using DotNetNuke.Entities.Users;
 
     internal static class ServicesHelper

--- a/Dnn.CommunityForums/Services/Tokens/ForumsModuleTokenReplacer.cs
+++ b/Dnn.CommunityForums/Services/Tokens/ForumsModuleTokenReplacer.cs
@@ -18,19 +18,18 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System;
-using System.Net;
-using System.Web;
-using System.Web.UI;
-
-using DotNetNuke.Services.Authentication;
-
 namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
 {
+    using System;
+    using System.Net;
+    using System.Web;
+    using System.Web.UI;
+
     using DotNetNuke.ComponentModel.DataAnnotations;
     using DotNetNuke.Entities.Host;
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Entities.Portals;
+    using DotNetNuke.Services.Authentication;
     using DotNetNuke.Services.Tokens;
 
     internal class ForumsModuleTokenReplacer : BaseCustomTokenReplace, DotNetNuke.Services.Tokens.IPropertyAccess
@@ -127,7 +126,7 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
                                this.PortalSettings.EnablePopUps &&
                                this.PortalSettings.LoginTabId == DotNetNuke.Common.Utilities.Null.NullInteger &&
                                !AuthenticationController.HasSocialAuthenticationEnabled() ?
-                                    PropertyAccess.FormatString(DotNetNuke.Common.Utilities.UrlUtils.PopUpUrl(HttpUtility.UrlDecode(GetLoginUrl()), this.PortalSettings, true, false, 300, 650), format) :
+                                    PropertyAccess.FormatString(DotNetNuke.Common.Utilities.UrlUtils.PopUpUrl(System.Net.WebUtility.UrlDecode(GetLoginUrl()), this.PortalSettings, true, false, 300, 650), format) :
                                     string.Empty;
                     }
 

--- a/Dnn.CommunityForums/Services/Tokens/ResourceStringTokenReplacer.cs
+++ b/Dnn.CommunityForums/Services/Tokens/ResourceStringTokenReplacer.cs
@@ -18,12 +18,12 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System.Text;
-using DotNetNuke.Common.Utilities;
-
 namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
 {
+    using System.Text;
     using System.Text.RegularExpressions;
+
+    using DotNetNuke.Common.Utilities;
     using DotNetNuke.Services.Tokens;
 
     internal class ResourceStringTokenReplacer : DotNetNuke.Services.Tokens.IPropertyAccess

--- a/Dnn.CommunityForums/Services/Tokens/TokenReplacer.cs
+++ b/Dnn.CommunityForums/Services/Tokens/TokenReplacer.cs
@@ -18,14 +18,13 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System.Runtime.CompilerServices;
-
 namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
 {
     using System;
     using System.Data.SqlTypes;
     using System.Linq;
     using System.Net;
+    using System.Runtime.CompilerServices;
     using System.Text;
     using System.Text.RegularExpressions;
     using System.Web;
@@ -237,7 +236,7 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
         internal static StringBuilder ReplaceForumTokens(StringBuilder template, ForumInfo forum, PortalSettings portalSettings, SettingsInfo mainSettings, INavigationManager navigationManager, ForumUserInfo forumUser, int tabId, CurrentUserTypes currentUserType, Uri requestUri, string rawUrl)
         {
             /* if no last post or subject missing, remove associated last topic tokens */
-            if (forum.LastPostID == 0 || string.IsNullOrEmpty(HttpUtility.HtmlDecode(forum.LastPostSubject)))
+            if (forum.LastPostID == 0 || string.IsNullOrEmpty(System.Net.WebUtility.HtmlDecode(forum.LastPostSubject)))
             {
                 template = RemovePrefixedToken(template, "[FORUM:LASTPOSTSUBJECT");
                 template = RemovePrefixedToken(template, "[FORUM:LASTPOSTDISPLAYNAME");
@@ -312,7 +311,7 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
         {
             if (!string.IsNullOrEmpty(body))
             {
-                body = Utilities.ManageImagePath(HttpUtility.HtmlDecode(body), uri);
+                body = Utilities.ManageImagePath(System.Net.WebUtility.HtmlDecode(body), uri);
                 body = body.Replace("[", "&#91;").Replace("]", "&#93;");
                 if (body.ToUpper().Contains("&#91;CODE&#93;"))
                 {
@@ -322,7 +321,7 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
 
                 if (RegexUtils.GetCachedRegex("\\[CODE([^>]*)\\]", RegexOptions.Compiled & RegexOptions.IgnoreCase, 2).IsMatch(body))
                 {
-                    body = CodeParser.ParseCode(HttpUtility.HtmlDecode(body));
+                    body = CodeParser.ParseCode(System.Net.WebUtility.HtmlDecode(body));
                 }
 
                 body = Utilities.StripExecCode(body);

--- a/Dnn.CommunityForums/ViewModels/Topic.cs
+++ b/Dnn.CommunityForums/ViewModels/Topic.cs
@@ -18,12 +18,11 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System.Web.UI.Design;
-
 namespace DotNetNuke.Modules.ActiveForums.ViewModels
 {
     using System;
     using System.Collections.Generic;
+    using System.Web.UI.Design;
 
     public class Topic
     {

--- a/Dnn.CommunityForums/WhatsNew.ascx.cs
+++ b/Dnn.CommunityForums/WhatsNew.ascx.cs
@@ -27,6 +27,7 @@ namespace DotNetNuke.Modules.ActiveForums
     using System.Text.RegularExpressions;
     using System.Web.UI;
 
+    using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Modules;
 
     public partial class WhatsNew : PortalModuleBase, IActionable
@@ -229,7 +230,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     var template = sbTemplate.ToString();
 
                     // Do this regex replace first before moving on to the simpler ones.
-                    template = Regex.Replace(template, @"\[BODY\:\s*(\d+)\s*\]", m => SafeSubstring(body, int.Parse(m.Groups[1].Value)), RegexOptions.IgnoreCase);
+                    template = RegexUtils.GetCachedRegex( @"\[BODY\:\s*(\d+)\s*\]", RegexOptions.IgnoreCase).Replace(template, m => SafeSubstring(body, int.Parse(m.Groups[1].Value)));
 
                     sb.Append(template);
                 }

--- a/Dnn.CommunityForums/class/Author.cs
+++ b/Dnn.CommunityForums/class/Author.cs
@@ -18,10 +18,10 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System;
-
 namespace DotNetNuke.Modules.ActiveForums
 {
+    using System;
+
     [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Replaced by DotNetNuke.Modules.ActiveForums.Entities.AuthorInfo.")]
     public class Author : DotNetNuke.Modules.ActiveForums.Entities.AuthorInfo { }
 }

--- a/Dnn.CommunityForums/class/ForumsConfig.cs
+++ b/Dnn.CommunityForums/class/ForumsConfig.cs
@@ -354,7 +354,7 @@ namespace DotNetNuke.Modules.ActiveForums
                             template = sHTML;
                         }
 
-                        templateInfo.Template = System.Web.HttpUtility.HtmlDecode(template);
+                        templateInfo.Template = System.Net.WebUtility.HtmlDecode(template);
                         tc.Template_Save(templateInfo);
                     }
                     catch (Exception ex)

--- a/Dnn.CommunityForums/class/ParamBuilder.cs
+++ b/Dnn.CommunityForums/class/ParamBuilder.cs
@@ -18,10 +18,9 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System;
-
 namespace DotNetNuke.Modules.ActiveForums
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Web;
@@ -37,7 +36,7 @@ namespace DotNetNuke.Modules.ActiveForums
         {
             get
             {
-                return this.Params == null ? new string[] { } : this.Params.Keys.Select(key => string.Format("{0}={1}", HttpUtility.UrlEncode(key), HttpUtility.UrlEncode(this.Params[key].ToString()))).ToArray();
+                return this.Params == null ? new string[] { } : this.Params.Keys.Select(key => string.Format("{0}={1}", System.Net.WebUtility.UrlEncode(key), System.Net.WebUtility.UrlEncode(this.Params[key].ToString()))).ToArray();
             }
         }
 
@@ -88,8 +87,8 @@ namespace DotNetNuke.Modules.ActiveForums
 
                 if (urlEncoded)
                 {
-                    key = HttpUtility.UrlDecode(key);
-                    value = HttpUtility.UrlDecode(value);
+                    key = System.Net.WebUtility.UrlDecode(key);
+                    value = System.Net.WebUtility.UrlDecode(value);
                 }
 
                 this.Params[key] = value;

--- a/Dnn.CommunityForums/class/Settings.cs
+++ b/Dnn.CommunityForums/class/Settings.cs
@@ -18,13 +18,12 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using DotNetNuke.Common.Utilities;
-
 namespace DotNetNuke.Modules.ActiveForums
 {
     using System;
     using System.Collections;
 
+    using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Profile;
     using DotNetNuke.Modules.ActiveForums.Entities;
     using Newtonsoft.Json.Linq;

--- a/Dnn.CommunityForums/class/TemplateCache.cs
+++ b/Dnn.CommunityForums/class/TemplateCache.cs
@@ -18,14 +18,14 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System.Text;
-using System.Text.RegularExpressions;
-using DotNetNuke.Common.Utilities;
-
 namespace DotNetNuke.Modules.ActiveForums
 {
     using System;
+    using System.Text;
+    using System.Text.RegularExpressions;
     using System.Web;
+
+    using DotNetNuke.Common.Utilities;
 
     internal static class TemplateCache
     {

--- a/Dnn.CommunityForums/class/TemplateUtils.cs
+++ b/Dnn.CommunityForums/class/TemplateUtils.cs
@@ -18,9 +18,6 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using DotNetNuke.Modules.ActiveForums.Controllers;
-using DotNetNuke.Modules.ActiveForums.Entities;
-
 namespace DotNetNuke.Modules.ActiveForums
 {
     using System;
@@ -37,7 +34,8 @@ namespace DotNetNuke.Modules.ActiveForums
 
     using DotNetNuke.Abstractions;
     using DotNetNuke.Entities.Portals;
-    using DotNetNuke.UI.UserControls;
+    using DotNetNuke.Modules.ActiveForums.Entities;
+    using DotNetNuke.Modules.ActiveForums.Entities;
     using Microsoft.ApplicationBlocks.Data;
 
     public class TemplateUtils
@@ -595,7 +593,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 }
 
                 var objCode = new CodeParser();
-                template = CodeParser.ParseCode(HttpUtility.HtmlDecode(template));
+                template = CodeParser.ParseCode(System.Net.WebUtility.HtmlDecode(template));
             }
 
             return template;

--- a/Dnn.CommunityForums/class/UserProfile.cs
+++ b/Dnn.CommunityForums/class/UserProfile.cs
@@ -16,15 +16,15 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 //
-using System;
-using System.Collections;
-using System.Data;
-
-using DotNetNuke.Common.Utilities;
-using DotNetNuke.UI.UserControls;
-
 namespace DotNetNuke.Modules.ActiveForums
 {
+    using System;
+    using System.Collections;
+    using System.Data;
+
+    using DotNetNuke.Common.Utilities;
+    using DotNetNuke.UI.UserControls;
+
     #region "Deprecated"
     [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Use DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo.")]
     public class UserProfileInfo : DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo

--- a/Dnn.CommunityForums/components/Common/HandlerBase.cs
+++ b/Dnn.CommunityForums/components/Common/HandlerBase.cs
@@ -240,11 +240,8 @@ namespace DotNetNuke.Modules.ActiveForums.Handlers
                     this._ps = DotNetNuke.Entities.Portals.PortalController.Instance.GetCurrentPortalSettings();
                 }
 
-                // Dim sc As New Social.SocialSettings
-                // _mainSettings = sc.LoadSettings[_ps.PortalId]
                 this._mainSettings = SettingsBase.GetModuleSettings(this.ModuleId);
 
-                // If context.Request.IsAuthenticated Then
                 this._isValid = true;
                 if (this.AdminRequired & !context.Request.IsAuthenticated)
                 {
@@ -254,7 +251,6 @@ namespace DotNetNuke.Modules.ActiveForums.Handlers
 
                 if (this.AdminRequired && context.Request.IsAuthenticated)
                 {
-                    // _isValid = DotNetNuke.Security.PortalSecurity.IsInRole(_ps.AdministratorRoleName)
                     DotNetNuke.Entities.Modules.ModuleController objMC =
                         new DotNetNuke.Entities.Modules.ModuleController();
                     DotNetNuke.Entities.Modules.ModuleInfo objM = objMC.GetModule(this.ModuleId, this.TabId);
@@ -387,7 +383,7 @@ namespace DotNetNuke.Modules.ActiveForums.Handlers
                             {
                                 if (!string.IsNullOrEmpty(tmp))
                                 {
-                                    tmp = HttpUtility.UrlDecode(tmp);
+                                    tmp = System.Net.WebUtility.UrlDecode(tmp);
                                 }
 
                                 if (slist != null)
@@ -428,7 +424,7 @@ namespace DotNetNuke.Modules.ActiveForums.Handlers
                         }
                         else if (!string.IsNullOrEmpty(prop) && !string.IsNullOrEmpty(tmp))
                         {
-                            ht.Add(prop, HttpUtility.UrlDecode(tmp));
+                            ht.Add(prop, System.Net.WebUtility.UrlDecode(tmp));
                         }
                         else if (!string.IsNullOrEmpty(prop) && slist != null)
                         {

--- a/Dnn.CommunityForums/components/Helpers/JSON.cs
+++ b/Dnn.CommunityForums/components/Helpers/JSON.cs
@@ -29,6 +29,8 @@ namespace DotNetNuke.Modules.ActiveForums
     using System.Text.RegularExpressions;
     using System.Web;
 
+    using DotNetNuke.Common.Utilities;
+
     public partial class Utilities
     {
         public class JSON
@@ -203,7 +205,7 @@ namespace DotNetNuke.Modules.ActiveForums
                             }
 
                             val = val.Replace("#^", ", ");
-                            dict.Add(pairArray[0], HttpUtility.UrlDecode(val));
+                            dict.Add(pairArray[0], System.Net.WebUtility.UrlDecode(val));
                         }
                     }
 
@@ -263,8 +265,7 @@ namespace DotNetNuke.Modules.ActiveForums
             /// <returns>string</returns>
             internal static string EscapeJsonString(string originalString)
             {
-                Regex reg = new Regex("\\s+", RegexOptions.Multiline);
-                originalString = reg.Replace(originalString, " ");
+                originalString = RegexUtils.GetCachedRegex("\\s+", RegexOptions.Multiline).Replace(originalString, " ");
                 return IsJSONArray(originalString) ? originalString : originalString.Replace("\\/", "/").Replace("/", "\\/").Replace("\\\"", "\"").Replace("\"", "\\\"").Replace(System.Environment.NewLine, string.Empty);
             }
         }

--- a/Dnn.CommunityForums/components/Helpers/Localization.cs
+++ b/Dnn.CommunityForums/components/Helpers/Localization.cs
@@ -136,7 +136,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 node = nodeData.AppendChild(xmlDoc.CreateElement("value"));
             }
 
-            node.InnerXml = HttpUtility.HtmlEncode(text);
+            node.InnerXml = System.Net.WebUtility.HtmlEncode(text);
         }
     }
 }

--- a/Dnn.CommunityForums/components/Helpers/TextUtils.cs
+++ b/Dnn.CommunityForums/components/Helpers/TextUtils.cs
@@ -27,6 +27,7 @@ namespace DotNetNuke.Modules.ActiveForums
     using System.Text.RegularExpressions;
     using System.Web;
 
+    using DotNetNuke.Common.Utilities;
     using DotNetNuke.Security;
 
     public partial class Utilities
@@ -66,18 +67,9 @@ namespace DotNetNuke.Modules.ActiveForums
                     return string.Empty;
                 }
 
-                // TODO: REPLACE THIS
-                PortalSecurity objPortalSecurity = new PortalSecurity();
-                try
-                {
-                    text = objPortalSecurity.InputFilter(text, PortalSecurity.FilterFlag.NoScripting);
-                }
-                catch (Exception ex)
-                {
-                }
-
+                text = System.Net.WebUtility.HtmlEncode(text);
                 string pattern = "<script.*/*>|</script>|<[a-zA-Z][^>]*=['\"]+javascript:\\w+.*['\"]+>|<\\w+[^>]*\\son\\w+=.*[ /]*>";
-                text = Regex.Replace(text, pattern, string.Empty, RegexOptions.IgnoreCase);
+                text = RegexUtils.GetCachedRegex(pattern, RegexOptions.Compiled & RegexOptions.IgnoreCase).Replace(text, string.Empty);
                 string strip = "/*,*/,alert,document.,window.,eval(,eval[,@import,vbscript,javascript,jscript,msgbox";
                 foreach (string s in strip.Split(','))
                 {
@@ -98,17 +90,15 @@ namespace DotNetNuke.Modules.ActiveForums
                     return string.Empty;
                 }
 
-                sText = HttpUtility.HtmlDecode(sText);
-                sText = HttpUtility.UrlDecode(sText);
+                sText = System.Net.WebUtility.HtmlDecode(sText);
+                sText = System.Net.WebUtility.UrlDecode(sText);
                 sText = sText.Trim();
                 if (string.IsNullOrEmpty(sText))
                 {
                     return string.Empty;
                 }
 
-                // TODO: REPLACE THIS
-                PortalSecurity objPortalSecurity = new PortalSecurity();
-                sText = objPortalSecurity.InputFilter(sText, PortalSecurity.FilterFlag.NoScripting);
+                sText = System.Net.WebUtility.HtmlEncode(sText);
                 sText = FilterScripts(sText);
                 string strip = "/*,*/,alert,document.,window.,eval(,eval[,src=,rel=,href=,@import,vbscript,javascript,jscript,msgbox,<style";
                 foreach (string s in strip.Split(','))
@@ -121,10 +111,9 @@ namespace DotNetNuke.Modules.ActiveForums
                 }
 
                 string pattern = "<(.|\\n)*?>";
-                sText = Regex.Replace(sText, pattern, string.Empty, RegexOptions.IgnoreCase);
-                sText = HttpUtility.HtmlEncode(sText);
+                sText = RegexUtils.GetCachedRegex(pattern, RegexOptions.IgnoreCase).Replace(sText, string.Empty);
+                sText = System.Net.WebUtility.HtmlEncode(sText);
 
-                // sText = HttpUtility.UrlEncode(sText)
                 return sText;
             }
         }

--- a/Dnn.CommunityForums/components/Helpers/UpgradeModuleSettings.cs
+++ b/Dnn.CommunityForums/components/Helpers/UpgradeModuleSettings.cs
@@ -18,10 +18,9 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System;
-
 namespace DotNetNuke.Modules.ActiveForums.Helpers
 {
+    using System;
     using System.Reflection;
     using System.Web.UI;
     using System.Xml;

--- a/Dnn.CommunityForums/components/Social/ActiveSocial.cs
+++ b/Dnn.CommunityForums/components/Social/ActiveSocial.cs
@@ -115,7 +115,8 @@ namespace DotNetNuke.Modules.ActiveForums
                 {
                     if (string.IsNullOrEmpty(summary))
                     {
-                        summary = Utilities.StripHTMLTag(body);
+                        summary = Utilities.StripQuoteTag(body);
+                        summary = Utilities.StripHTMLTag(summary);
                         if (summary.Length > 150)
                         {
                             summary = summary.Substring(0, 150) + "...";
@@ -125,6 +126,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     ji.Title = subject;
                     ji.Summary = summary;
                     ji.ItemData = new ItemData { Url = uRL };
+                    ji.Body = Utilities.StripQuoteTag(body);
                     ji.Body = Utilities.StripHTMLTag(body);
                     ji.DateUpdated = DateTime.UtcNow;
                     JournalController.Instance.UpdateJournalItem(journalItem: ji, module: DotNetNuke.Entities.Modules.ModuleController.Instance.GetModule(moduleId, tabId, true));
@@ -176,7 +178,8 @@ namespace DotNetNuke.Modules.ActiveForums
                     };
                     if (string.IsNullOrEmpty(summary))
                     {
-                        summary = Utilities.StripHTMLTag(body);
+                        summary = Utilities.StripQuoteTag(body);
+                        summary = Utilities.StripHTMLTag(summary);
                         if (summary.Length > 150)
                         {
                             summary = summary.Substring(0, 150) + "...";
@@ -184,6 +187,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     }
 
                     ji.Summary = summary;
+                    ji.Body = Utilities.StripQuoteTag(body);
                     ji.Body = Utilities.StripHTMLTag(body);
                     ji.JournalTypeId = 6;
                     ji.ObjectKey = $"{forumId}:{topicId}:{replyId}";

--- a/Dnn.CommunityForums/controls/admin_manageforums_home.ascx.cs
+++ b/Dnn.CommunityForums/controls/admin_manageforums_home.ascx.cs
@@ -18,8 +18,6 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System.Linq;
-
 namespace DotNetNuke.Modules.ActiveForums
 {
     using System;
@@ -27,7 +25,9 @@ namespace DotNetNuke.Modules.ActiveForums
     using System.Collections.Generic;
     using System.Data;
     using System.Linq;
+    using System.Linq;
     using System.Web.UI.WebControls;
+
     using DotNetNuke.Modules.ActiveForums.Entities;
 
     public partial class admin_manageforums_home : ActiveAdminBase
@@ -89,35 +89,35 @@ namespace DotNetNuke.Modules.ActiveForums
                         sb.Append("<tr class=\"afgroupback\"><td class=\"afgroupback_left\">" + this.RenderSpacer(1, 4) + "</td><td colspan=\"3\" width=\"100%\" onmouseover=\"this.className='agrowedit'\" onmouseout=\"this.className=''\" onclick=\"LoadView('manageforums_forumeditor','" + forum.ForumGroupId + "|G');\">");
                         sb.Append(sGroupName);
                         sb.Append("</td><td>");
-                        var inheritance = string.Empty;
+                        var inheritanceLabel = string.Empty;
                         if (forum.ForumGroup.InheritSettings)
                         {
-                            inheritance = "<img src=\"" + this.Page.ResolveUrl(Globals.ModuleImagesPath + "admin_check.png") + "\" class=\"dcf-controlpanel-inheritance-img\" alt=\"" + string.Format(this.GetSharedResource("[RESX:Tips:InheritSettingsOn]"), forum.ForumGroup.GroupName, this.GetSharedResource("[RESX:ModuleDefaults]")) + "\" title=\"" + string.Format(this.GetSharedResource("[RESX:Tips:InheritSettingsOn]"), forum.ForumGroup.GroupName, this.GetSharedResource("[RESX:ModuleDefaults]")) + "\"/>";
+                            inheritanceLabel = this.GetSharedResource("[RESX:InheritsSettings]");
                         }
                         else if (forum.ForumGroup.FeatureSettings.EqualSettings(SettingsBase.GetModuleSettings(this.ModuleId).ForumFeatureSettings))
                         {
-                            inheritance = "<img src=\"" + this.Page.ResolveUrl(Globals.ModuleImagesPath + "info32.png") + "\" class=\"dcf-controlpanel-inheritance-img\" alt=\"" + string.Format(this.GetSharedResource("[RESX:Tips:InheritSettingsRecommended]"), forum.ForumGroup.GroupName, this.GetSharedResource("[RESX:ModuleDefaults]")) + "\" title=\"" + string.Format(this.GetSharedResource("[RESX:Tips:InheritSettingsRecommended]"), forum.ForumGroup.GroupName, this.GetSharedResource("[RESX:ModuleDefaults]")) + "\" />";
+                            inheritanceLabel = this.GetSharedResource("[RESX:ShouldInheritSettings]");
                         }
 
-                        if (!string.IsNullOrEmpty(inheritance))
+                        if (!string.IsNullOrEmpty(inheritanceLabel))
                         {
-                            sb.Append($"<div class=\"amcpnormal dcf-controlpanel-inheritance-label\">{inheritance}</div>");
+                            sb.Append($"<div class=\"amcpnormal dcf-controlpanel-inheritance-label\">{inheritanceLabel}</div>");
                         }
 
                         sb.Append("</td><td>");
-                        inheritance = string.Empty;
+                        inheritanceLabel = string.Empty;
                         if (forum.ForumGroup.InheritSecurity)
                         {
-                            inheritance = "<img src=\"" + this.Page.ResolveUrl(Globals.ModuleImagesPath + "admin_check.png") + "\" class=\"dcf-controlpanel-inheritance-img\" alt=\"" + string.Format(this.GetSharedResource("[RESX:Tips:InheritSecurityOn]"), forum.ForumGroup.GroupName, this.GetSharedResource("[RESX:ModuleDefaults]")) + "\" title=\"" + string.Format(this.GetSharedResource("[RESX:Tips:InheritSecurityOn]"), forum.ForumGroup.GroupName, this.GetSharedResource("[RESX:ModuleDefaults]")) + "\" />";
+                            inheritanceLabel = this.GetSharedResource("[RESX:InheritsSecurity]");
                         }
                         else if (forum.ForumGroup.Security.EqualPermissions(new DotNetNuke.Modules.ActiveForums.Controllers.PermissionController().GetById(permissionId: SettingsBase.GetModuleSettings(this.ModuleId).DefaultPermissionId, moduleId: this.ModuleId)))
                         {
-                            inheritance = "<img src=\"" + this.Page.ResolveUrl(Globals.ModuleImagesPath + "info32.png") + "\" class=\"dcf-controlpanel-inheritance-img\" alt=\"" + string.Format(this.GetSharedResource("[RESX:Tips:InheritSecurityRecommended]"), forum.ForumGroup.GroupName, this.GetSharedResource("[RESX:ModuleDefaults]")) + "\" title=\"" + string.Format(this.GetSharedResource("[RESX:Tips:InheritSecurityRecommended]"), forum.ForumGroup.GroupName, this.GetSharedResource("[RESX:ModuleDefaults]")) + "\"/>";
+                            inheritanceLabel = this.GetSharedResource("[RESX:ShouldInheritSecurity]");
                         }
 
-                        if (!string.IsNullOrEmpty(inheritance))
+                        if (!string.IsNullOrEmpty(inheritanceLabel))
                         {
-                            sb.Append($"<div class=\"amcpnormal dcf-controlpanel-inheritance-label\">{inheritance}</div>");
+                            sb.Append($"<div class=\"amcpnormal dcf-controlpanel-inheritance-label\">{inheritanceLabel}</div>");
                         }
 
                         sb.Append("</td>");
@@ -149,35 +149,35 @@ namespace DotNetNuke.Modules.ActiveForums
                         sb.Append("<tr class=\"afforumback\"><td class=\"afforumback_left\">" + this.RenderSpacer(1, 4) + "</td><td style=\"width:15px;\" width=\"15\">" + this.RenderSpacer(5, 15) + "</td><td colspan=\"2\" width=\"100%\" onmouseover=\"this.className='afrowedit'\" onmouseout=\"this.className=''\" onclick=\"LoadView('manageforums_forumeditor','" + forum.ForumID + "|F');\">");
                         sb.Append(sForumName);
                         sb.Append("</td><td>");
-                        var inheritance = string.Empty;
+                        var inheritanceLabel = string.Empty;
                         if (forum.InheritSettings)
                         {
-                            inheritance = "<img src=\"" + this.Page.ResolveUrl(Globals.ModuleImagesPath + "admin_check.png") + "\" class=\"dcf-controlpanel-inheritance-img\" alt=\"" + string.Format(this.GetSharedResource("[RESX:Tips:InheritSettingsOn]"), forum.ForumName, forum.ForumGroup.GroupName) + "\" title=\"" + string.Format(this.GetSharedResource("[RESX:Tips:InheritSettingsOn]"), forum.ForumName, forum.ForumGroup.GroupName) + "\" />";
+                            inheritanceLabel = this.GetSharedResource("[RESX:InheritsSettings]");
                         }
                         else if (forum.FeatureSettings.EqualSettings(forum.ForumGroup.FeatureSettings))
                         {
-                            inheritance = "<img src=\"" + this.Page.ResolveUrl(Globals.ModuleImagesPath + "info32.png") + "\" class=\"dcf-controlpanel-inheritance-img\" alt=\"" + string.Format(this.GetSharedResource("[RESX:Tips:InheritSettingsRecommended]"), forum.ForumName, forum.ForumGroup.GroupName) + "\" title=\"" + string.Format(this.GetSharedResource("[RESX:Tips:InheritSettingsRecommended]"), forum.ForumName, forum.ForumGroup.GroupName) + "\" />";
+                            inheritanceLabel = this.GetSharedResource("[RESX:ShouldInheritSettings]");
                         }
 
-                        if (!string.IsNullOrEmpty(inheritance))
+                        if (!string.IsNullOrEmpty(inheritanceLabel))
                         {
-                            sb.Append($"<div class=\"amcpnormal dcf-controlpanel-inheritance-label\">{inheritance}</div>");
+                            sb.Append($"<div class=\"amcpnormal dcf-controlpanel-inheritance-label\">{inheritanceLabel}</div>");
                         }
 
                         sb.Append("</td><td>");
-                        inheritance = string.Empty;
+                        inheritanceLabel = string.Empty;
                         if (forum.InheritSecurity)
                         {
-                            inheritance = "<img src=\"" + this.Page.ResolveUrl(Globals.ModuleImagesPath + "admin_check.png") + "\" class=\"dcf-controlpanel-inheritance-img\" alt=\"" + string.Format(this.GetSharedResource("[RESX:Tips:InheritSecurityOn]"), forum.ForumName, forum.ForumGroup.GroupName) + "\" title=\"" + string.Format(this.GetSharedResource("[RESX:Tips:InheritSecurityOn]"), forum.ForumName, forum.ForumGroup.GroupName) + "\"/>";
+                            inheritanceLabel = this.GetSharedResource("[RESX:InheritsSecurity]");
                         }
                         else if (forum.Security.EqualPermissions(forum.ForumGroup.Security))
                         {
-                            inheritance = "<img src=\"" + this.Page.ResolveUrl(Globals.ModuleImagesPath + "info32.png") + "\" class=\"dcf-controlpanel-inheritance-img\" alt=\"" + string.Format(this.GetSharedResource("[RESX:Tips:InheritSecurityRecommended]"), forum.ForumName, forum.ForumGroup.GroupName) + "\" title=\"" + string.Format(this.GetSharedResource("[RESX:Tips:InheritSecurityRecommended]"), forum.ForumName, forum.ForumGroup.GroupName) + "\"/>";
+                            inheritanceLabel = this.GetSharedResource("[RESX:ShouldInheritSecurity]");
                         }
 
-                        if (!string.IsNullOrEmpty(inheritance))
+                        if (!string.IsNullOrEmpty(inheritanceLabel))
                         {
-                            sb.Append($"<div class=\"amcpnormal dcf-controlpanel-inheritance-label\">{inheritance}</div>");
+                            sb.Append($"<div class=\"amcpnormal dcf-controlpanel-inheritance-label\">{inheritanceLabel}</div>");
                         }
 
                         sb.Append("</td>");
@@ -224,35 +224,35 @@ namespace DotNetNuke.Modules.ActiveForums
                 sb.Append("<tr class=\"afforumback\"><td class=\"afforumback_left\">" + this.RenderSpacer(1, 4) + "</td><td style=\"width:15px;\">" + this.RenderSpacer(5, 15) + "</td><td style=\"width:15px;\">" + this.RenderSpacer(5, 15) + "</td><td width=\"100%\" onmouseover=\"this.className='afrowedit'\" onmouseout=\"this.className=''\" onclick=\"LoadView('manageforums_forumeditor','" + subforum.ForumID + "|F');\">");
                 sb.Append(sForumName);
                 sb.Append("</td><td>");
-                var inheritance = string.Empty;
+                var inheritanceLabel = string.Empty;
                 if (forum.InheritSettings)
                 {
-                    inheritance = "<img src=\"" + this.Page.ResolveUrl(Globals.ModuleImagesPath + "admin_check.png") + "\" class=\"dcf-controlpanel-inheritance-img\" alt=\"" + string.Format(this.GetSharedResource("[RESX:Tips:InheritSettingsOn]"), forum.ForumName, forum.ForumGroup.GroupName) + "\" title=\"" + string.Format(this.GetSharedResource("[RESX:Tips:InheritSettingsOn]"), forum.ForumName, forum.ForumGroup.GroupName) + "\"/>";
+                    inheritanceLabel = this.GetSharedResource("[RESX:InheritsSettings]");
                 }
                 else if (forum.FeatureSettings.EqualSettings(forum.ForumGroup.FeatureSettings))
                 {
-                    inheritance = "<img src=\"" + this.Page.ResolveUrl(Globals.ModuleImagesPath + "info32.png") + "\" class=\"dcf-controlpanel-inheritance-img\" alt=\"" + string.Format(this.GetSharedResource("[RESX:Tips:InheritSettingsRecommended]"), forum.ForumName, forum.ForumGroup.GroupName) + "\" title=\"" + string.Format(this.GetSharedResource("[RESX:Tips:InheritSettingsRecommended]"), forum.ForumName, forum.ForumGroup.GroupName) + "\" />";
+                    inheritanceLabel = this.GetSharedResource("[RESX:ShouldInheritSettings]");
                 }
 
-                if (!string.IsNullOrEmpty(inheritance))
+                if (!string.IsNullOrEmpty(inheritanceLabel))
                 {
-                    sb.Append($"<div class=\"amcpnormal dcf-controlpanel-inheritance-label\">{inheritance}</div>");
+                    sb.Append($"<div class=\"amcpnormal dcf-controlpanel-inheritance-label\">{inheritanceLabel}</div>");
                 }
 
                 sb.Append("</td><td>");
-                inheritance = string.Empty;
+                inheritanceLabel = string.Empty;
                 if (forum.InheritSecurity)
                 {
-                    inheritance = "<img src=\"" + this.Page.ResolveUrl(Globals.ModuleImagesPath + "admin_check.png") + "\" class=\"dcf-controlpanel-inheritance-img\" alt=\"" + string.Format(this.GetSharedResource("[RESX:Tips:InheritSecurityOn]"), forum.ForumName, forum.ForumGroup.GroupName) + "\" title=\"" + string.Format(this.GetSharedResource("[RESX:Tips:InheritSecurityOn]"), forum.ForumName, forum.ForumGroup.GroupName) + "\" />";
+                    inheritanceLabel = this.GetSharedResource("[RESX:InheritsSecurity]");
                 }
                 else if (forum.Security.EqualPermissions(forum.ForumGroup.Security))
                 {
-                    inheritance = "<img src=\"" + this.Page.ResolveUrl(Globals.ModuleImagesPath + "info32.png") + "\" class=\"dcf-controlpanel-inheritance-img\" alt=\"" + string.Format(this.GetSharedResource("[RESX:Tips:InheritSecurityRecommended]"), forum.ForumName, forum.ForumGroup.GroupName) + "\" title=\"" + string.Format(this.GetSharedResource("[RESX:Tips:InheritSecurityRecommended]"), forum.ForumName, forum.ForumGroup.GroupName) + "\" />";
+                    inheritanceLabel = this.GetSharedResource("[RESX:ShouldInheritSecurity]");
                 }
 
-                if (!string.IsNullOrEmpty(inheritance))
+                if (!string.IsNullOrEmpty(inheritanceLabel))
                 {
-                    sb.Append($"<div class=\"amcpnormal dcf-controlpanel-inheritance-label\">{inheritance}</div>");
+                    sb.Append($"<div class=\"amcpnormal dcf-controlpanel-inheritance-label\">{inheritanceLabel}</div>");
                 }
 
                 sb.Append("</td>");

--- a/Dnn.CommunityForums/controls/af_post.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_post.ascx.cs
@@ -396,12 +396,12 @@ namespace DotNetNuke.Modules.ActiveForums
             else
             {
                 // User has acccess
-                var sBody = HttpUtility.HtmlDecode(ti.Content.Body);
-                var sSubject = HttpUtility.HtmlDecode(ti.Content.Subject);
+                var sBody = System.Net.WebUtility.HtmlDecode(ti.Content.Body);
+                var sSubject = System.Net.WebUtility.HtmlDecode(ti.Content.Subject);
                 sBody = Utilities.PrepareForEdit(this.PortalId, this.ForumModuleId, this.ImagePath, sBody, this.allowHTML, this.editorType);
                 sSubject = Utilities.PrepareForEdit(this.PortalId, this.ForumModuleId, this.ImagePath, sSubject, false, EditorTypes.TEXTBOX);
                 this.ctlForm.Subject = sSubject;
-                this.ctlForm.Summary = HttpUtility.HtmlDecode(ti.Content.Summary);
+                this.ctlForm.Summary = System.Net.WebUtility.HtmlDecode(ti.Content.Summary);
                 this.ctlForm.Body = sBody;
                 this.ctlForm.AnnounceEnd = ti.AnnounceEnd;
                 this.ctlForm.AnnounceStart = ti.AnnounceStart;
@@ -481,8 +481,8 @@ namespace DotNetNuke.Modules.ActiveForums
             }
             else
             {
-                var sBody = HttpUtility.HtmlDecode(ri.Content.Body);
-                var sSubject = HttpUtility.HtmlDecode(ri.Content.Subject);
+                var sBody = System.Net.WebUtility.HtmlDecode(ri.Content.Body);
+                var sSubject = System.Net.WebUtility.HtmlDecode(ri.Content.Subject);
                 sBody = Utilities.PrepareForEdit(this.PortalId, this.ForumModuleId, this.ImagePath, sBody, this.allowHTML, this.editorType);
                 sSubject = Utilities.PrepareForEdit(this.PortalId, this.ForumModuleId, this.ImagePath, sSubject, false, EditorTypes.TEXTBOX);
                 this.ctlForm.Subject = sSubject;
@@ -572,8 +572,8 @@ namespace DotNetNuke.Modules.ActiveForums
                     this.Context.ApplicationInstance.CompleteRequest();
                 }
 
-                this.ctlForm.Subject = Utilities.GetSharedResource("[RESX:SubjectPrefix]") + " " + HttpUtility.HtmlDecode(ti.Content.Subject);
-                this.ctlForm.TopicSubject = HttpUtility.HtmlDecode(ti.Content.Subject);
+                this.ctlForm.Subject = Utilities.GetSharedResource("[RESX:SubjectPrefix]") + " " + System.Net.WebUtility.HtmlDecode(ti.Content.Subject);
+                this.ctlForm.TopicSubject = System.Net.WebUtility.HtmlDecode(ti.Content.Subject);
                 var body = string.Empty;
 
                 if (ti.IsLocked && (this.ForumUser.CurrentUserType == CurrentUserTypes.Anon || this.ForumUser.CurrentUserType == CurrentUserTypes.Auth))
@@ -644,7 +644,7 @@ namespace DotNetNuke.Modules.ActiveForums
                         if (body.ToUpper().Contains("<CODE") | body.ToUpper().Contains("[CODE]"))
                         {
                             var objCode = new CodeParser();
-                            body = CodeParser.ParseCode(System.Web.HttpUtility.HtmlDecode(body));
+                            body = CodeParser.ParseCode(System.Net.WebUtility.HtmlDecode(body));
                         }
                     }
                     else
@@ -934,7 +934,7 @@ namespace DotNetNuke.Modules.ActiveForums
             // This HTML decode is used to make Quote functionality work properly even when it appears in Text Box instead of Editor
             if (this.Request.Params[ParamKeys.QuoteId] != null)
             {
-                body = System.Web.HttpUtility.HtmlDecode(body);
+                body = System.Net.WebUtility.HtmlDecode(body);
             }
 
             int authorId;

--- a/Dnn.CommunityForums/controls/af_search.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_search.ascx.cs
@@ -18,8 +18,6 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System.Web;
-
 namespace DotNetNuke.Modules.ActiveForums
 {
     using System;
@@ -27,6 +25,7 @@ namespace DotNetNuke.Modules.ActiveForums
     using System.Data;
     using System.Linq;
     using System.Text;
+    using System.Web;
     using System.Web.UI;
     using System.Web.UI.WebControls;
 
@@ -464,12 +463,12 @@ namespace DotNetNuke.Modules.ActiveForums
 
                     if (!string.IsNullOrWhiteSpace(this.SearchText))
                     {
-                        this.parameters.Add($"{SearchParamKeys.Query}=" + System.Web.HttpUtility.UrlEncode(this.SearchText));
+                        this.parameters.Add($"{SearchParamKeys.Query}=" + System.Net.WebUtility.UrlEncode(this.SearchText));
                     }
 
                     if (!string.IsNullOrWhiteSpace(this.Tags))
                     {
-                        this.parameters.Add($"{SearchParamKeys.Tag}=" + System.Web.HttpUtility.UrlEncode(this.Tags));
+                        this.parameters.Add($"{SearchParamKeys.Tag}=" + System.Net.WebUtility.UrlEncode(this.Tags));
                     }
 
                     if (this.SearchId > 0)
@@ -509,12 +508,12 @@ namespace DotNetNuke.Modules.ActiveForums
 
                     if (!string.IsNullOrWhiteSpace(this.AuthorUsername))
                     {
-                        this.parameters.Add($"{SearchParamKeys.Author}=" + System.Web.HttpUtility.UrlEncode(this.AuthorUsername));
+                        this.parameters.Add($"{SearchParamKeys.Author}=" + System.Net.WebUtility.UrlEncode(this.AuthorUsername));
                     }
 
                     if (!string.IsNullOrWhiteSpace(this.Forums))
                     {
-                        this.parameters.Add($"{SearchParamKeys.Forums}=" + System.Web.HttpUtility.UrlEncode(this.Forums));
+                        this.parameters.Add($"{SearchParamKeys.Forums}=" + System.Net.WebUtility.UrlEncode(this.Forums));
                     }
                 }
 

--- a/Dnn.CommunityForums/controls/af_searchadvanced.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_searchadvanced.ascx.cs
@@ -348,12 +348,12 @@ namespace DotNetNuke.Modules.ActiveForums
 
             if (!string.IsNullOrWhiteSpace(searchText))
             {
-                @params.Add($"{SearchParamKeys.Query}={System.Web.HttpUtility.UrlEncode(searchText)}");
+                @params.Add($"{SearchParamKeys.Query}={System.Net.WebUtility.UrlEncode(searchText)}");
             }
 
             if (!string.IsNullOrWhiteSpace(tags))
             {
-                @params.Add($"{SearchParamKeys.Tag}={System.Web.HttpUtility.UrlEncode(tags)}");
+                @params.Add($"{SearchParamKeys.Tag}={System.Net.WebUtility.UrlEncode(tags)}");
             }
 
             if (searchType > 0)
@@ -383,12 +383,12 @@ namespace DotNetNuke.Modules.ActiveForums
 
             if (!string.IsNullOrWhiteSpace(authorUsername))
             {
-                @params.Add($"{SearchParamKeys.Author}={System.Web.HttpUtility.UrlEncode(authorUsername)}");
+                @params.Add($"{SearchParamKeys.Author}={System.Net.WebUtility.UrlEncode(authorUsername)}");
             }
 
             if (!string.IsNullOrWhiteSpace(forums))
             {
-                @params.Add($"{SearchParamKeys.Forums}={System.Web.HttpUtility.UrlEncode(forums)}");
+                @params.Add($"{SearchParamKeys.Forums}={System.Net.WebUtility.UrlEncode(forums)}");
             }
 
             if (this.SocialGroupId > 0)

--- a/Dnn.CommunityForums/controls/af_searchquick.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_searchquick.ascx.cs
@@ -82,7 +82,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 {
                     $"{ParamKeys.ViewType}={Views.Search}",
                     $"{ParamKeys.ForumId}={this.ForumId}",
-                    $"{SearchParamKeys.Query}={HttpUtility.UrlEncode(this.txtSearch.Text.Trim())}",
+                    $"{SearchParamKeys.Query}={System.Net.WebUtility.UrlEncode(this.txtSearch.Text.Trim())}",
                 };
 
                 if (this.SocialGroupId > 0)

--- a/Dnn.CommunityForums/controls/profile_mypreferences.ascx.cs
+++ b/Dnn.CommunityForums/controls/profile_mypreferences.ascx.cs
@@ -81,7 +81,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     {
                         upi.Signature = Utilities.XSSFilter(this.txtSignature.Text, true);
                         upi.Signature = Utilities.StripHTMLTag(upi.Signature);
-                        upi.Signature = System.Web.HttpUtility.HtmlEncode(upi.Signature);
+                        upi.Signature = System.Net.WebUtility.HtmlEncode(upi.Signature);
                     }
                     else if (this.MainSettings.AllowSignatures == 2)
                     {

--- a/Dnn.CommunityForums/feeds.aspx.cs
+++ b/Dnn.CommunityForums/feeds.aspx.cs
@@ -151,7 +151,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
                         // build channel
                         sb.Append(this.WriteElement("channel", 1));
-                        sb.Append(this.WriteElement("title", HttpUtility.HtmlEncode(ps.PortalName) + " " + this.forumName, 2));
+                        sb.Append(this.WriteElement("title", System.Net.WebUtility.HtmlEncode(ps.PortalName) + " " + this.forumName, 2));
                         sb.Append(this.WriteElement("link", uRL, 2));
                         sb.Append(this.WriteElement("description", this.forumDescription, 2));
                         sb.Append(this.WriteElement("language", this.PortalSettings.DefaultLanguage, 2));
@@ -178,7 +178,7 @@ namespace DotNetNuke.Modules.ActiveForums
                             }
                         }
 
-                        sb.Append("<atom:link href=\"http://" + this.Request.Url.Host + HttpUtility.HtmlEncode(this.Request.RawUrl) + "\" rel=\"self\" type=\"application/rss+xml\" />");
+                        sb.Append("<atom:link href=\"http://" + this.Request.Url.Host + System.Net.WebUtility.HtmlEncode(this.Request.RawUrl) + "\" rel=\"self\" type=\"application/rss+xml\" />");
                         sb.Append(this.WriteElement("/channel", 1));
                         sb.Replace("[LASTBUILDDATE]", this.lastBuildDate.ToString("r"));
                         sb.Append("</rss>");

--- a/Dnn.CommunityForums/handlers/adminhelper.ashx.cs
+++ b/Dnn.CommunityForums/handlers/adminhelper.ashx.cs
@@ -145,9 +145,9 @@ namespace DotNetNuke.Modules.ActiveForums.Handlers
             sOut += ",";
             sOut += Utilities.JSON.Pair("FilterType", filter.FilterType.ToString());
             sOut += ",";
-            sOut += Utilities.JSON.Pair("Find", HttpUtility.UrlEncode(filter.Find.Replace(" ", "-|-")));
+            sOut += Utilities.JSON.Pair("Find", System.Net.WebUtility.UrlEncode(filter.Find.Replace(" ", "-|-")));
             sOut += ",";
-            sOut += Utilities.JSON.Pair("Replacement", HttpUtility.UrlEncode(filter.Replace.Replace(" ", "-|-")));
+            sOut += Utilities.JSON.Pair("Replacement", System.Net.WebUtility.UrlEncode(filter.Replace.Replace(" ", "-|-")));
             sOut += "}";
             return sOut;
         }
@@ -289,7 +289,7 @@ namespace DotNetNuke.Modules.ActiveForums.Handlers
             pi.Name = Utilities.CleanName(pi.Name);
             if (!string.IsNullOrEmpty(pi.ValidationExpression))
             {
-                pi.ValidationExpression = HttpUtility.UrlDecode(HttpUtility.HtmlDecode(pi.ValidationExpression));
+                pi.ValidationExpression = System.Net.WebUtility.UrlDecode(System.Net.WebUtility.HtmlDecode(pi.ValidationExpression));
             }
 
             if (pi.PropertyId == -1)

--- a/Dnn.CommunityForumsTests/class/UtilitiesTests.cs
+++ b/Dnn.CommunityForumsTests/class/UtilitiesTests.cs
@@ -96,7 +96,7 @@
         }
 
         [Test]
-        [Obsolete("Deprecated in Community Forums. Removed in 09.00.00. Use HttpUtility.HtmlEncode.")]
+        [Obsolete("Deprecated in Community Forums. Removed in 09.00.00. Use System.Net.WebUtility.HtmlEncode.")]
         public void HtmlEncodeTest()
         {
             // Arrange
@@ -111,7 +111,7 @@
         }
 
         [Test]
-        [Obsolete("Deprecated in Community Forums. Removed in 09.00.00. Use HttpUtility.HtmlDecode.")]
+        [Obsolete("Deprecated in Community Forums. Removed in 09.00.00. Use System.Net.WebUtility.HtmlDecode.")]
         public void HtmlDecodeTestEmptyTag()
         {
             // Arrange
@@ -123,7 +123,7 @@
         }
 
         [Test]
-        [Obsolete("Deprecated in Community Forums. Removed in 09.00.00. Use HttpUtility.HtmlDecode.")]
+        [Obsolete("Deprecated in Community Forums. Removed in 09.00.00. Use System.Net.WebUtility.HtmlDecode.")]
         public void HtmlDecodeTest()
         {
             // Arrange


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
When posting to DNN journal, removes "quoted" portion from a reply 

## Changes made
- Add StripQuoteTag utility method and use it when posting to journal (#748)
- Use DNN RegexUtil.GetCachedRegex() for additional regex replacements (#1158) 
- Use System.Net.WebUtility.*Encode/*Decode rather than System.Web.HttpUtility & remove PortalSecurity calls (#1159) 
- Minor text/string utility refactoring
- Minor refactoring to relocate `using` statements

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install.

Before this pull request, you don't actually see what the responder is posting -- just the portion being "quoted":
![image](https://github.com/user-attachments/assets/90daa139-f211-4b88-9fdc-0b9fc456a05d)

This is the actual reply. This pull request will remove the "Posted by..." part and just show the actual reply:
![image](https://github.com/user-attachments/assets/1d9863e4-5e10-489f-ad70-30705acc20f7)

What the journal looks like after this pull request:
![image](https://github.com/user-attachments/assets/14a9ee1d-5e0f-43f1-9b3d-1f67446249ed)

This works for editing an existing reply as well.

## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #748 
Close #1158 
Close #1159