### PR TITLE
FIX: re-order operations when deleting replies 

### DIFF
--- a/Dnn.CommunityForums/DnnCommunityForums.csproj
+++ b/Dnn.CommunityForums/DnnCommunityForums.csproj
@@ -1254,8 +1254,8 @@
     <None Include="sql\07.00.09.SqlDataProvider" />
     <None Include="sql\07.00.09.SqlDataProvider" />
     <None Include="sql\07.00.10.SqlDataProvider" />
-    <None Include="sql\08.02.02.SqlDataProvider" />
     <None Include="sql\08.02.00.SqlDataProvider" />
+    <None Include="sql\08.02.03.SqlDataProvider" />
     <None Include="sql\Enterprise.sql" />
     <Content Include="config\templates\StatsTemplate.ascx" />
     <Content Include="config\defaultsetup.config">

--- a/Dnn.CommunityForums/DnnCommunityForums.dnn
+++ b/Dnn.CommunityForums/DnnCommunityForums.dnn
@@ -400,14 +400,19 @@
               <version>08.02.00</version>
             </script>
             <script type="Install">
-              <path>sql</path>
-              <name>08.02.02.SqlDataProvider</name>
-              <version>08.02.02</version>
+                <path>sql</path>
+                <name>08.02.02.SqlDataProvider</name>
+                <version>08.02.02</version>
+            </script>
+            <script type="Install">
+                <path>sql</path>
+                <name>08.02.03.SqlDataProvider</name>
+                <version>08.02.03</version>
             </script>
             <script type="UnInstall">
               <path>sql</path>
               <name>Uninstall.SqlDataProvider</name>
-              <version>08.02.02</version>
+              <version>08.02.03</version>
             </script>
           </scripts>
         </component>

--- a/Dnn.CommunityForums/sql/08.02.03.SqlDataProvider
+++ b/Dnn.CommunityForums/sql/08.02.03.SqlDataProvider
@@ -1,0 +1,48 @@
+SET NOCOUNT ON 
+GO
+
+/* issues 1240 - error deleting post when removing reply */
+
+IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_Reply_Delete]') AND type in (N'P', N'PC'))
+DROP PROCEDURE {databaseOwner}[{objectQualifier}activeforums_Reply_Delete]
+GO
+
+/*activeforums_Reply_Delete*/
+CREATE PROCEDURE {databaseOwner}[{objectQualifier}activeforums_Reply_Delete]
+@ForumId int,
+@TopicId int,
+@ReplyId int,
+@DelBehavior int
+AS
+DECLARE @ContentId int
+SELECT @ContentId = ContentId FROM {databaseOwner}{objectQualifier}activeforums_Replies WHERE TopicId = @TopicId AND ReplyId = @ReplyId
+BEGIN
+
+DECLARE @LastTopicReply int
+SET @LastTopicReply = (SELECT MAX(ReplyId) from {databaseOwner}{objectQualifier}activeforums_Replies WHERE TopicId = @TopicId AND IsApproved = 1 AND IsDeleted = 0 AND ReplyId <> @ReplyId)
+UPDATE {databaseOwner}{objectQualifier}activeforums_ForumTopics SET LastReplyId = @LastTopicReply WHERE ForumId = @ForumId and TopicId = @TopicId
+
+IF @DelBehavior = 1
+	BEGIN
+		UPDATE {databaseOwner}{objectQualifier}activeforums_Replies SET IsDeleted = 1 WHERE TopicId = @TopicId AND ReplyId = @ReplyId
+	END
+ELSE
+	BEGIN
+		DELETE FROM {databaseOwner}{objectQualifier}activeforums_Replies WHERE TopicId = @TopicId AND ReplyId = @ReplyId
+		DELETE FROM {databaseOwner}{objectQualifier}activeforums_Content WHERE ContentId = @ContentId 
+	END
+END
+UPDATE {databaseOwner}{objectQualifier}activeforums_Topics
+SET ReplyCount = ISNULL((Select Count(ReplyId) from {databaseOwner}{objectQualifier}activeforums_Replies WHERE TopicId = @TopicId AND IsDeleted = 0 AND IsApproved = 1),0)
+WHERE TopicId = @TopicId
+exec {databaseOwner}{objectQualifier}activeforums_Forums_LastUpdates @ForumId
+
+-- reset thread order
+EXEC {databaseOwner}{objectQualifier}activeforums_SaveTopicNextPrev @ForumId
+GO
+
+/* issues 1240 - error deleting post when removing reply */
+
+
+/* --------------------- */
+


### PR DESCRIPTION

<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Deleting replies causing 'error deleting post'. Investigation uncovered this error which is referential integrity issue:
![image](https://github.com/user-attachments/assets/3f78aba5-23cc-4e89-8973-d5aebec0c479)

The activeforums_Reply_Delete stored procedure was deleting from activeforums_Replies *before* setting activeforums_ForumTpics.LastReplyId (which points to record being deleted). When deleting a reply that is LastReplyId, throws exception. Re-order operations to set LastReplyId first before deleting reply.

## Changes made
- Change order of operations to set LastReplyId in activeforums_ForumTopics before deleting reply from activeforums_Replies
- Set lastreplyid to null not zero (zero not a valid value for foreign key)

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1242