### PR TITLE
FIX: Error deleting topic

### DIFF
--- a/Dnn.CommunityForums/Controllers/TopicController.cs
+++ b/Dnn.CommunityForums/Controllers/TopicController.cs
@@ -47,7 +47,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
         {
             var cachekey = this.GetCacheKey(moduleId: this.moduleId, id: topicId);
             var ti = DotNetNuke.Modules.ActiveForums.DataCache.ContentCacheRetrieve(this.moduleId, cachekey) as DotNetNuke.Modules.ActiveForums.Entities.TopicInfo;
-            if (ti == null)
+            if (ti == null || ti.ContentId < 1)
             {
                 ti = base.GetById(topicId);
             }
@@ -293,7 +293,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
 
         public void DeleteById(int topicId)
         {
-            DotNetNuke.Modules.ActiveForums.Entities.TopicInfo ti = base.GetById(topicId);
+            DotNetNuke.Modules.ActiveForums.Entities.TopicInfo ti = new DotNetNuke.Modules.ActiveForums.Controllers.TopicController(this.moduleId).GetById(topicId);
             if (ti != null)
             {
                 new Social().DeleteJournalItemForPost(ti.PortalId, ti.ForumId, topicId, 0);


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Error when deleting topic. Related to #1243; Added logic to lookup contentId; also call this.GetById not base.GetById when deleting in order set child objects in topic object model.


## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install.

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1242