### PR TITLE
FIX: Multiple records created in activeforums_UserProfiles for same user

### DIFF
--- a/Dnn.CommunityForums/Controllers/ForumUserController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumUserController.cs
@@ -220,9 +220,9 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
         public static int Save(DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo user)
         {
             user.DateUpdated = DateTime.UtcNow;
-            var x = new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(user.ModuleId).Save<int>(user, user.ProfileId);
+            var forumUser = new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(user.ModuleId).Save<int>(user, user.ProfileId);
             DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.ClearCache(user.PortalId, user.UserId);
-            return x.UserId;
+            return forumUser.UserId;
         }
 
         public bool GetUserIsAdmin(int portalId, int moduleId, int userId)

--- a/Dnn.CommunityForums/CustomControls/UserControls/UserProfile.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/UserProfile.cs
@@ -374,10 +374,9 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                         user.Signature = Utilities.XSSFilter(this.txtSignature.Text, false);
                     }
 
-
                 }
 
-                new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ForumModuleId).Save<int>(user, user.UserId);
+                DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.Save(user);
             }
 
             return true;

--- a/Dnn.CommunityForums/Entities/ForumUserInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumUserInfo.cs
@@ -622,7 +622,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             return string.Empty;
         }
 
-        internal string GetCacheKey() => new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetCacheKey(this.PortalId, this.UserId);
+        internal string GetCacheKey() => string.Format(CacheKeys.ForumUser, this.PortalId, this.UserId);
 
         internal void UpdateCache() => DataCache.UserCacheStore(this.GetCacheKey(), this);
     }

--- a/Dnn.CommunityForums/controls/profile_mypreferences.ascx.cs
+++ b/Dnn.CommunityForums/controls/profile_mypreferences.ascx.cs
@@ -91,7 +91,8 @@ namespace DotNetNuke.Modules.ActiveForums
                     {
                         upi.Signature = Utilities.XSSFilter(this.txtSignature.Text, false);
                     }
-                    new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ForumModuleId).Save<int>(upi, upi.UserId);
+
+                    DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.Save(upi);
 
                     this.Response.Redirect(this.NavigateUrl(this.TabId), false);
                     this.Context.ApplicationInstance.CompleteRequest();

--- a/Dnn.CommunityForums/sql/08.02.00.SqlDataProvider
+++ b/Dnn.CommunityForums/sql/08.02.00.SqlDataProvider
@@ -2410,3 +2410,85 @@ END
 GO
 /* issue 688 end -- like notifications */
 /* --------------------- */
+
+
+/* issue 1218 begin -- multiple userProfiles records */
+
+
+/* activeforums_UserProfiles_Opt3  */
+IF  EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'{objectQualifier}activeforums_UserProfiles') AND name = N'idx_{objectQualifier}activeforums_UserProfiles_Opt3')
+DROP INDEX [idx_{objectQualifier}activeforums_UserProfiles_Opt3] ON {databaseOwner}{objectQualifier}activeforums_UserProfiles 
+GO
+
+
+
+/* delete any duplicated user records, keeping latest one */
+WITH up_max AS (
+SELECT up.PortalId, up.UserId, MAX(ProfileId) AS ProfileId 
+FROM {databaseOwner}[{objectQualifier}activeforums_UserProfiles] up 
+GROUP BY up.PortalId, up.UserId
+)
+, up_multiples AS (
+SELECT up.PortalId, up.UserId, up_max.ProfileId
+FROM {databaseOwner}[{objectQualifier}activeforums_UserProfiles] up 
+LEFT OUTER JOIN up_max
+ON up_max.PortalId = up.PortalId
+AND up_max.UserId = up.UserId
+GROUP BY up.UserId, up.PortalId, up_max.ProfileId
+HAVING COUNT(*) > 1
+)
+
+DELETE up 
+FROM {databaseOwner}[{objectQualifier}activeforums_UserProfiles] up 
+INNER JOIN up_max
+ON up_max.PortalId = up.PortalId
+AND up_max.UserId = up.UserId
+INNER JOIN up_multiples
+ON up_multiples.PortalId = up_max.PortalId
+AND up_multiples.UserId = up_max.UserId
+
+WHERE up.PortalId = up_max.PortalId
+AND up.UserId = up_max.UserId
+AND up.ProfileId < up_max.ProfileId
+GO
+
+CREATE UNIQUE NONCLUSTERED INDEX [idx_{objectQualifier}activeforums_UserProfiles_Opt3] ON {databaseOwner}{objectQualifier}activeforums_UserProfiles 
+(
+	[PortalId] ASC,
+	[UserId] ASC
+)
+INCLUDE ( [ProfileId],
+[TopicCount],
+[ReplyCount],
+[ViewCount],
+[AnswerCount],
+[RewardPoints],
+[UserCaption],
+[DateCreated],
+[DateUpdated],
+[DateLastActivity],
+[Signature],
+[SignatureDisabled],
+[TrustLevel],
+[AdminWatch],
+[AttachDisabled],
+[Avatar],
+[AvatarType],
+[AvatarDisabled],
+[PrefDefaultSort],
+[PrefDefaultShowReplies],
+[PrefJumpLastPost],
+[PrefTopicSubscribe],
+[PrefSubscriptionType],
+[PrefEmailFormat],
+[PrefBlockAvatars],
+[PrefBlockSignatures],
+[PrefPageSize],
+[DateLastPost]) WITH (SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, IGNORE_DUP_KEY = OFF, ONLINE = OFF) 
+GO
+
+
+/* --------------------- */
+
+
+/* issue 1218 end -- multiple userProfiles records */


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Fix issue found during pre-release testing where multiple records were being created for same user in `activeforums_UserProfiles`

## Changes made
- ForumUser needs to be saved correctly (primary key is ProfileId **not** UserId)
- Add SQL script to delete any duplicated users records, keeping only latest one (should not encounter this except anyone doing pre-release testing)
- Create index `[idx_activeforums_UserProfiles_Opt3]` with `**unique**` constraint

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
local install

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1218