### PR TITLE
FIX: Replace null CreatedOnDate with minimum SQL date when creating Forum User in activeforums_UserProfiles

### DIFF
--- a/Dnn.CommunityForums/Controllers/ForumUserController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumUserController.cs
@@ -96,6 +96,10 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                         if (user.UserInfo != null)
                         {
                             user.DateCreated = user.UserInfo.CreatedOnDate;
+                            if (user.DateCreated < System.Data.SqlTypes.SqlDateTime.MinValue.Value)
+                            {
+                                user.DateCreated = System.Data.SqlTypes.SqlDateTime.MinValue.Value;
+                            }
                             this.Insert(user);
                         }
                     }

--- a/Dnn.CommunityForums/Entities/ForumUserInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumUserInfo.cs
@@ -78,7 +78,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
 
         public string UserCaption { get; set; }
 
-        public DateTime DateCreated { get; set; } = DateTime.UtcNow;
+        public DateTime? DateCreated { get; set; } = DateTime.UtcNow;
 
         public DateTime? DateUpdated { get; set; }
 
@@ -509,7 +509,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                 case "displayname":
                     return PropertyAccess.FormatString(DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetDisplayName(this.PortalSettings, this.MainSettings, isMod: new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(portalId: accessingUser.PortalID, userId: accessingUser.UserID).GetIsMod(this.ModuleId), isAdmin: new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(portalId: accessingUser.PortalID, userId: accessingUser.UserID).IsAdmin, this.UserId, this.Username, this.FirstName, this.LastName, this.DisplayName), format);
                 case "datecreated":
-                    return Utilities.GetUserFormattedDateTime((DateTime?)this.DateCreated, formatProvider, accessingUser.Profile.PreferredTimeZone.GetUtcOffset(DateTime.UtcNow));
+                    return Utilities.GetUserFormattedDateTime(this.DateCreated, formatProvider, accessingUser.Profile.PreferredTimeZone.GetUtcOffset(DateTime.UtcNow));
                 case "dateupdated":
                     return Utilities.GetUserFormattedDateTime(this.DateUpdated, formatProvider, accessingUser.Profile.PreferredTimeZone.GetUtcOffset(DateTime.UtcNow));
                 case "datelastpost":


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...

If a user doesn't have a value in CreatedOnDate in Users table, use minimum SQL date when creating the Forum User in activeforums_UserProfiles.


## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1226