### PR TITLE
ENH: Save Social Integration forum security using common permissions

### DIFF
--- a/Dnn.CommunityForums/Controllers/ForumController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumController.cs
@@ -33,6 +33,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
     using DotNetNuke.UI.UserControls;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Modules.ActiveForums.Entities;
+    using DotNetNuke.Collections;
 
     internal class ForumController : DotNetNuke.Modules.ActiveForums.Controllers.RepositoryControllerBase<DotNetNuke.Modules.ActiveForums.Entities.ForumInfo>
     {
@@ -512,6 +513,21 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             {
                 Exceptions.LogException(ex);
                 return false;
+            }
+        }
+
+        internal static void UpdatePermissionsForSocialGroupForums(int moduleId)
+        {
+            try
+            {
+                new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().Get().Where(f => f.SocialGroupId != 0).ForEach(forum =>
+                {
+                    new DotNetNuke.Modules.ActiveForums.Controllers.PermissionController().UpdateSecurityForSocialGroupForum(forum);
+                });
+            }
+            catch (Exception ex)
+            {
+                Exceptions.LogException(ex);
             }
         }
 

--- a/Dnn.CommunityForums/Controllers/PermissionController.cs
+++ b/Dnn.CommunityForums/Controllers/PermissionController.cs
@@ -21,9 +21,11 @@
 namespace DotNetNuke.Modules.ActiveForums.Controllers
 {
     using System;
+    using System.Collections;
     using System.Collections.Specialized;
     using System.Linq;
     using System.Linq.Expressions;
+    using System.Xml;
 
     using DotNetNuke.Abstractions.Portals;
 
@@ -61,6 +63,104 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             return this.GetById(permissionInfo.PermissionsId, permissionInfo.ModuleId);
         }
 
+        internal void UpdateSecurityForSocialGroupForum(DotNetNuke.Modules.ActiveForums.Entities.ForumInfo forum)
+        {
+            var permissions = this.GetById(forum.PermissionsId, forum.ModuleId);
+            Hashtable htSettings = DotNetNuke.Entities.Modules.ModuleController.Instance.GetModule(moduleId: forum.ModuleId, tabId: forum.TabId, ignoreCache: false).TabModuleSettings;
+            if (htSettings == null || htSettings.Count == 0)
+            {
+                htSettings = DotNetNuke.Entities.Modules.ModuleController.Instance.GetModule(moduleId: forum.ModuleId, tabId: forum.TabId, ignoreCache: false).ModuleSettings;
+            }
+
+            if (htSettings == null || htSettings.Count == 0 || !htSettings.ContainsKey("ForumConfig"))
+            {
+                var ex = new Exception($"Unable to configure forum security for Social Group: {forum.SocialGroupId}");
+                DotNetNuke.Services.Exceptions.Exceptions.LogException(ex);
+            }
+            else
+            {
+                var xDoc = new XmlDocument();
+                xDoc.LoadXml(htSettings["ForumConfig"].ToString());
+                XmlNode xRoot = xDoc.DocumentElement;
+                var roleIdAnon = Convert.ToInt32(Common.Globals.glbRoleUnauthUser);
+                var roleIdAdmin = GetAdministratorsRoleId(forum.PortalId);
+                var roleIdRegUsers = GetRegisteredRoleId(forum.PortalId);
+                var roleIdGroupMember = forum.SocialGroupId;
+                foreach (var sectype in new string[] { "groupadmin", "groupmember", "registereduser", "anon" })
+                {
+                    var xNode = xRoot.SelectSingleNode("//defaultforums/forum/security[@type='" + sectype + "']");
+                    foreach (XmlNode sNode in xNode.ChildNodes)
+                    {
+                        var sPerm = sNode.Name;
+                        var roleId = -1;
+                        switch (sectype)
+                        {
+                            case "groupadmin":
+                                roleId = roleIdAdmin;
+                                break;
+                            case "groupmember":
+                                roleId = roleIdGroupMember;
+                                break;
+                            case "registereduser":
+                                roleId = roleIdRegUsers;
+                                break;
+                            case "anon":
+                                roleId = roleIdAnon;
+                                break;
+                        }
+
+                        if (Convert.ToBoolean(sNode.Attributes["value"].Value))
+                        {
+                            switch (sPerm)
+                            {
+                                case "view":
+                                    permissions.View = AddPermToSet(roleId.ToString(), 0, permissions.View);
+                                    break;
+                                case "read":
+                                    permissions.Read = AddPermToSet(roleId.ToString(), 0, permissions.Read);
+                                    break;
+                                case "create":
+                                    permissions.Create = AddPermToSet(roleId.ToString(), 0, permissions.Create);
+                                    break;
+                                case "reply":
+                                    permissions.Reply = AddPermToSet(roleId.ToString(), 0, permissions.Reply);
+                                    break;
+                                case "edit":
+                                    permissions.Edit = AddPermToSet(roleId.ToString(), 0, permissions.Edit);
+                                    break;
+                                case "delete":
+                                    permissions.Delete = AddPermToSet(roleId.ToString(), 0, permissions.Delete);
+                                    break;
+                                case "lock":
+                                    permissions.Lock = AddPermToSet(roleId.ToString(), 0, permissions.Lock);
+                                    break;
+                                case "pin":
+                                    permissions.Pin = AddPermToSet(roleId.ToString(), 0, permissions.Pin);
+                                    break;
+                                case "attach":
+                                    permissions.Attach = AddPermToSet(roleId.ToString(), 0, permissions.Attach);
+                                    break;
+                                case "subscribe":
+                                    permissions.Subscribe = AddPermToSet(roleId.ToString(), 0, permissions.Subscribe);
+                                    break;
+                                case "moderate":
+                                    permissions.Moderate = AddPermToSet(roleId.ToString(), 0, permissions.Moderate);
+                                    break;
+                                case "move":
+                                    permissions.Move = AddPermToSet(roleId.ToString(), 0, permissions.Move);
+                                    break;
+                                case "ban":
+                                    permissions.Ban = AddPermToSet(roleId.ToString(), 0, permissions.Ban);
+                                    break;
+                            }
+                        }
+                    }
+                }
+
+                this.Update(permissions);
+            }
+        }
+
         internal DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo GetById(int permissionId, int moduleId)
         {
             var cachekey = this.GetCacheKey(moduleId: moduleId, id: permissionId);
@@ -69,9 +169,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             {
                 permissions = base.GetById(permissionId, moduleId);
                 DotNetNuke.Modules.ActiveForums.DataCache.SettingsCacheStore(moduleId, cachekey, permissions);
-
             }
-
             return permissions;
         }
 
@@ -637,6 +735,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
         {
             string newSet = RemovePermFromSet(objectId, objectType, permissionSet);
             string[] permSet = newSet.Split('|');
+            permSet[objectType] += string.Concat(objectId, ";");
             newSet = string.Concat(permSet[0] + "|" + (permSet.Length > 1 ? permSet[1] : string.Empty) + "|" + (permSet.Length > 2 ? permSet[2] : string.Empty), "|");
             return newSet;
         }

--- a/Dnn.CommunityForums/ForumSettings.ascx.cs
+++ b/Dnn.CommunityForums/ForumSettings.ascx.cs
@@ -272,6 +272,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 var anonSec = this.txtGroupAnonSec.Value.Split(',');
                 this.SaveForumSecurity("anon", anonSec);
 
+                DotNetNuke.Modules.ActiveForums.Controllers.ForumController.UpdatePermissionsForSocialGroupForums(this.ModuleId);
+
                 try
                 {
                     if (this.IsFullTextAvailable && this.FullTextSearch && this.FullTextStatus != 1) // Available, selected and not currently installed


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Updates security settings when using social integration to use same permissions storage and security checking as standard forums.
(follow-on to PR #1230 & social integration testing).


## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

Module settings for security when using social integration:
![image](https://github.com/user-attachments/assets/0b78b3b7-b1aa-46c8-a01b-6a2f054aa229)

Permissions/Security now stored just like for other forums
![image](https://github.com/user-attachments/assets/8d3aad6a-97ca-403c-8b52-555315a945d1)

## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1229