### PR TITLE
FIX: Incorrect author shown in filtered topics view immediately after a reply

### DIFF
--- a/Dnn.CommunityForums/Controllers/ForumUserController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumUserController.cs
@@ -359,58 +359,6 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             }
         }
 
-        internal static string GetDisplayName(DotNetNuke.Entities.Portals.PortalSettings portalSettings, int moduleId, bool linkProfile, bool isMod, bool isAdmin, int userId, string username, string firstName = "", string lastName = "", string displayName = "", string profileLinkClass = "af-profile-link", string profileNameClass = "af-profile-name")
-        {
-            if (portalSettings == null)
-            {
-                portalSettings = DotNetNuke.Modules.ActiveForums.Utilities.GetPortalSettings();
-            }
-
-            if (portalSettings == null)
-            {
-                return null;
-            }
-
-            var mainSettings = SettingsBase.GetModuleSettings(moduleId);
-
-            var outputTemplate = string.IsNullOrWhiteSpace(profileLinkClass) ? "{0}" : string.Concat("<span class='", profileNameClass, "'>{0}</span>");
-
-            if (linkProfile && userId > 0)
-            {
-                var profileVisibility = mainSettings.ProfileVisibility;
-
-                switch (profileVisibility)
-                {
-                    case ProfileVisibilities.Disabled:
-                        linkProfile = false;
-                        break;
-
-                    case ProfileVisibilities.Everyone: // Nothing to do in this case
-                        break;
-
-                    case ProfileVisibilities.RegisteredUsers:
-                        linkProfile = HttpContext.Current.Request.IsAuthenticated;
-                        break;
-
-                    case ProfileVisibilities.Moderators:
-                        linkProfile = isMod || isAdmin;
-                        break;
-
-                    case ProfileVisibilities.Admins:
-                        linkProfile = isAdmin;
-                        break;
-                }
-
-                if (linkProfile && portalSettings.UserTabId != null && portalSettings.UserTabId != DotNetNuke.Common.Utilities.Null.NullInteger && portalSettings.UserTabId != -1)
-                    outputTemplate = string.Concat("<a href='", Utilities.NavigateURL(portalSettings.UserTabId, string.Empty, new[] { "userid=" + userId }), "' class='", profileLinkClass, "' rel='nofollow'>{0}</a>");
-            }
-
-            var outputName = GetDisplayName(portalSettings, mainSettings, isMod, isAdmin, userId, username, firstName, lastName, displayName);
-            outputName = System.Net.WebUtility.HtmlEncode(outputName);
-
-            return string.Format(outputTemplate, outputName);
-        }
-
         internal static bool CanLinkToProfile(DotNetNuke.Entities.Portals.PortalSettings portalSettings, SettingsInfo mainSettings, int moduleId, DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo accessingUser, DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo forumUser)
         {
             if (portalSettings == null)

--- a/Dnn.CommunityForums/Controllers/ForumUserController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumUserController.cs
@@ -441,7 +441,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                         break;
 
                     case ProfileVisibilities.RegisteredUsers:
-                        canLinkToProfile = HttpContext.Current.Request.IsAuthenticated;
+                        canLinkToProfile = accessingUser.IsRegistered;
                         break;
 
                     case ProfileVisibilities.Moderators:

--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
@@ -1028,10 +1028,13 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
         {
             var sOutput = template;
 
-            // most topic values come in first result set and are set in LoadData(); however some, like IP Address and contentId, comes in this result set.
-            this.topic.Content.IPAddress = dr.GetString("IPAddress");
-            this.topic.ContentId = dr.GetInt("ContentId");
-            this.topic.Content.ContentId = dr.GetInt("ContentId");
+            if (dr.GetInt("ReplyId").Equals(0))
+            {
+                // most topic values come in first result set and are set in LoadData(); however some, like IP Address and contentId, comes in this result set.
+                this.topic.Content.IPAddress = dr.GetString("IPAddress");
+                this.topic.ContentId = dr.GetInt("ContentId");
+                this.topic.Content.ContentId = dr.GetInt("ContentId");
+            }
 
             var reply = new DotNetNuke.Modules.ActiveForums.Entities.ReplyInfo
             {

--- a/Dnn.CommunityForums/Entities/ForumUserInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumUserInfo.cs
@@ -154,10 +154,10 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         public string Email => string.IsNullOrEmpty(this.UserInfo?.Email) ? string.Empty : this.UserInfo?.Email;
 
         [IgnoreColumn]
-        public bool GetIsMod(int ModuleId)
-        {
-            return (!this.IsAnonymous && !(string.IsNullOrEmpty(DotNetNuke.Modules.ActiveForums.Controllers.ForumController.GetForumsForUser(this.UserRoles, this.PortalId, ModuleId, "CanApprove"))));
-        }
+        public bool IsRegistered => !this.IsAnonymous && this.UserInfo != null && this.UserInfo.Roles.Contains(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRegisteredRoleName(this.PortalId));
+
+        [IgnoreColumn]
+        public bool GetIsMod(int ModuleId) => !this.IsAnonymous && !(string.IsNullOrEmpty(DotNetNuke.Modules.ActiveForums.Controllers.ForumController.GetForumsForUser(this.UserRoles, this.PortalId, ModuleId, "CanApprove")));
 
         [IgnoreColumn]
         public bool IsSuperUser => this.UserInfo != null && this.UserInfo.IsSuperUser;

--- a/Dnn.CommunityForums/Entities/ForumUserInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumUserInfo.cs
@@ -21,15 +21,13 @@
 namespace DotNetNuke.Modules.ActiveForums.Entities
 {
     using System;
-    using System.Web;
+    using System.Linq;
 
     using DotNetNuke.ComponentModel.DataAnnotations;
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Users;
-    using DotNetNuke.Security.Permissions;
     using DotNetNuke.Services.Tokens;
-    using DotNetNuke.UI.UserControls;
 
     [TableName("activeforums_UserProfiles")]
     [PrimaryKey("ProfileId", AutoIncrement = true)]

--- a/Dnn.CommunityForums/controls/af_sendto.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_sendto.ascx.cs
@@ -71,7 +71,7 @@ namespace DotNetNuke.Modules.ActiveForums
                             }
 
                             messageDefault = messageDefault.Replace("[TOPICLINK]", sURL);
-                            messageDefault = messageDefault.Replace("[DISPLAYNAME]", DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetDisplayName(this.PortalSettings, this.ModuleId, false, false, false, this.UserId, this.UserInfo.Username, this.UserInfo.FirstName, this.UserInfo.LastName, this.UserInfo.DisplayName));
+                            messageDefault = messageDefault.Replace("[DISPLAYNAME]", $"<span class='af-profile-name'>{DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetDisplayName(portalSettings: this.PortalSettings, mainSettings: this.MainSettings, isMod: false, isAdmin: false, userId: this.UserId, username: this.UserInfo.Username, firstName: this.UserInfo.FirstName, lastName: this.UserInfo.LastName, displayName: this.UserInfo.DisplayName)}</span>");
                             this.txtMessage.Text = messageDefault;
                         }
                     }

--- a/Dnn.CommunityForums/feeds.aspx.cs
+++ b/Dnn.CommunityForums/feeds.aspx.cs
@@ -24,6 +24,7 @@ namespace DotNetNuke.Modules.ActiveForums
     using System.Collections;
     using System.Collections.Generic;
     using System.Data;
+    using System.Reflection;
     using System.Text;
     using System.Text.RegularExpressions;
     using System.Web;
@@ -241,7 +242,16 @@ namespace DotNetNuke.Modules.ActiveForums
             sb.Append(this.WriteElement("title", dr["Subject"].ToString(), indent + 1));
             sb.Append(this.WriteElement("description", body, indent + 1));
             sb.Append(this.WriteElement("link", uRL, indent + 1));
-            sb.Append(this.WriteElement("dc:creator", DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetDisplayName(this.PortalSettings, this.moduleID, false, false, false, -1, dr["AuthorUserName"].ToString(), dr["AuthorFirstName"].ToString(), dr["AuthorLastName"].ToString(), dr["AuthorDisplayName"].ToString(), null), indent + 1));
+            sb.Append(this.WriteElement("dc:creator", DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetDisplayName(portalSettings: this.PortalSettings,
+                                                                                                                                     mainSettings: mainSettings,
+                                                                                                                                     isMod: false,
+                                                                                                                                     isAdmin: false,
+                                                                                                                                     userId: -1,
+                                                                                                                                     username: dr["AuthorUserName"].ToString(),
+                                                                                                                                     firstName: dr["AuthorFirstName"].ToString(),
+                                                                                                                                     lastName: dr["AuthorLastName"].ToString(),
+                                                                                                                                     displayName: dr["AuthorDisplayName"].ToString()),
+                                                                                                                                     indent + 1));
             sb.Append(this.WriteElement("pubDate", Convert.ToDateTime(dr["DateCreated"]).AddMinutes(this.offSet).ToString("r"), indent + 1));
             sb.Append(this.WriteElement("guid", uRL, indent + 1));
             sb.Append(this.WriteElement("slash:comments", dr["ReplyCount"].ToString(), indent + 1));


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
After a reply is posted, the author of the topic is shown incorrectly (it shows the reply author not the topic author). 

This is due to topic object population/hydration in topic view and topic is cached with incorrect contentid. Once cache expires and topic is reloaded, topic is shown correctly. 

## Changes made
- Corrects the population of the topic object

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1254