### PR TITLE
FIX: Wrong signature displayed in forum posts

### DIFF
--- a/Dnn.CommunityForums/themes/community-bootstrap/templates/TopicView.ascx
+++ b/Dnn.CommunityForums/themes/community-bootstrap/templates/TopicView.ascx
@@ -88,8 +88,7 @@
 								
 							</section>
 							<footer class="dcf-post-footer">
-                                [FORUMUSER:SIGNATURE|<div class="dcf-post-signature">{0}</div>
-                                ]
+                                [FORUMAUTHOR:SIGNATURE|<div class="dcf-post-signature">{0}</div>]
 								<div class="dcf-post-footer-bottom">
 									<div class="dcf-col-50">
                                         [FORUMPOST:MODEDITDATE]
@@ -139,8 +138,7 @@
 								
 							</section>
 							<footer class="dcf-post-footer">
-                                [FORUMUSER:SIGNATURE|<div class="dcf-post-signature">{0}</div>
-                                ]
+                                [FORUMAUTHOR:SIGNATURE|<div class="dcf-post-signature">{0}</div>]
 								<div class="dcf-post-footer-bottom">
 									<div class="dcf-col-50">
                                         [FORUMPOST:MODEDITDATE]

--- a/Dnn.CommunityForums/themes/community-default/templates/TopicView.ascx
+++ b/Dnn.CommunityForums/themes/community-default/templates/TopicView.ascx
@@ -95,7 +95,7 @@
 								
 							</section>
 							<footer class="dcf-post-footer">
-                                [FORUMUSER:SIGNATURE|<div class="dcf-post-signature">{0}</div>]
+                                [FORUMAUTHOR:SIGNATURE|<div class="dcf-post-signature">{0}</div>]
 
                                 <div class="dcf-cols dcf-post-footer-bottom">
 									<div class="dcf-col-50">
@@ -151,7 +151,7 @@
 								
 							</section>
 							<footer class="dcf-post-footer">
-                                [FORUMUSER:SIGNATURE|<div class="dcf-post-signature">{0}</div>]
+                                [FORUMAUTHOR:SIGNATURE|<div class="dcf-post-signature">{0}</div>]
 
 								<div class="dcf-cols dcf-post-footer-bottom">
 									<div class="dcf-col-50">


### PR DESCRIPTION


<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Forum post showing viewing user's signature not author's signature

## Changes made
- FIX: Use [FORUMAUTHOR:SIGNATURE] not [FORUMUSER:SIGNATURE] in delivered TopicView templates

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install
![image](https://github.com/user-attachments/assets/810c02e3-11ca-403c-b5cc-5a30f9849c05)

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1194 