### PR TITLE
FIX: security option labels missing in module settings for social group security

### DIFF
--- a/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.de-DE.resx
+++ b/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.de-DE.resx
@@ -431,67 +431,68 @@
   </data>
   <data name="[RESX:Ban].Text" xml:space="preserve">
     <value>Sperre</value>
-  </data><data name="[RESX:SecGrid:Pin].Text" xml:space="preserve">
+  </data>
+  <data name="[RESX:SecGrid:pin].Text" xml:space="preserve">
     <value>Stecknadel</value>
   </data>
-  <data name="[RESX:SecGrid:Attach].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:attach].Text" xml:space="preserve">
     <value>Anhängen</value>
   </data>
-  <data name="[RESX:SecGrid:Ban].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:ban].Text" xml:space="preserve">
     <value>Sperre</value>
   </data>
-  <data name="[RESX:SecGrid:Create].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:create].Text" xml:space="preserve">
     <value>Erzeugen</value>
   </data>
-  <data name="[RESX:SecGrid:Delete].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:delete].Text" xml:space="preserve">
     <value>Löschen</value>
   </data>
-  <data name="[RESX:SecGrid:Edit].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:edit].Text" xml:space="preserve">
     <value>Bearbeiten</value>
   </data>
-  <data name="[RESX:SecGrid:Lock].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:lock].Text" xml:space="preserve">
     <value>Sperre</value>
   </data>
-  <data name="[RESX:SecGrid:Moderate].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:moderate].Text" xml:space="preserve">
     <value>Moderieren</value>
   </data>
-  <data name="[RESX:SecGrid:Move].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:move].Text" xml:space="preserve">
     <value>Verschieben</value>
   </data>
-  <data name="[RESX:SecGrid:Read].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:read].Text" xml:space="preserve">
     <value>Lesen</value>
   </data>
-  <data name="[RESX:SecGrid:Reply].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:reply].Text" xml:space="preserve">
     <value>Antwort</value>
   </data>
-  <data name="[RESX:SecGrid:Subscribe]Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:subscribe]Text" xml:space="preserve">
     <value>Abonnieren</value>
   </data>
-  <data name="[RESX:SecGrid:View].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:view].Text" xml:space="preserve">
     <value>Ansehen</value>
   </data>
-  <data name="[RESX:SecGrid:Announce].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:announce].Text" xml:space="preserve">
     <value>Ankündigung</value>
   </data>
-  <data name="[RESX:SecGrid:Subscribe].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:subscribe].Text" xml:space="preserve">
     <value>Abonnieren</value>
   </data>
-  <data name="[RESX:SecGrid:Trust].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:trust].Text" xml:space="preserve">
     <value>Vertrauensstellung</value>
   </data>
-  <data name="[RESX:SecGrid:Tag].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:tag].Text" xml:space="preserve">
     <value>Tag</value>
   </data>
-  <data name="[RESX:SecGrid:Prioritize].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:prioritize].Text" xml:space="preserve">
     <value>Priorisieren</value>
   </data>
-  <data name="[RESX:SecGrid:Categorize].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:categorize].Text" xml:space="preserve">
     <value>Kategorisieren</value>
   </data>
-  <data name="[RESX:SecGrid:Poll].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:poll].Text" xml:space="preserve">
     <value>Umfrage</value>
   </data>
-  <data name="[RESX:SecGrid:Split].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:split].Text" xml:space="preserve">
     <value>Trennen</value>
   </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.es-ES.resx
+++ b/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.es-ES.resx
@@ -326,67 +326,68 @@
   </data>
   <data name="[RESX:Ban].Text" xml:space="preserve">
     <value>Bloquear</value>
-  </data> <data name="[RESX:SecGrid:Pin].Text" xml:space="preserve">
+  </data>
+  <data name="[RESX:SecGrid:pin].Text" xml:space="preserve">
     <value>Anclar</value>
   </data>
-  <data name="[RESX:SecGrid:Attach].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:attach].Text" xml:space="preserve">
     <value>Adjuntar</value>
   </data>
-  <data name="[RESX:SecGrid:Ban].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:ban].Text" xml:space="preserve">
     <value>Bloquear</value>
   </data>
-  <data name="[RESX:SecGrid:Create].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:create].Text" xml:space="preserve">
     <value>Crear</value>
   </data>
-  <data name="[RESX:SecGrid:Delete].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:delete].Text" xml:space="preserve">
     <value>Eliminar</value>
   </data>
-  <data name="[RESX:SecGrid:Edit].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:edit].Text" xml:space="preserve">
     <value>Editar</value>
   </data>
-  <data name="[RESX:SecGrid:Lock].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:lock].Text" xml:space="preserve">
     <value>Bloquear</value>
   </data>
-  <data name="[RESX:SecGrid:Moderate].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:moderate].Text" xml:space="preserve">
     <value>Moderar</value>
   </data>
-  <data name="[RESX:SecGrid:Move].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:move].Text" xml:space="preserve">
     <value>Mover</value>
   </data>
-  <data name="[RESX:SecGrid:Read].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:read].Text" xml:space="preserve">
     <value>Lectura</value>
   </data>
-  <data name="[RESX:SecGrid:Reply].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:reply].Text" xml:space="preserve">
     <value>Respuesta</value>
   </data>
-  <data name="[RESX:SecGrid:Subscribe]Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:subscribe]Text" xml:space="preserve">
     <value>Subscribir</value>
   </data>
-  <data name="[RESX:SecGrid:View].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:view].Text" xml:space="preserve">
     <value>Vista</value>
   </data>
-  <data name="[RESX:SecGrid:Announce].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:announce].Text" xml:space="preserve">
     <value>Anuncio</value>
   </data>
-  <data name="[RESX:SecGrid:Subscribe].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:subscribe].Text" xml:space="preserve">
     <value>Subscribir</value>
   </data>
-  <data name="[RESX:SecGrid:Tag].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:tag].Text" xml:space="preserve">
     <value>Etiqueta</value>
   </data>
-  <data name="[RESX:SecGrid:Trust].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:trust].Text" xml:space="preserve">
     <value>Confianza</value>
   </data>
-  <data name="[RESX:SecGrid:Prioritize].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:prioritize].Text" xml:space="preserve">
     <value>Priorizar</value>
   </data>
-  <data name="[RESX:SecGrid:Categorize].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:categorize].Text" xml:space="preserve">
     <value>Catalogar</value>
   </data>
-  <data name="[RESX:SecGrid:Poll].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:poll].Text" xml:space="preserve">
     <value>Encuesta</value>
   </data>
-  <data name="[RESX:SecGrid:Split].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:split].Text" xml:space="preserve">
     <value>Partir</value>
   </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.fr-FR.resx
+++ b/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.fr-FR.resx
@@ -326,67 +326,68 @@
   </data>
   <data name="[RESX:Ban].Text" xml:space="preserve">
     <value>Bannir</value>
-  </data><data name="[RESX:SecGrid:Pin].Text" xml:space="preserve">
+  </data>
+  <data name="[RESX:SecGrid:pin].Text" xml:space="preserve">
     <value>Épingler</value>
   </data>
-  <data name="[RESX:SecGrid:Attach].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:attach].Text" xml:space="preserve">
     <value>Joindre</value>
   </data>
-  <data name="[RESX:SecGrid:Ban].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:ban].Text" xml:space="preserve">
     <value>Bannir</value>
   </data>
-  <data name="[RESX:SecGrid:Create].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:create].Text" xml:space="preserve">
     <value>Créer</value>
   </data>
-  <data name="[RESX:SecGrid:Delete].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:delete].Text" xml:space="preserve">
     <value>Supprimer</value>
   </data>
-  <data name="[RESX:SecGrid:Edit].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:edit].Text" xml:space="preserve">
     <value>Éditer</value>
   </data>
-  <data name="[RESX:SecGrid:Lock].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:lock].Text" xml:space="preserve">
     <value>Verrouiller</value>
   </data>
-  <data name="[RESX:SecGrid:Moderate].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:moderate].Text" xml:space="preserve">
     <value>Modérer</value>
   </data>
-  <data name="[RESX:SecGrid:Move].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:move].Text" xml:space="preserve">
     <value>Déplacer</value>
   </data>
-  <data name="[RESX:SecGrid:Read].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:read].Text" xml:space="preserve">
     <value>Lire</value>
   </data>
-  <data name="[RESX:SecGrid:Reply].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:reply].Text" xml:space="preserve">
     <value>Répondre</value>
   </data>
-  <data name="[RESX:SecGrid:Subscribe]Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:subscribe]Text" xml:space="preserve">
     <value>S’inscrire</value>
   </data>
-  <data name="[RESX:SecGrid:View].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:view].Text" xml:space="preserve">
     <value>Afficher</value>
   </data>
-  <data name="[RESX:SecGrid:Announce].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:announce].Text" xml:space="preserve">
     <value>Announce</value>
   </data>
-  <data name="[RESX:SecGrid:Subscribe].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:subscribe].Text" xml:space="preserve">
     <value>S’inscrire</value>
   </data>
-  <data name="[RESX:SecGrid:Trust].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:trust].Text" xml:space="preserve">
     <value>Confiance</value>
   </data>
-  <data name="[RESX:SecGrid:Tag].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:tag].Text" xml:space="preserve">
     <value>Étiquette</value>
   </data>
-  <data name="[RESX:SecGrid:Prioritize].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:prioritize].Text" xml:space="preserve">
     <value>Prioriser</value>
   </data>
-  <data name="[RESX:SecGrid:Categorize].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:categorize].Text" xml:space="preserve">
     <value>Catégoriser</value>
   </data>
-  <data name="[RESX:SecGrid:Poll].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:poll].Text" xml:space="preserve">
     <value>Scrutin</value>
   </data>
-  <data name="[RESX:SecGrid:Split].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:split].Text" xml:space="preserve">
     <value>Fendre</value>
   </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.it-IT.resx
+++ b/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.it-IT.resx
@@ -326,67 +326,68 @@
   </data>
   <data name="[RESX:Ban].Text" xml:space="preserve">
     <value>Vietare</value>
-  </data><data name="[RESX:SecGrid:Pin].Text" xml:space="preserve">
+  </data>
+  <data name="[RESX:SecGrid:pin].Text" xml:space="preserve">
     <value>Spilla</value>
   </data>
-  <data name="[RESX:SecGrid:Attach].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:attach].Text" xml:space="preserve">
     <value>Allegare</value>
   </data>
-  <data name="[RESX:SecGrid:Ban].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:ban].Text" xml:space="preserve">
     <value>Vietare</value>
   </data>
-  <data name="[RESX:SecGrid:Create].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:create].Text" xml:space="preserve">
     <value>Creare</value>
   </data>
-  <data name="[RESX:SecGrid:Delete].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:delete].Text" xml:space="preserve">
     <value>Cancellare</value>
   </data>
-  <data name="[RESX:SecGrid:Edit].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:edit].Text" xml:space="preserve">
     <value>Redigere</value>
   </data>
-  <data name="[RESX:SecGrid:Lock].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:lock].Text" xml:space="preserve">
     <value>Serratura</value>
   </data>
-  <data name="[RESX:SecGrid:Moderate].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:moderate].Text" xml:space="preserve">
     <value>Moderato</value>
   </data>
-  <data name="[RESX:SecGrid:Move].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:move].Text" xml:space="preserve">
     <value>Sposta</value>
   </data>
-  <data name="[RESX:SecGrid:Read].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:read].Text" xml:space="preserve">
     <value>Leggere</value>
   </data>
-  <data name="[RESX:SecGrid:Reply].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:reply].Text" xml:space="preserve">
     <value>Risposta</value>
   </data>
-  <data name="[RESX:SecGrid:Subscribe]Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:subscribe]Text" xml:space="preserve">
     <value>Abbonarsi</value>
   </data>
-  <data name="[RESX:SecGrid:View].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:view].Text" xml:space="preserve">
     <value>Vista</value>
   </data>
-  <data name="[RESX:SecGrid:Announce].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:announce].Text" xml:space="preserve">
     <value>Annuncio</value>
   </data>
-  <data name="[RESX:SecGrid:Subscribe].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:subscribe].Text" xml:space="preserve">
     <value>Abbonarsi</value>
   </data>
-  <data name="[RESX:SecGrid:Trust].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:trust].Text" xml:space="preserve">
     <value>Attendibilità</value>
   </data>
-  <data name="[RESX:SecGrid:Tag].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:tag].Text" xml:space="preserve">
     <value>Tag</value>
   </data>
-  <data name="[RESX:SecGrid:Prioritize].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:prioritize].Text" xml:space="preserve">
     <value>Assegna priorità</value>
   </data>
-  <data name="[RESX:SecGrid:Categorize].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:categorize].Text" xml:space="preserve">
     <value>Categorizzare</value>
   </data>
-  <data name="[RESX:SecGrid:Poll].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:poll].Text" xml:space="preserve">
     <value>Scrutinio</value>
   </data>
-  <data name="[RESX:SecGrid:Split].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:split].Text" xml:space="preserve">
     <value>Diviso</value>
   </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.nl-NL.resx
+++ b/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.nl-NL.resx
@@ -326,67 +326,68 @@
   </data>
   <data name="[RESX:Ban].Text" xml:space="preserve">
     <value>Verbod</value>
-  </data><data name="[RESX:SecGrid:Pin].Text" xml:space="preserve">
+  </data>
+  <data name="[RESX:SecGrid:pin].Text" xml:space="preserve">
     <value>Vastzetten</value>
   </data>
-  <data name="[RESX:SecGrid:Attach].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:attach].Text" xml:space="preserve">
     <value>Vastmaken</value>
   </data>
-  <data name="[RESX:SecGrid:Ban].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:ban].Text" xml:space="preserve">
     <value>Verbod</value>
   </data>
-  <data name="[RESX:SecGrid:Create].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:create].Text" xml:space="preserve">
     <value>Scheppen</value>
   </data>
-  <data name="[RESX:SecGrid:Delete].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:delete].Text" xml:space="preserve">
     <value>Verwijderen</value>
   </data>
-  <data name="[RESX:SecGrid:Edit].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:edit].Text" xml:space="preserve">
     <value>Bewerken</value>
   </data>
-  <data name="[RESX:SecGrid:Lock].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:lock].Text" xml:space="preserve">
     <value>Slot</value>
   </data>
-  <data name="[RESX:SecGrid:Moderate].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:moderate].Text" xml:space="preserve">
     <value>Modereren</value>
   </data>
-  <data name="[RESX:SecGrid:Move].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:move].Text" xml:space="preserve">
     <value>Bewegen</value>
   </data>
-  <data name="[RESX:SecGrid:Read].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:read].Text" xml:space="preserve">
     <value>Lezen</value>
   </data>
-  <data name="[RESX:SecGrid:Reply].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:reply].Text" xml:space="preserve">
     <value>Antwoord</value>
   </data>
-  <data name="[RESX:SecGrid:Subscribe]Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:subscribe]Text" xml:space="preserve">
     <value>Abonneren</value>
   </data>
-  <data name="[RESX:SecGrid:View].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:view].Text" xml:space="preserve">
     <value>Bekijken</value>
   </data>
-  <data name="[RESX:SecGrid:Announce].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:announce].Text" xml:space="preserve">
     <value>Aankondiging</value>
   </data>
-  <data name="[RESX:SecGrid:Subscribe].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:subscribe].Text" xml:space="preserve">
     <value>Abonneren</value>
   </data>
-  <data name="[RESX:SecGrid:Trust].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:trust].Text" xml:space="preserve">
     <value>Vertrouwen</value>
   </data>
-  <data name="[RESX:SecGrid:Tag].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:tag].Text" xml:space="preserve">
     <value>Label</value>
   </data>
-  <data name="[RESX:SecGrid:Prioritize].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:prioritize].Text" xml:space="preserve">
     <value>Prioriteren</value>
   </data>
-  <data name="[RESX:SecGrid:Categorize].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:categorize].Text" xml:space="preserve">
     <value>Categoriseren</value>
   </data>
-  <data name="[RESX:SecGrid:Poll].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:poll].Text" xml:space="preserve">
     <value>Peiling</value>
   </data>
-  <data name="[RESX:SecGrid:Split].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:split].Text" xml:space="preserve">
     <value>Splijten</value>
   </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.resx
+++ b/Dnn.CommunityForums/App_LocalResources/ForumSettings.ascx.resx
@@ -431,67 +431,68 @@
   </data>
   <data name="[RESX:Ban].Text" xml:space="preserve">
     <value>Ban</value>
-  </data><data name="[RESX:SecGrid:Pin].Text" xml:space="preserve">
+  </data>
+  <data name="[RESX:SecGrid:pin].Text" xml:space="preserve">
     <value>Pin</value>
   </data>
-  <data name="[RESX:SecGrid:Attach].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:attach].Text" xml:space="preserve">
     <value>Attach</value>
   </data>
-  <data name="[RESX:SecGrid:Ban].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:ban].Text" xml:space="preserve">
     <value>Ban</value>
   </data>
-  <data name="[RESX:SecGrid:Create].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:create].Text" xml:space="preserve">
     <value>Create</value>
   </data>
-  <data name="[RESX:SecGrid:Delete].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:delete].Text" xml:space="preserve">
     <value>Delete</value>
   </data>
-  <data name="[RESX:SecGrid:Edit].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:edit].Text" xml:space="preserve">
     <value>Edit</value>
   </data>
-  <data name="[RESX:SecGrid:Lock].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:lock].Text" xml:space="preserve">
     <value>Lock</value>
   </data>
-  <data name="[RESX:SecGrid:Moderate].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:moderate].Text" xml:space="preserve">
     <value>Moderate</value>
   </data>
-  <data name="[RESX:SecGrid:Move].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:move].Text" xml:space="preserve">
     <value>Move</value>
   </data>
-  <data name="[RESX:SecGrid:Read].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:read].Text" xml:space="preserve">
     <value>Read</value>
   </data>
-  <data name="[RESX:SecGrid:Reply].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:reply].Text" xml:space="preserve">
     <value>Reply</value>
   </data>
-  <data name="[RESX:SecGrid:Subscribe]Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:subscribe]Text" xml:space="preserve">
     <value>Subscribe</value>
   </data>
-  <data name="[RESX:SecGrid:View].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:view].Text" xml:space="preserve">
     <value>View</value>
   </data>
-  <data name="[RESX:SecGrid:Announce].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:announce].Text" xml:space="preserve">
     <value>Announce</value>
   </data>
-  <data name="[RESX:SecGrid:Subscribe].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:subscribe].Text" xml:space="preserve">
     <value>Subscribe</value>
   </data>
-  <data name="[RESX:SecGrid:Trust].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:trust].Text" xml:space="preserve">
     <value>Trust</value>
   </data>
-  <data name="[RESX:SecGrid:Tag].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:tag].Text" xml:space="preserve">
     <value>Tag</value>
   </data>
-  <data name="[RESX:SecGrid:Prioritize].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:prioritize].Text" xml:space="preserve">
     <value>Prioritize</value>
   </data>
-  <data name="[RESX:SecGrid:Categorize].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:categorize].Text" xml:space="preserve">
     <value>Categorize</value>
   </data>
-  <data name="[RESX:SecGrid:Poll].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:poll].Text" xml:space="preserve">
     <value>Poll</value>
   </data>
-  <data name="[RESX:SecGrid:Split].Text" xml:space="preserve">
+  <data name="[RESX:SecGrid:split].Text" xml:space="preserve">
     <value>Split</value>
   </data>
 </root>

--- a/Dnn.CommunityForums/ForumSettings.ascx.cs
+++ b/Dnn.CommunityForums/ForumSettings.ascx.cs
@@ -491,7 +491,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     }
 
                     sb.Append("<td class=\"" + sClass + "\">");
-                    sb.Append(this.LocalizeString("SecGrid:" + rows[i, 0]));
+                    sb.Append(this.LocalizeString("[RESX:SecGrid:" + rows[i, 0].ToLowerInvariant() + "]"));
                     sb.Append("</td>");
                 }
 


### PR DESCRIPTION


<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Continuation of PR #1186 
FIX: security option labels missing in module settings when configuring social group security

## Changes made
- resource strings need to be matching case in code and resx file
- Wrap in [RESX: ... ]

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install
![image](https://github.com/user-attachments/assets/c1bb3da6-7311-42b5-b522-8a23837e4557)

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1185