### PR TITLE
FIX: Issues with email notifications

### DIFF
--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
@@ -73,7 +73,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
         public string OptDefaultSort { get; set; }
 
-        public string MetaTemplate { get; set; } = "[META][TITLE][FORUMTOPIC:SUBJECT] - [PORTAL:PORTALNAME] - [TAB:TITLE] - [FORUMGROUP:GROUPNAME] - [FORUM:FORUMNAME][/TITLE][DESCRIPTION][BODY:255][/DESCRIPTION][KEYWORDS][TAGS][VALUE][/KEYWORDS][/META]";
+        public string MetaTemplate { get; set; } = "[META][TITLE][FORUMTOPIC:SUBJECT] - [PORTAL:PORTALNAME] - [TAB:TITLE] - [FORUMGROUP:GROUPNAME] - [FORUM:FORUMNAME][/TITLE][DESCRIPTION][FORUMTOPIC:BODY:255][/DESCRIPTION][KEYWORDS][TAGS][VALUE][/KEYWORDS][/META]";
 
         public string MetaTitle { get; set; } = string.Empty;
 

--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicsView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicsView.cs
@@ -55,7 +55,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
         private bool isSubscribedForum;
         private bool useListActions;
 
-        public string MetaTemplate { get; set; } = "[META][TITLE][PORTAL:PORTALNAME] - [TAB:TITLE] - [FORUMGROUP:GROUPNAME] - [FORUM:FORUMNAME][/TITLE][DESCRIPTION][BODY][/DESCRIPTION][KEYWORDS][VALUE][/KEYWORDS][/META]";
+        public string MetaTemplate { get; set; } = "[META][TITLE][PORTAL:PORTALNAME] - [TAB:TITLE] - [FORUMGROUP:GROUPNAME] - [FORUM:FORUMNAME][/TITLE][DESCRIPTION][FORUM:FORUMDESCRIPTION][/DESCRIPTION][KEYWORDS][VALUE][/KEYWORDS][/META]";
 
         public string MetaTitle { get; set; } = string.Empty;
 
@@ -229,36 +229,6 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                             {
                                 this.MetaTemplate = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.RemoveObsoleteTokens(new StringBuilder( this.MetaTemplate)).ToString();
                                 this.MetaTemplate = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.ReplaceForumTokens(new StringBuilder(this.MetaTemplate), this.ForumInfo, this.PortalSettings, this.MainSettings, new Services.URLNavigator().NavigationManager(), this.ForumUser, this.TabId, this.ForumUser.CurrentUserType, this.Request.Url, this.Request.RawUrl).ToString();
-                                this.MetaTemplate = this.MetaTemplate.Replace("[TAGS]", string.Empty);
-                                if (this.MetaTemplate.Contains("[TOPICSUBJECT:"))
-                                {
-                                    string pattern = "(\\[TOPICSUBJECT:(.+?)\\])";
-                                    foreach (Match m in RegexUtils.GetCachedRegex(pattern, RegexOptions.Compiled & RegexOptions.IgnoreCase, 2).Matches(this.MetaTemplate))
-                                    {
-                                        this.MetaTemplate = this.MetaTemplate.Replace(m.Value, string.Empty);
-                                    }
-                                }
-
-                                this.MetaTemplate = this.MetaTemplate.Replace("[TOPICSUBJECT]", string.Empty);
-                                if (this.MetaTemplate.Contains("[BODY:"))
-                                {
-                                    string pattern = "(\\[BODY:(.+?)\\])";
-                                    foreach (Match m in RegexUtils.GetCachedRegex(pattern, RegexOptions.Compiled & RegexOptions.IgnoreCase, 2).Matches(this.MetaTemplate))
-                                    {
-                                        int iLen = Convert.ToInt32(m.Groups[2].Value);
-                                        if (this.ForumInfo.ForumDesc.Length > iLen)
-                                        {
-                                            this.MetaTemplate = this.MetaTemplate.Replace(m.Value, this.ForumInfo.ForumDesc.Substring(0, iLen) + "...");
-                                        }
-                                        else
-                                        {
-                                            this.MetaTemplate = this.MetaTemplate.Replace(m.Value, this.ForumInfo.ForumDesc);
-                                        }
-                                    }
-                                }
-
-                                this.MetaTemplate = this.MetaTemplate.Replace("[BODY]", Utilities.StripHTMLTag(this.ForumInfo.ForumDesc));
-
                                 this.MetaTitle = TemplateUtils.GetTemplateSection(this.MetaTemplate, "[TITLE]", "[/TITLE]").Replace("[TITLE]", string.Empty).Replace("[/TITLE]", string.Empty);
                                 this.MetaTitle = this.MetaTitle.TruncateAtWord(SEOConstants.MaxMetaTitleLength);
                                 this.MetaDescription = TemplateUtils.GetTemplateSection(this.MetaTemplate, "[DESCRIPTION]", "[/DESCRIPTION]").Replace("[DESCRIPTION]", string.Empty).Replace("[/DESCRIPTION]", string.Empty);

--- a/Dnn.CommunityForums/Services/Tokens/TokenReplacer.cs
+++ b/Dnn.CommunityForums/Services/Tokens/TokenReplacer.cs
@@ -947,6 +947,8 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
             template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[MODLINK]", "[FORUM:MODLINK", "[MODLINK]");
             template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[LINK]", "[FORUMPOST:LINK", "[LINK]");
             template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[HYPERLINK]", "[FORUMPOST:LINK", "[LINK]");
+            template = ReplaceTokenSynonym(template, "[SUBJECT]", "[FORUMPOST:SUBJECT]");
+            template = ReplaceTokenSynonym(template, "[SUBJECTLINK]", "[FORUMPOST:SUBJECTLINK]");
             template = ReplaceTokenSynonym(template, "[LINKURL]", "[FORUMPOST:LINK]");
             template = ReplaceTokenSynonym(template, "[FORUMLINK]", "[FORUM:FORUMLINK]");
 

--- a/Dnn.CommunityForums/class/Settings.cs
+++ b/Dnn.CommunityForums/class/Settings.cs
@@ -300,7 +300,10 @@ namespace DotNetNuke.Modules.ActiveForums
 
         public string DefaultSettingsKey
         {
-            get { return this.MainSettings.GetString(SettingKeys.DefaultSettingsKey); }
+            get
+            {
+                return this.MainSettings.GetString(SettingKeys.DefaultSettingsKey) ?? $"M:{this.ModuleId}";
+            }
         }
 
         public FeatureSettings ForumFeatureSettings

--- a/Dnn.CommunityForums/components/Controls/ControlUtils.cs
+++ b/Dnn.CommunityForums/components/Controls/ControlUtils.cs
@@ -163,8 +163,9 @@ namespace DotNetNuke.Modules.ActiveForums
                 return Utilities.NavigateURL(tabId, portalSettings, string.Empty, @params.ToArray());
             }
 
-            var sURL = string.Empty;
-            if (!string.IsNullOrEmpty(mainSettings.PrefixURLBase))
+            var sURL = Utilities.NavigateURL(tabId, portalSettings, string.Empty, @params.ToArray());
+            var tabInfo = DotNetNuke.Entities.Tabs.TabController.Instance.GetTab(tabId, portalId);
+            if (!string.IsNullOrEmpty(mainSettings.PrefixURLBase) && !mainSettings.PrefixURLBase.Trim().Equals(tabInfo.TabName.Trim(), StringComparison.InvariantCultureIgnoreCase))
             {
                 sURL += "/" + mainSettings.PrefixURLBase;
             }


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Fix email notifications

## Changes made
- Link in the notification was missing the scheme://hostname/
- Email subject was blank on upgraded forums module
- (unrelated) change [BODY] tokens in SEO metadata in TopicView and TopicsView to use [FORUMTOPIC:BODY] and [FORUM:FORUMDESCRIPTION] to skip legacy conversion and avoid unnecessary admin log alerts like this:
![image](https://github.com/user-attachments/assets/68b9b982-e978-4c0f-ab25-5b81c814840e)


## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install:

Before:
![image](https://github.com/user-attachments/assets/ce0c5ffb-8077-4ad4-ae0d-b06214fcb51b)

After:
![image](https://github.com/user-attachments/assets/70a78696-488b-49e5-99a8-a8a3e245f636)

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1235