### PR TITLE
ENH: Move email notification subject template to forum settings

### DIFF
--- a/Dnn.CommunityForums/App_LocalResources/ControlPanel.ascx.fr-FR.resx
+++ b/Dnn.CommunityForums/App_LocalResources/ControlPanel.ascx.fr-FR.resx
@@ -1477,4 +1477,10 @@ Votre méthode de suppression est actuellement définie sur {0}.  Vos sujets ser
   <data name="[RESX:Tips:InheritSecurityOn].Text" xml:space="preserve">
     <value>{0} hérite de la sécurité de {1}</value>
   </data>
+  <data name="[RESX:EmailSubjectTemplate].Text" xml:space="preserve">
+    <value>Modèle d’objet d’e-mail</value>
+  </data>
+  <data name="[RESX:Tips:EmailSubjectTemplate].Text" xml:space="preserve">
+    <value>Entrez le modèle à utiliser comme ligne d’objet lors de l’envoi de notifications. Le modèle peut inclure des jetons. Veuillez visiter le référentiel Github des forums de la communauté DNN (https://github.com/DNNCommunity/Dnn.CommunityForums) et consulter le wiki pour obtenir de la documentation sur les jetons.</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/ControlPanel.ascx.it-IT.resx
+++ b/Dnn.CommunityForums/App_LocalResources/ControlPanel.ascx.it-IT.resx
@@ -1474,4 +1474,10 @@ Il metodo di rimozione è attualmente impostato su {0}.  I tuoi argomenti verran
   <data name="[RESX:Tips:InheritSecurityOn].Text" xml:space="preserve">
     <value>{0} eredita la sicurezza da {1}</value>
   </data>
+  <data name="[RESX:EmailSubjectTemplate].Text" xml:space="preserve">
+    <value>Modello di oggetto dell'email</value>
+  </data>
+  <data name="[RESX:Tips:EmailSubjectTemplate].Text" xml:space="preserve">
+    <value>Inserisci il modello da utilizzare come oggetto per l'invio delle notifiche. Il modello può includere token. Visita il repository Github (https://github.com/DNNCommunity/Dnn.CommunityForums) dei forum della community DNN e consulta il wiki per la documentazione sui token.</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/ControlPanel.ascx.nl-NL.resx
+++ b/Dnn.CommunityForums/App_LocalResources/ControlPanel.ascx.nl-NL.resx
@@ -1624,4 +1624,10 @@ De verwijder-methode is momenteel ingesteld op "{0}".  Uw onderwerpen worden {1}
   <data name="[RESX:Tips:InheritSecurityOn].Text" xml:space="preserve">
     <value>{0} erft de veiligheid van {1}</value>
   </data>
+  <data name="[RESX:EmailSubjectTemplate].Text" xml:space="preserve">
+    <value>E-mail Onderwerp Sjabloon</value>
+  </data>
+  <data name="[RESX:Tips:EmailSubjectTemplate].Text" xml:space="preserve">
+    <value>Voer de sjabloon in die als onderwerpregel moet worden gebruikt bij het verzenden van meldingen. De sjabloon kan tokens bevatten. Ga naar de Github-repository (https://github.com/DNNCommunity/Dnn.CommunityForums) van de DNN-communityforums en bekijk de wiki voor documentatie over tokens.</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/ControlPanel.ascx.resx
+++ b/Dnn.CommunityForums/App_LocalResources/ControlPanel.ascx.resx
@@ -1579,4 +1579,10 @@ Your removal method is currently set to {0}.  Your topics will be {1} based upon
   <data name="[RESX:Tips:InheritSettingsRecommended].Text" xml:space="preserve">
     <value>{0} has the same settings as {1}, so you should enable 'inherit settings' for {0}</value>
   </data>
+  <data name="[RESX:EmailSubjectTemplate].Text" xml:space="preserve">
+    <value>Email Subject Template</value>
+  </data>
+  <data name="[RESX:Tips:EmailSubjectTemplate].Text" xml:space="preserve">
+    <value>Enter the template to be used as the subject line when sending notifications. The template can include tokens. Please visit the DNN Community Forums Github repository (https://github.com/DNNCommunity/Dnn.CommunityForums) and review the wiki for documentation on tokens.</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/Controlpanel.ascx.de-DE.resx
+++ b/Dnn.CommunityForums/App_LocalResources/Controlpanel.ascx.de-DE.resx
@@ -1579,4 +1579,10 @@ Ihre Entfernungsmethode ist derzeit auf {0} eingestellt.  Ihre Themen werden anh
   <data name="[RESX:Tips:InheritSecurityOn].Text" xml:space="preserve">
     <value>{0} übernimmt die Sicherheit von {1}</value>
   </data>
+  <data name="[RESX:EmailSubjectTemplate].Text" xml:space="preserve">
+    <value>E-Mail-Betreff-Vorlage</value>
+  </data>
+  <data name="[RESX:Tips:EmailSubjectTemplate].Text" xml:space="preserve">
+    <value>Geben Sie die Vorlage ein, die beim Senden von Benachrichtigungen als Betreffzeile verwendet werden soll. Die Vorlage kann Token enthalten. Bitte besuchen Sie das Github-Repository der DNN-Community-Foren (https://github.com/DNNCommunity/Dnn.CommunityForums) und überprüfen Sie das Wiki auf Dokumentation zu Token.</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/Controlpanel.ascx.es-ES.resx
+++ b/Dnn.CommunityForums/App_LocalResources/Controlpanel.ascx.es-ES.resx
@@ -1474,4 +1474,10 @@ El método de eliminación está configurado actualmente en {0}.  Los temas se {
   <data name="[RESX:Tips:InheritSecurityOn].Text" xml:space="preserve">
     <value>{0} hereda la seguridad de {1}</value>
   </data>
+  <data name="[RESX:EmailSubjectTemplate].Text" xml:space="preserve">
+    <value>Plantilla de asunto de correo electrónico</value>
+  </data>
+  <data name="[RESX:Tips:EmailSubjectTemplate].Text" xml:space="preserve">
+    <value>Introduzca la plantilla que se utilizará como asunto al enviar notificaciones. La plantilla puede incluir tokens. Visite el repositorio de Github (https://github.com/DNNCommunity/Dnn.CommunityForums) de los foros de la comunidad DNN y revise la wiki para obtener documentación sobre tokens.</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/ControlPanel.css
+++ b/Dnn.CommunityForums/ControlPanel.css
@@ -434,5 +434,5 @@ ul.amcpformlist li div.amcpradiorow input[type="checkbox"]{font-size:14px;margin
 
 .dcf-controlpanel .dcf-controlpanel-inheritance-label { width: 150px; padding-left: 3px; padding-right: 3px; text-align: center; }
 .dcf-controlpanel .dcf-controlpanel-inheritance-img { width: 16px; height: 16px; }
+.dcf-controlpanel .dcf-controlpanel-inheritance-heading-settings { margin-left: 500px; cursor: auto; }
 .dcf-controlpanel .dcf-controlpanel-inheritance-heading-security { margin-left: 30px; cursor: auto; }
-.dcf-controlpanel .dcf-controlpanel-inheritance-heading-settings { margin-left: 665px; cursor: auto; }

--- a/Dnn.CommunityForums/Entities/FeatureSettings.cs
+++ b/Dnn.CommunityForums/Entities/FeatureSettings.cs
@@ -141,6 +141,9 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         public string EmailAddress => Utilities.SafeConvertString(this.featureSettings[ForumSettingKeys.EmailAddress], string.Empty);
 
         [IgnoreColumn]
+        public string EmailNotificationSubjectTemplate => Utilities.SafeConvertString(this.featureSettings[ForumSettingKeys.EmailNotificationSubjectTemplate], string.Empty);
+
+        [IgnoreColumn]
         public bool IndexContent => Utilities.SafeConvertBool(this.featureSettings[ForumSettingKeys.IndexContent]);
 
         /// <summary>

--- a/Dnn.CommunityForums/class/ForumsConfig.cs
+++ b/Dnn.CommunityForums/class/ForumsConfig.cs
@@ -250,7 +250,7 @@ namespace DotNetNuke.Modules.ActiveForums
                                         SortOrder = c,
                                         ForumSettingsKey = $"G:{groupId}",
                                         PermissionsId = SettingsBase.GetModuleSettings(moduleId).DefaultPermissionId,
-};
+                                    };
                                     new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().Forums_Save(portalId, fi, true, true, true);
                                 }
                             }
@@ -598,6 +598,8 @@ namespace DotNetNuke.Modules.ActiveForums
                         {
                             templateInfo.Subject = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.MapLegacyEmailNotificationTokenSynonyms(new StringBuilder(templateInfo.Subject), PortalSettings.Current, PortalSettings.Current.DefaultLanguage).ToString();
                             tc.Template_Save(templateInfo);
+                            Settings.SaveSetting(templateInfo.ModuleId, $"M:{templateInfo.ModuleId}", ForumSettingKeys.EmailNotificationSubjectTemplate, templateInfo.Subject);
+                            DotNetNuke.Modules.ActiveForums.DataCache.ClearAllCache(templateInfo.ModuleId);
                         }
                         catch (Exception ex)
                         {
@@ -691,6 +693,11 @@ namespace DotNetNuke.Modules.ActiveForums
 
                 string sKey = $"M:{moduleId}";
                 DotNetNuke.Entities.Modules.ModuleController.Instance.UpdateModuleSetting(moduleId, SettingKeys.DefaultSettingsKey, sKey);
+                if (string.IsNullOrEmpty(SettingsBase.GetModuleSettings(moduleId).ForumFeatureSettings.EmailNotificationSubjectTemplate))
+                {
+                    Settings.SaveSetting(moduleId, sKey, ForumSettingKeys.EmailNotificationSubjectTemplate, "[FORUMAUTHOR:DISPLAYNAME] [POSTEDORREPLIEDTO] [SUBSCRIBEDFORUMORTOPICSUBJECTFORUMNAME] on [PORTAL:PORTALNAME]");
+                }
+
                 Settings.SaveSetting(moduleId, sKey, ForumSettingKeys.EmailAddress, string.Empty);
                 Settings.SaveSetting(moduleId, sKey, ForumSettingKeys.UseFilter, "true");
                 Settings.SaveSetting(moduleId, sKey, ForumSettingKeys.AllowPostIcon, "false");
@@ -742,12 +749,13 @@ namespace DotNetNuke.Modules.ActiveForums
                 Settings.SaveSetting(moduleId, sKey, ForumSettingKeys.ReplyFormId, Convert.ToString(replyEditorTemplateId));
                 Settings.SaveSetting(moduleId, sKey, ForumSettingKeys.QuickReplyFormId, Convert.ToString(quickReplyTemplateId));
                 Settings.SaveSetting(moduleId, sKey, ForumSettingKeys.ProfileTemplateId, Convert.ToString(profileInfoTemplateId));
+                DotNetNuke.Modules.ActiveForums.DataCache.ClearAllCache(moduleId);
             }
             catch (Exception ex)
             {
                 DotNetNuke.Services.Exceptions.Exceptions.LogException(ex);
             }
-            
+
         }
     }
 }

--- a/Dnn.CommunityForums/class/Globals.cs
+++ b/Dnn.CommunityForums/class/Globals.cs
@@ -274,6 +274,7 @@ namespace DotNetNuke.Modules.ActiveForums
         public const string ModDeleteTemplateId = "MODDELETETEMPLATEID";
         public const string ModNotifyTemplateId = "MODNOTIFYTEMPLATEID";
         public const string EmailAddress = "EMAILADDRESS";
+        public const string EmailNotificationSubjectTemplate = "EMAILNOTIFICATIONSUBJECTTEMPLATE";
         public const string UseFilter = "USEFILTER";
         public const string AllowAttach = "ALLOWATTACH";
         public const string TopicFormId = "TOPICFORMID";

--- a/Dnn.CommunityForums/controls/admin_manageforums_forumeditor.ascx
+++ b/Dnn.CommunityForums/controls/admin_manageforums_forumeditor.ascx
@@ -242,11 +242,17 @@ function saveSettings(){
     } else {
         var ProfileTemplateId = 0;
     };
-	var EmailAddress = document.getElementById("<%=txtEmailAddress.ClientID%>");
+    var EmailAddress = document.getElementById("<%=txtEmailAddress.ClientID%>");
     if (EmailAddress) {
         EmailAddress = EmailAddress.value;
     } else {
         EmailAddress = '';
+    };
+    var EmailNotificationSubjectTemplate = document.getElementById("<%=txtEmailNotificationSubjectTemplate.ClientID%>");
+    if (EmailNotificationSubjectTemplate) {
+        EmailNotificationSubjectTemplate = EmailNotificationSubjectTemplate.value;
+    } else {
+        EmailNotificationSubjectTemplate = '';
     };
     var CreatePostCount = document.getElementById("<%=txtCreatePostCount.ClientID%>");
     if (CreatePostCount) {
@@ -360,7 +366,7 @@ function saveSettings(){
 		IndexContent, AllowRSS, AllowAttach, AttachCount, AttachMaxSize, AttachTypeAllowed, EditorMobile, AllowLikes, ReplyPostCount, AttachAllowBrowseSite, AttachInsertAllowed, MaxAttachWidth,
 		MaxAttachHeight, AttachConvertToJGPAllowed, AllowHtml, EditorType, EditorHeight, EditorWidth, CreatePostCount, AutoSubscribeNewTopicsOnly, EditorPermittedRoles, TopicFormId, ReplyFormId,
 		AutoSubscribeRoles, ProfileTemplateId, IsModerated, DefaultTrustLevel, AutoTrustLevel, ModApproveTemplateId, ModRejectTemplateId, ModMoveTemplateId, ModDeleteTemplateId,
-        ModNotifyTemplateId, AutoSubscribeEnabled, QuickReplyFormId);
+        ModNotifyTemplateId, AutoSubscribeEnabled, QuickReplyFormId, EmailNotificationSubjectTemplate);
 
 
 };
@@ -990,14 +996,6 @@ function afadmin_getProperties() {
 						<td>
 							<img src="~/DesktopModules/ActiveForums/images/spacer.gif" width="20" runat="server" /></td>
 					</tr>
-                    <tr id="trEmail" runat="server">
-                        <td>
-                            <img id="Img19" src="~/DesktopModules/ActiveForums/images/tooltip.png" runat="server" onmouseover="amShowTip(this, '[RESX:Tips:EmailAddress]');" onmouseout="amHideTip(this);" /></td>
-                        <td class="amcpbold" style="white-space: nowrap">[RESX:EmailAddress]:</td>
-                        <td width="100%">
-                            <asp:TextBox ID="txtEmailAddress" runat="server" CssClass="amcptxtbx" /></td>
-                        <td></td>
-                    </tr>
                 </table>
 				<table id="trActive" runat="server" width="100%">
 					<tr>
@@ -1098,11 +1096,11 @@ function afadmin_getProperties() {
 						<td></td>
 					</tr>
 					 <tr>
-					<td><img id="Img24" src="~/DesktopModules/ActiveForums/images/tooltip.png" runat="server" onmouseover="amShowTip(this, '[RESX:Tips:QuickReplyForm]');" onmouseout="amHideTip(this);" /></td>
-					<td class="amcpbold" style="white-space:nowrap">[RESX:QuickReplyForm]:</td>
-					<td width="100%"><asp:DropDownList ID="drpQuickReplyForm" runat="server" CssClass="amcptxtbx" /></td>
-					<td></td>
-				</tr>
+					    <td><img id="Img24" src="~/DesktopModules/ActiveForums/images/tooltip.png" runat="server" onmouseover="amShowTip(this, '[RESX:Tips:QuickReplyForm]');" onmouseout="amHideTip(this);" /></td>
+					    <td class="amcpbold" style="white-space:nowrap">[RESX:QuickReplyForm]:</td>
+					    <td width="100%"><asp:DropDownList ID="drpQuickReplyForm" runat="server" CssClass="amcptxtbx" /></td>
+					    <td></td>
+				    </tr>
 					<tr>
 						<td>
 							<img id="Img16" src="~/DesktopModules/ActiveForums/images/tooltip.png" runat="server" onmouseover="amShowTip(this, '[RESX:Tips:UserProfileTemplate]');" onmouseout="amHideTip(this);" /></td>
@@ -1111,6 +1109,22 @@ function afadmin_getProperties() {
 							<asp:DropDownList ID="drpProfileDisplay" runat="server" CssClass="amcptxtbx" /></td>
 						<td></td>
 					</tr>
+                    <tr id="trEmail" runat="server">
+                        <td>
+                            <img id="Img19" src="~/DesktopModules/ActiveForums/images/tooltip.png" runat="server" onmouseover="amShowTip(this, '[RESX:Tips:EmailAddress]');" onmouseout="amHideTip(this);" /></td>
+                        <td class="amcpbold" style="white-space: nowrap">[RESX:EmailAddress]:</td>
+                        <td width="100%">
+                            <asp:TextBox ID="txtEmailAddress" runat="server" CssClass="amcptxtbx" /></td>
+                        <td></td>
+                    </tr>
+                    <tr id="trEmailNotificationSubjectTemplate" runat="server">
+                        <td>
+                            <img id="Img27" src="~/DesktopModules/ActiveForums/images/tooltip.png" runat="server" onmouseover="amShowTip(this, '[RESX:Tips:EmailSubjectTemplate]');" onmouseout="amHideTip(this);" /></td>
+                        <td class="amcpbold" style="white-space: nowrap">[RESX:EmailSubjectTemplate]:</td>
+                        <td width="100%">
+                            <asp:TextBox ID="txtEmailNotificationSubjectTemplate" runat="server" CssClass="amcptxtbx" /></td>
+                        <td></td>
+                    </tr>
                     <tr>
                         <td>
                             <img src="~/DesktopModules/ActiveForums/images/tooltip.png" runat="server" onmouseover="amShowTip(this, '[RESX:Tips:CreatePostCount]');" onmouseout="amHideTip(this);" /></td>

--- a/Dnn.CommunityForums/controls/admin_manageforums_forumeditor.ascx.cs
+++ b/Dnn.CommunityForums/controls/admin_manageforums_forumeditor.ascx.cs
@@ -73,7 +73,6 @@ namespace DotNetNuke.Modules.ActiveForums
                 this.trGroups.Visible = false;
                 this.trName.Visible = false;
                 this.trPrefix.Visible = false;
-                this.trEmail.Visible = false;
                 this.trActive.Visible = false;
                 this.trHidden.Visible = false;
                 this.reqGroups.Enabled = false;
@@ -435,6 +434,7 @@ namespace DotNetNuke.Modules.ActiveForums
             AFSettings.SaveSetting(this.ModuleId, sKey, ForumSettingKeys.ModNotifyTemplateId, parameters[41]);
             AFSettings.SaveSetting(this.ModuleId, sKey, ForumSettingKeys.AutoSubscribeEnabled, parameters[42]);
             AFSettings.SaveSetting(this.ModuleId, sKey, ForumSettingKeys.QuickReplyFormId, parameters[43]);
+            AFSettings.SaveSetting(this.ModuleId, sKey, ForumSettingKeys.EmailNotificationSubjectTemplate, parameters[44]);
         }
 
         private void LoadForum(int forumId)
@@ -570,6 +570,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
             this.txtAutoTrustLevel.Text = featureSettings.AutoTrustLevel.ToString();
             this.txtEmailAddress.Text = featureSettings.EmailAddress;
+            this.txtEmailNotificationSubjectTemplate.Text = featureSettings.EmailNotificationSubjectTemplate;
             this.txtCreatePostCount.Text = featureSettings.CreatePostCount.ToString();
             this.txtReplyPostCount.Text = featureSettings.ReplyPostCount.ToString();
 

--- a/Dnn.CommunityForums/controls/admin_manageforums_forumeditor.ascx.designer.cs
+++ b/Dnn.CommunityForums/controls/admin_manageforums_forumeditor.ascx.designer.cs
@@ -168,33 +168,6 @@ namespace DotNetNuke.Modules.ActiveForums
         protected global::System.Web.UI.WebControls.TextBox txtPrefixURL;
 
         /// <summary>
-        /// trEmail control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.HtmlControls.HtmlTableRow trEmail;
-
-        /// <summary>
-        /// Img19 control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.HtmlControls.HtmlImage Img19;
-
-        /// <summary>
-        /// txtEmailAddress control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.WebControls.TextBox txtEmailAddress;
-
-        /// <summary>
         /// trActive control.
         /// </summary>
         /// <remarks>
@@ -472,6 +445,60 @@ namespace DotNetNuke.Modules.ActiveForums
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.DropDownList drpProfileDisplay;
+
+        /// <summary>
+        /// trEmail control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlTableRow trEmail;
+
+        /// <summary>
+        /// Img19 control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlImage Img19;
+
+        /// <summary>
+        /// txtEmailAddress control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.TextBox txtEmailAddress;
+
+        /// <summary>
+        /// trEmailNotificationSubjectTemplate control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlTableRow trEmailNotificationSubjectTemplate;
+
+        /// <summary>
+        /// Img27 control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlImage Img27;
+
+        /// <summary>
+        /// txtEmailNotificationSubjectTemplate control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.TextBox txtEmailNotificationSubjectTemplate;
 
         /// <summary>
         /// txtCreatePostCount control.


### PR DESCRIPTION

<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Moves email notification subject template to forum control panel rather than from template database table, which will be removed in next major release. This allows email notifications to have specific subject lines if forums or groups override inherited settings.

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
local install

![image](https://github.com/user-attachments/assets/2f785513-5aa3-40f9-bbac-9f579703e398)


## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #702