### PR TITLE
FIX: incorrect array size for social group security in module settings

### DIFF
--- a/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.de-DE.resx
+++ b/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.de-DE.resx
@@ -431,5 +431,67 @@
   </data>
   <data name="[RESX:Ban].Text" xml:space="preserve">
     <value>Sperre</value>
+  </data><data name="[RESX:SecGrid:Pin].Text" xml:space="preserve">
+    <value>Stecknadel</value>
+  </data>
+  <data name="[RESX:SecGrid:Attach].Text" xml:space="preserve">
+    <value>Anhängen</value>
+  </data>
+  <data name="[RESX:SecGrid:Ban].Text" xml:space="preserve">
+    <value>Sperre</value>
+  </data>
+  <data name="[RESX:SecGrid:Create].Text" xml:space="preserve">
+    <value>Erzeugen</value>
+  </data>
+  <data name="[RESX:SecGrid:Delete].Text" xml:space="preserve">
+    <value>Löschen</value>
+  </data>
+  <data name="[RESX:SecGrid:Edit].Text" xml:space="preserve">
+    <value>Bearbeiten</value>
+  </data>
+  <data name="[RESX:SecGrid:Lock].Text" xml:space="preserve">
+    <value>Sperre</value>
+  </data>
+  <data name="[RESX:SecGrid:Moderate].Text" xml:space="preserve">
+    <value>Moderieren</value>
+  </data>
+  <data name="[RESX:SecGrid:Move].Text" xml:space="preserve">
+    <value>Verschieben</value>
+  </data>
+  <data name="[RESX:SecGrid:Read].Text" xml:space="preserve">
+    <value>Lesen</value>
+  </data>
+  <data name="[RESX:SecGrid:Reply].Text" xml:space="preserve">
+    <value>Antwort</value>
+  </data>
+  <data name="[RESX:SecGrid:Subscribe]Text" xml:space="preserve">
+    <value>Abonnieren</value>
+  </data>
+  <data name="[RESX:SecGrid:View].Text" xml:space="preserve">
+    <value>Ansehen</value>
+  </data>
+  <data name="[RESX:SecGrid:Announce].Text" xml:space="preserve">
+    <value>Ankündigung</value>
+  </data>
+  <data name="[RESX:SecGrid:Subscribe].Text" xml:space="preserve">
+    <value>Abonnieren</value>
+  </data>
+  <data name="[RESX:SecGrid:Trust].Text" xml:space="preserve">
+    <value>Vertrauensstellung</value>
+  </data>
+  <data name="[RESX:SecGrid:Tag].Text" xml:space="preserve">
+    <value>Tag</value>
+  </data>
+  <data name="[RESX:SecGrid:Prioritize].Text" xml:space="preserve">
+    <value>Priorisieren</value>
+  </data>
+  <data name="[RESX:SecGrid:Categorize].Text" xml:space="preserve">
+    <value>Kategorisieren</value>
+  </data>
+  <data name="[RESX:SecGrid:Poll].Text" xml:space="preserve">
+    <value>Umfrage</value>
+  </data>
+  <data name="[RESX:SecGrid:Split].Text" xml:space="preserve">
+    <value>Trennen</value>
   </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.es-ES.resx
+++ b/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.es-ES.resx
@@ -326,5 +326,67 @@
   </data>
   <data name="[RESX:Ban].Text" xml:space="preserve">
     <value>Bloquear</value>
+  </data> <data name="[RESX:SecGrid:Pin].Text" xml:space="preserve">
+    <value>Anclar</value>
+  </data>
+  <data name="[RESX:SecGrid:Attach].Text" xml:space="preserve">
+    <value>Adjuntar</value>
+  </data>
+  <data name="[RESX:SecGrid:Ban].Text" xml:space="preserve">
+    <value>Bloquear</value>
+  </data>
+  <data name="[RESX:SecGrid:Create].Text" xml:space="preserve">
+    <value>Crear</value>
+  </data>
+  <data name="[RESX:SecGrid:Delete].Text" xml:space="preserve">
+    <value>Eliminar</value>
+  </data>
+  <data name="[RESX:SecGrid:Edit].Text" xml:space="preserve">
+    <value>Editar</value>
+  </data>
+  <data name="[RESX:SecGrid:Lock].Text" xml:space="preserve">
+    <value>Bloquear</value>
+  </data>
+  <data name="[RESX:SecGrid:Moderate].Text" xml:space="preserve">
+    <value>Moderar</value>
+  </data>
+  <data name="[RESX:SecGrid:Move].Text" xml:space="preserve">
+    <value>Mover</value>
+  </data>
+  <data name="[RESX:SecGrid:Read].Text" xml:space="preserve">
+    <value>Lectura</value>
+  </data>
+  <data name="[RESX:SecGrid:Reply].Text" xml:space="preserve">
+    <value>Respuesta</value>
+  </data>
+  <data name="[RESX:SecGrid:Subscribe]Text" xml:space="preserve">
+    <value>Subscribir</value>
+  </data>
+  <data name="[RESX:SecGrid:View].Text" xml:space="preserve">
+    <value>Vista</value>
+  </data>
+  <data name="[RESX:SecGrid:Announce].Text" xml:space="preserve">
+    <value>Anuncio</value>
+  </data>
+  <data name="[RESX:SecGrid:Subscribe].Text" xml:space="preserve">
+    <value>Subscribir</value>
+  </data>
+  <data name="[RESX:SecGrid:Tag].Text" xml:space="preserve">
+    <value>Etiqueta</value>
+  </data>
+  <data name="[RESX:SecGrid:Trust].Text" xml:space="preserve">
+    <value>Confianza</value>
+  </data>
+  <data name="[RESX:SecGrid:Prioritize].Text" xml:space="preserve">
+    <value>Priorizar</value>
+  </data>
+  <data name="[RESX:SecGrid:Categorize].Text" xml:space="preserve">
+    <value>Catalogar</value>
+  </data>
+  <data name="[RESX:SecGrid:Poll].Text" xml:space="preserve">
+    <value>Encuesta</value>
+  </data>
+  <data name="[RESX:SecGrid:Split].Text" xml:space="preserve">
+    <value>Partir</value>
   </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.fr-FR.resx
+++ b/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.fr-FR.resx
@@ -326,5 +326,67 @@
   </data>
   <data name="[RESX:Ban].Text" xml:space="preserve">
     <value>Bannir</value>
+  </data><data name="[RESX:SecGrid:Pin].Text" xml:space="preserve">
+    <value>Épingler</value>
+  </data>
+  <data name="[RESX:SecGrid:Attach].Text" xml:space="preserve">
+    <value>Joindre</value>
+  </data>
+  <data name="[RESX:SecGrid:Ban].Text" xml:space="preserve">
+    <value>Bannir</value>
+  </data>
+  <data name="[RESX:SecGrid:Create].Text" xml:space="preserve">
+    <value>Créer</value>
+  </data>
+  <data name="[RESX:SecGrid:Delete].Text" xml:space="preserve">
+    <value>Supprimer</value>
+  </data>
+  <data name="[RESX:SecGrid:Edit].Text" xml:space="preserve">
+    <value>Éditer</value>
+  </data>
+  <data name="[RESX:SecGrid:Lock].Text" xml:space="preserve">
+    <value>Verrouiller</value>
+  </data>
+  <data name="[RESX:SecGrid:Moderate].Text" xml:space="preserve">
+    <value>Modérer</value>
+  </data>
+  <data name="[RESX:SecGrid:Move].Text" xml:space="preserve">
+    <value>Déplacer</value>
+  </data>
+  <data name="[RESX:SecGrid:Read].Text" xml:space="preserve">
+    <value>Lire</value>
+  </data>
+  <data name="[RESX:SecGrid:Reply].Text" xml:space="preserve">
+    <value>Répondre</value>
+  </data>
+  <data name="[RESX:SecGrid:Subscribe]Text" xml:space="preserve">
+    <value>S’inscrire</value>
+  </data>
+  <data name="[RESX:SecGrid:View].Text" xml:space="preserve">
+    <value>Afficher</value>
+  </data>
+  <data name="[RESX:SecGrid:Announce].Text" xml:space="preserve">
+    <value>Announce</value>
+  </data>
+  <data name="[RESX:SecGrid:Subscribe].Text" xml:space="preserve">
+    <value>S’inscrire</value>
+  </data>
+  <data name="[RESX:SecGrid:Trust].Text" xml:space="preserve">
+    <value>Confiance</value>
+  </data>
+  <data name="[RESX:SecGrid:Tag].Text" xml:space="preserve">
+    <value>Étiquette</value>
+  </data>
+  <data name="[RESX:SecGrid:Prioritize].Text" xml:space="preserve">
+    <value>Prioriser</value>
+  </data>
+  <data name="[RESX:SecGrid:Categorize].Text" xml:space="preserve">
+    <value>Catégoriser</value>
+  </data>
+  <data name="[RESX:SecGrid:Poll].Text" xml:space="preserve">
+    <value>Scrutin</value>
+  </data>
+  <data name="[RESX:SecGrid:Split].Text" xml:space="preserve">
+    <value>Fendre</value>
   </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.it-IT.resx
+++ b/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.it-IT.resx
@@ -326,5 +326,67 @@
   </data>
   <data name="[RESX:Ban].Text" xml:space="preserve">
     <value>Vietare</value>
+  </data><data name="[RESX:SecGrid:Pin].Text" xml:space="preserve">
+    <value>Spilla</value>
+  </data>
+  <data name="[RESX:SecGrid:Attach].Text" xml:space="preserve">
+    <value>Allegare</value>
+  </data>
+  <data name="[RESX:SecGrid:Ban].Text" xml:space="preserve">
+    <value>Vietare</value>
+  </data>
+  <data name="[RESX:SecGrid:Create].Text" xml:space="preserve">
+    <value>Creare</value>
+  </data>
+  <data name="[RESX:SecGrid:Delete].Text" xml:space="preserve">
+    <value>Cancellare</value>
+  </data>
+  <data name="[RESX:SecGrid:Edit].Text" xml:space="preserve">
+    <value>Redigere</value>
+  </data>
+  <data name="[RESX:SecGrid:Lock].Text" xml:space="preserve">
+    <value>Serratura</value>
+  </data>
+  <data name="[RESX:SecGrid:Moderate].Text" xml:space="preserve">
+    <value>Moderato</value>
+  </data>
+  <data name="[RESX:SecGrid:Move].Text" xml:space="preserve">
+    <value>Sposta</value>
+  </data>
+  <data name="[RESX:SecGrid:Read].Text" xml:space="preserve">
+    <value>Leggere</value>
+  </data>
+  <data name="[RESX:SecGrid:Reply].Text" xml:space="preserve">
+    <value>Risposta</value>
+  </data>
+  <data name="[RESX:SecGrid:Subscribe]Text" xml:space="preserve">
+    <value>Abbonarsi</value>
+  </data>
+  <data name="[RESX:SecGrid:View].Text" xml:space="preserve">
+    <value>Vista</value>
+  </data>
+  <data name="[RESX:SecGrid:Announce].Text" xml:space="preserve">
+    <value>Annuncio</value>
+  </data>
+  <data name="[RESX:SecGrid:Subscribe].Text" xml:space="preserve">
+    <value>Abbonarsi</value>
+  </data>
+  <data name="[RESX:SecGrid:Trust].Text" xml:space="preserve">
+    <value>Attendibilità</value>
+  </data>
+  <data name="[RESX:SecGrid:Tag].Text" xml:space="preserve">
+    <value>Tag</value>
+  </data>
+  <data name="[RESX:SecGrid:Prioritize].Text" xml:space="preserve">
+    <value>Assegna priorità</value>
+  </data>
+  <data name="[RESX:SecGrid:Categorize].Text" xml:space="preserve">
+    <value>Categorizzare</value>
+  </data>
+  <data name="[RESX:SecGrid:Poll].Text" xml:space="preserve">
+    <value>Scrutinio</value>
+  </data>
+  <data name="[RESX:SecGrid:Split].Text" xml:space="preserve">
+    <value>Diviso</value>
   </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.nl-NL.resx
+++ b/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.nl-NL.resx
@@ -326,5 +326,67 @@
   </data>
   <data name="[RESX:Ban].Text" xml:space="preserve">
     <value>Verbod</value>
+  </data><data name="[RESX:SecGrid:Pin].Text" xml:space="preserve">
+    <value>Vastzetten</value>
+  </data>
+  <data name="[RESX:SecGrid:Attach].Text" xml:space="preserve">
+    <value>Vastmaken</value>
+  </data>
+  <data name="[RESX:SecGrid:Ban].Text" xml:space="preserve">
+    <value>Verbod</value>
+  </data>
+  <data name="[RESX:SecGrid:Create].Text" xml:space="preserve">
+    <value>Scheppen</value>
+  </data>
+  <data name="[RESX:SecGrid:Delete].Text" xml:space="preserve">
+    <value>Verwijderen</value>
+  </data>
+  <data name="[RESX:SecGrid:Edit].Text" xml:space="preserve">
+    <value>Bewerken</value>
+  </data>
+  <data name="[RESX:SecGrid:Lock].Text" xml:space="preserve">
+    <value>Slot</value>
+  </data>
+  <data name="[RESX:SecGrid:Moderate].Text" xml:space="preserve">
+    <value>Modereren</value>
+  </data>
+  <data name="[RESX:SecGrid:Move].Text" xml:space="preserve">
+    <value>Bewegen</value>
+  </data>
+  <data name="[RESX:SecGrid:Read].Text" xml:space="preserve">
+    <value>Lezen</value>
+  </data>
+  <data name="[RESX:SecGrid:Reply].Text" xml:space="preserve">
+    <value>Antwoord</value>
+  </data>
+  <data name="[RESX:SecGrid:Subscribe]Text" xml:space="preserve">
+    <value>Abonneren</value>
+  </data>
+  <data name="[RESX:SecGrid:View].Text" xml:space="preserve">
+    <value>Bekijken</value>
+  </data>
+  <data name="[RESX:SecGrid:Announce].Text" xml:space="preserve">
+    <value>Aankondiging</value>
+  </data>
+  <data name="[RESX:SecGrid:Subscribe].Text" xml:space="preserve">
+    <value>Abonneren</value>
+  </data>
+  <data name="[RESX:SecGrid:Trust].Text" xml:space="preserve">
+    <value>Vertrouwen</value>
+  </data>
+  <data name="[RESX:SecGrid:Tag].Text" xml:space="preserve">
+    <value>Label</value>
+  </data>
+  <data name="[RESX:SecGrid:Prioritize].Text" xml:space="preserve">
+    <value>Prioriteren</value>
+  </data>
+  <data name="[RESX:SecGrid:Categorize].Text" xml:space="preserve">
+    <value>Categoriseren</value>
+  </data>
+  <data name="[RESX:SecGrid:Poll].Text" xml:space="preserve">
+    <value>Peiling</value>
+  </data>
+  <data name="[RESX:SecGrid:Split].Text" xml:space="preserve">
+    <value>Splijten</value>
   </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.resx
+++ b/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.resx
@@ -431,5 +431,67 @@
   </data>
   <data name="[RESX:Ban].Text" xml:space="preserve">
     <value>Ban</value>
+  </data><data name="[RESX:SecGrid:Pin].Text" xml:space="preserve">
+    <value>Pin</value>
+  </data>
+  <data name="[RESX:SecGrid:Attach].Text" xml:space="preserve">
+    <value>Attach</value>
+  </data>
+  <data name="[RESX:SecGrid:Ban].Text" xml:space="preserve">
+    <value>Ban</value>
+  </data>
+  <data name="[RESX:SecGrid:Create].Text" xml:space="preserve">
+    <value>Create</value>
+  </data>
+  <data name="[RESX:SecGrid:Delete].Text" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="[RESX:SecGrid:Edit].Text" xml:space="preserve">
+    <value>Edit</value>
+  </data>
+  <data name="[RESX:SecGrid:Lock].Text" xml:space="preserve">
+    <value>Lock</value>
+  </data>
+  <data name="[RESX:SecGrid:Moderate].Text" xml:space="preserve">
+    <value>Moderate</value>
+  </data>
+  <data name="[RESX:SecGrid:Move].Text" xml:space="preserve">
+    <value>Move</value>
+  </data>
+  <data name="[RESX:SecGrid:Read].Text" xml:space="preserve">
+    <value>Read</value>
+  </data>
+  <data name="[RESX:SecGrid:Reply].Text" xml:space="preserve">
+    <value>Reply</value>
+  </data>
+  <data name="[RESX:SecGrid:Subscribe]Text" xml:space="preserve">
+    <value>Subscribe</value>
+  </data>
+  <data name="[RESX:SecGrid:View].Text" xml:space="preserve">
+    <value>View</value>
+  </data>
+  <data name="[RESX:SecGrid:Announce].Text" xml:space="preserve">
+    <value>Announce</value>
+  </data>
+  <data name="[RESX:SecGrid:Subscribe].Text" xml:space="preserve">
+    <value>Subscribe</value>
+  </data>
+  <data name="[RESX:SecGrid:Trust].Text" xml:space="preserve">
+    <value>Trust</value>
+  </data>
+  <data name="[RESX:SecGrid:Tag].Text" xml:space="preserve">
+    <value>Tag</value>
+  </data>
+  <data name="[RESX:SecGrid:Prioritize].Text" xml:space="preserve">
+    <value>Prioritize</value>
+  </data>
+  <data name="[RESX:SecGrid:Categorize].Text" xml:space="preserve">
+    <value>Categorize</value>
+  </data>
+  <data name="[RESX:SecGrid:Poll].Text" xml:space="preserve">
+    <value>Poll</value>
+  </data>
+  <data name="[RESX:SecGrid:Split].Text" xml:space="preserve">
+    <value>Split</value>
   </data>
 </root>

--- a/Dnn.CommunityForums/ForumSettings.ascx.cs
+++ b/Dnn.CommunityForums/ForumSettings.ascx.cs
@@ -437,7 +437,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 var xNodeList = xRoot.SelectSingleNode("//defaultforums/forum/security[@type='groupadmin']").ChildNodes;
                 var sb = new StringBuilder();
                 sb.Append("<table cellpadding=\"0\" cellspacing=\"0\">");
-                var rows = new string[13, 5];
+                var rows = new string[xNodeList.Count, 5];
                 int i = 0;
                 foreach (XmlNode x in xNodeList)
                 {
@@ -474,14 +474,14 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 sb.Append("<tr id=\"hd1\"><td></td><td colspan=\"10\" class=\"afgridhd sec1\">" + this.LocalizeString("UserPermissions") + "</td><td colspan=\"7\" class=\"afgridhd sec2\">" + this.LocalizeString("ModeratorPermissions") + "</td></tr>");
                 sb.Append("<tr id=\"hd2\"><td></td>");
                 string sClass;
-                for (i = 0; i <= 12; i++)
+                for (i = 0; i <= xNodeList.Count - 1; i++)
                 {
                     sClass = "afgridhdsub";
                     if (i == 0)
                     {
                         sClass += " colstart";
                     }
-                    else if (i == 12)
+                    else if (i == xNodeList.Count - 1)
                     {
                         sClass += " colend";
                     }
@@ -498,7 +498,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 sb.Append("</tr><tr id=\"row1\"><td class=\"rowhd\">" + this.LocalizeString("GroupAdmin") + "</td>");
                 i = 0;
 
-                for (i = 0; i <= 12; i++)
+                for (i = 0; i <= xNodeList.Count - 1; i++)
                 {
                     sClass = "gridcheck";
                     if (i <= 9)
@@ -510,7 +510,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                         sClass += " sec2";
                     }
 
-                    if (i == 12)
+                    if (i == xNodeList.Count - 1)
                     {
                         sClass += " colend";
                     }
@@ -537,7 +537,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 sb.Append("</tr>");
                 i = 0;
                 sb.Append("<tr id=\"row2\"><td class=\"rowhd\">" + this.LocalizeString("GroupMember") + "</td>");
-                for (i = 0; i <= 12; i++)
+                for (i = 0; i <= xNodeList.Count - 1; i++)
                 {
                     sClass = "gridcheck";
                     if (i <= 9)
@@ -549,7 +549,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                         sClass += " sec2";
                     }
 
-                    if (i == 12)
+                    if (i == xNodeList.Count - 1)
                     {
                         sClass += " colend";
                     }
@@ -576,7 +576,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
                 i = 0;
                 sb.Append("<tr id=\"row3\"><td class=\"rowhd\">" + this.LocalizeString("RegisteredUser") + "</td>");
-                for (i = 0; i <= 12; i++)
+                for (i = 0; i <= xNodeList.Count - 1; i++)
                 {
                     sClass = "gridcheck";
                     if (i <= 9)
@@ -588,7 +588,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                         sClass += " sec2";
                     }
 
-                    if (i == 12)
+                    if (i == xNodeList.Count - 1)
                     {
                         sClass += " colend";
                     }
@@ -614,7 +614,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 sb.Append("</tr>");
                 i = 0;
                 sb.Append("<tr id=\"row4\"><td class=\"rowhd\">" + this.LocalizeString("Anon") + "</td>");
-                for (i = 0; i <= 12; i++)
+                for (i = 0; i <= xNodeList.Count - 1; i++)
                 {
                     sClass = "gridcheck";
                     if (i <= 9)
@@ -626,7 +626,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                         sClass += " sec2";
                     }
 
-                    if (i == 12)
+                    if (i == xNodeList.Count - 1)
                     {
                         sClass += " colend";
                     }
@@ -675,8 +675,11 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 if (!string.IsNullOrEmpty(s))
                 {
                     string nodeName = s.Split('=')[0];
-                    string nodeValue = s.Split('=')[1];
-                    xNode[nodeName].Attributes["value"].Value = nodeValue;
+                    if (!string.IsNullOrEmpty(nodeName))
+                    {
+                        string nodeValue = s.Split('=')[1];
+                        xNode[nodeName].Attributes["value"].Value = nodeValue;
+                    }
                 }
             }
 


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Two issues with social group security in module settings 
- Incorrect array size causing module settings to not be saved
- localized strings not populated for security options in forum settings

## Changes made
- correct array size and usage
- add missing string resources

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1185