### PR TITLE
FIX: Exception editing topic from TopicsView

### DIFF
--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicsView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicsView.cs
@@ -321,7 +321,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
                 sOutput = TemplateUtils.ReplaceSubSection(sOutput, sAnnounce, "[ANNOUNCEMENTS]", "[/ANNOUNCEMENTS]");
             }
-                
+
             StringBuilder stringBuilder = new StringBuilder(sOutput);
             stringBuilder = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.ReplaceForumTokens(stringBuilder, this.ForumInfo, this.PortalSettings, this.MainSettings, new Services.URLNavigator().NavigationManager(), this.ForumUser, this.TabId, this.ForumUser.CurrentUserType, this.Request.Url, this.Request.RawUrl);
             sOutput = stringBuilder.ToString();
@@ -522,6 +522,14 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                         },
                     },
                 };
+                topicInfo.ContentId = new DotNetNuke.Modules.ActiveForums.Controllers.TopicController(this.ModuleId).GetById(Convert.ToInt32(drTopic["TopicId"])).ContentId;
+                topicInfo.Content.ContentId = topicInfo.ContentId;
+                if (topicInfo.LastReplyId > 0)
+                {
+                    topicInfo.LastReply.ContentId = new DotNetNuke.Modules.ActiveForums.Controllers.TopicController(this.ModuleId).GetById(Convert.ToInt32(drTopic["LastReplyId"])).ContentId;
+                    topicInfo.LastReply.Content.ContentId = topicInfo.LastReply.ContentId;
+                }
+
                 if (!(string.IsNullOrEmpty(topicInfo.Content.Summary)) && (!(Utilities.HasHTML(topicInfo.Content.Summary))))
                 {
                     topicInfo.Content.Summary = topicInfo.Content.Summary.Replace(System.Environment.NewLine, "<br />");


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Topics View loads from a stored procedure and then populates topic object model, which is subsequently cached and used when loading the topic via DAL2 for editing. However, TopicsView stored procedure doesn't return a ContentId, so the cached topic object doesn't have a valid ContentId, and cannot render content.

## Changes made
- Look up ContentId during Topics View loading and populate into the topic object
- Added TODO item to add ContentId to stored procedure and/or ultimately replace stored procedure with DAL2 loading into object directly.

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install
![image](https://github.com/user-attachments/assets/3e989813-3031-431e-b98b-6fcada0a62ce)
![image](https://github.com/user-attachments/assets/48762d0c-fc44-422a-a696-9e1a0bb1ac3a)

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1243