### PR TITLE
TASK: Don't look for user in HttpContext

### DIFF
--- a/Dnn.CommunityForums/Controllers/ForumUserController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumUserController.cs
@@ -146,10 +146,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
         }
 
         [Obsolete("Deprecated in Community Forums. Removing in 10.00.00. Use GetUserFromHttpContext() [renamed method]")]
-        public DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo GetUser(int portalId, int moduleId)
-        {
-            return this.GetUserFromHttpContext(portalId, moduleId);
-        }
+        public DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo GetUser(int portalId, int moduleId) => throw new NotImplementedException();
 
         public DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo GetUserFromHttpContext(int portalId, int moduleId)
         {

--- a/Dnn.CommunityForums/Controllers/ModerationController.cs
+++ b/Dnn.CommunityForums/Controllers/ModerationController.cs
@@ -48,6 +48,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
         internal static bool SendModerationNotification(int portalId, int tabId, int moduleId, int forumGroupId, int forumId, int topicId, int replyId, int AuthorId, Uri requestUri, string rawUrl)
         {
             var portalSettings = Utilities.GetPortalSettings(portalId);
+            var adminUser = new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(moduleId).GetByUserId(portalId, portalSettings.AdministratorId);
             var mainSettings = SettingsBase.GetModuleSettings(moduleId);
             try
             {
@@ -58,18 +59,18 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                 {
                     DotNetNuke.Modules.ActiveForums.Entities.ReplyInfo reply = new DotNetNuke.Modules.ActiveForums.Controllers.ReplyController(moduleId).GetById(replyId);
                     subject = Utilities.GetSharedResource("[RESX:NotificationSubjectReply]");
-                    subject = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.ReplacePostTokens(new StringBuilder(subject), reply, portalSettings, mainSettings, new Services.URLNavigator().NavigationManager(), new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(moduleId).GetUserFromHttpContext(portalId, moduleId), requestUri, rawUrl).ToString();
+                    subject = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.ReplacePostTokens(new StringBuilder(subject), reply, portalSettings, mainSettings, new Services.URLNavigator().NavigationManager(), adminUser, requestUri, rawUrl).ToString();
                     body = Utilities.GetSharedResource("[RESX:NotificationBodyReply]");
-                    body = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.ReplacePostTokens(new StringBuilder(body), reply, portalSettings, mainSettings, new Services.URLNavigator().NavigationManager(), new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(moduleId).GetUserFromHttpContext(portalId, moduleId), requestUri,  rawUrl).ToString();
+                    body = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.ReplacePostTokens(new StringBuilder(body), reply, portalSettings, mainSettings, new Services.URLNavigator().NavigationManager(), adminUser, requestUri,  rawUrl).ToString();
                     authorId = reply.Content.AuthorId;
                 }
                 else
                 {
                     DotNetNuke.Modules.ActiveForums.Entities.TopicInfo topic = new DotNetNuke.Modules.ActiveForums.Controllers.TopicController(moduleId).GetById(topicId);
                     subject = Utilities.GetSharedResource("[RESX:NotificationSubjectTopic]");
-                    subject = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.ReplacePostTokens(new StringBuilder(subject), topic, portalSettings, mainSettings, new Services.URLNavigator().NavigationManager(), new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(moduleId).GetUserFromHttpContext(portalId, moduleId), requestUri, rawUrl).ToString();
+                    subject = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.ReplacePostTokens(new StringBuilder(subject), topic, portalSettings, mainSettings, new Services.URLNavigator().NavigationManager(), adminUser, requestUri, rawUrl).ToString();
                     body = Utilities.GetSharedResource("[RESX:NotificationBodyTopic]");
-                    body = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.ReplacePostTokens(new StringBuilder(body), topic, portalSettings, mainSettings, new Services.URLNavigator().NavigationManager(), new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(moduleId).GetUserFromHttpContext(portalId, moduleId), requestUri, rawUrl).ToString();
+                    body = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.ReplacePostTokens(new StringBuilder(body), topic, portalSettings, mainSettings, new Services.URLNavigator().NavigationManager(), adminUser, requestUri, rawUrl).ToString();
                     authorId = topic.Content.AuthorId;
                 }
 

--- a/Dnn.CommunityForums/CustomControls/ServerControls/ForumContentNavigator.cs
+++ b/Dnn.CommunityForums/CustomControls/ServerControls/ForumContentNavigator.cs
@@ -187,8 +187,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
         protected override void Render(HtmlTextWriter writer)
         {
-            UserController uc = new UserController();
-            this.forumUser = uc.GetUser(this.PortalId, this.ModuleId);
+            this.forumUser = (User)new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetUserFromHttpContext(this.PortalId, this.ModuleId);
             Controls.ForumContent fd = new Controls.ForumContent();
             fd.ModuleId = this.ModuleId;
             fd.TabId = this.TabId;

--- a/Dnn.CommunityForums/CustomControls/ServerControls/ForumContentTree.cs
+++ b/Dnn.CommunityForums/CustomControls/ServerControls/ForumContentTree.cs
@@ -57,8 +57,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
         protected override void Render(HtmlTextWriter writer)
         {
-            UserController uc = new UserController();
-            this.forumUser = uc.GetUser(this.PortalId, this.ModuleId);
+            this.forumUser = (User)new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetUserFromHttpContext(this.PortalId, this.ModuleId);
             CategoryTreeView fd = new CategoryTreeView();
             fd.ModuleId = this.ModuleId;
             fd.TabId = this.TabId;

--- a/Dnn.CommunityForums/CustomControls/ServerControls/ForumNavigator.cs
+++ b/Dnn.CommunityForums/CustomControls/ServerControls/ForumNavigator.cs
@@ -45,8 +45,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
         protected override void Render(HtmlTextWriter writer)
         {
-            UserController uc = new UserController();
-            this.forumUser = uc.GetUser(this.PortalId, this.ModuleId);
+            this.forumUser = (User)new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetUserFromHttpContext(this.PortalId, this.ModuleId);
             Controls.ForumDirectory fd = new Controls.ForumDirectory();
             fd.ModuleId = this.ModuleId;
             fd.TabId = this.TabId;

--- a/Dnn.CommunityForums/WhatsNew.ascx.cs
+++ b/Dnn.CommunityForums/WhatsNew.ascx.cs
@@ -66,7 +66,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
         private DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo CurrentUser
         {
-            get { return this.currentUser ?? (this.currentUser = new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetUserFromHttpContext(this.PortalId, this.ModuleId)); }
+            get { return this.currentUser ?? (this.currentUser = new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).DNNGetCurrentUser(this.PortalId, this.UserId)); }
         }
 
         private string AuthorizedForums

--- a/Dnn.CommunityForums/class/SettingsBase.cs
+++ b/Dnn.CommunityForums/class/SettingsBase.cs
@@ -41,7 +41,7 @@ namespace DotNetNuke.Modules.ActiveForums
         #endregion
 
         #region Public Properties
-        internal DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo ForumUser => new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ForumModuleId).GetUserFromHttpContext(this.PortalId, this.ForumModuleId);
+        internal DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo ForumUser => new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ForumModuleId).GetByUserId(this.PortalId, this.UserId);
 
         internal string UserForumsList => DotNetNuke.Modules.ActiveForums.Controllers.ForumController.GetForumsForUser(this.ForumUser.UserRoles, this.PortalId, this.ForumModuleId);
 

--- a/Dnn.CommunityForums/components/Users/UserController.cs
+++ b/Dnn.CommunityForums/components/Users/UserController.cs
@@ -35,29 +35,25 @@ namespace DotNetNuke.Modules.ActiveForums
     public class UserController
     {
         [Obsolete("Deprecated in Community Forums. Removing in 10.00.00. Not Used.")]
-        public User GetUser(int PortalId, int ModuleId) => (User)new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(ModuleId).GetUserFromHttpContext(PortalId, ModuleId);
+        public User GetUser(int PortalId, int ModuleId) => throw new NotImplementedException();
 
         [Obsolete("Deprecated in Community Forums. Removing in 10.00.00. Not Used.")]
-        public User DNNGetCurrentUser(int PortalId, int ModuleId) => (User)new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(ModuleId).DNNGetCurrentUser(PortalId, ModuleId);
+        public User DNNGetCurrentUser(int PortalId, int ModuleId) => throw new NotImplementedException();
 
         [Obsolete("Deprecated in Community Forums. Removing in 10.00.00. Not Used.")]
-        private User GetDNNUser(int portalId, int userId) => (User)new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(-1).GetByUserId(portalId, userId);
+        private User GetDNNUser(int portalId, int userId) => throw new NotImplementedException();
 
         [Obsolete("Deprecated in Community Forums. Removing in 10.00.00. Not Used.")]
-        private User GetDNNUser(int portalId, string userName) => (User)new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(-1).GetDNNUser(portalId, userName);
+        private User GetDNNUser(int portalId, string userName) => throw new NotImplementedException();
 
         [Obsolete("Deprecated in Community Forums. Removing in 10.00.00. Not Used.")]
-        public User GetDNNUser(string userName)
-        {
-            DotNetNuke.Entities.Users.UserInfo dnnUser = DotNetNuke.Entities.Users.UserController.GetUserByName(DotNetNuke.Entities.Portals.PortalController.Instance.GetCurrentPortalSettings().PortalId, userName);
-            return (User)new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(-1).GetByUserId(DotNetNuke.Entities.Portals.PortalController.Instance.GetCurrentPortalSettings().PortalId, dnnUser.UserID);
-        }
+        public User GetDNNUser(string userName) => throw new NotImplementedException();
 
         [Obsolete("Deprecated in Community Forums. Removing in 10.00.00. Not Used.")]
-        public User GetUser(int PortalId, int ModuleId, int userId) => (User)new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(ModuleId).GetUserFromHttpContext(PortalId, ModuleId);
+        public User GetUser(int PortalId, int ModuleId, int userId) => throw new NotImplementedException();
 
         [Obsolete("Deprecated in Community Forums. Removing in 10.00.00. Not Used.")]
-        public User GetUser(int PortalId, int ModuleId, string userName) => (User)new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(ModuleId).GetByUserId(PortalId, DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetUserIdByUserName(PortalId, userName));
+        public User GetUser(int PortalId, int ModuleId, string userName) => throw new NotImplementedException();
 
         [Obsolete("Deprecated in Community Forums. Removing in 10.00.00. Not Used.")]
         public User FillProfile(int PortalId, int ModuleId, User u) => throw new NotImplementedException();


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Moderation notifications were using a method that retrieves user from HttpContext. Use PortalSettings AdministratorId instead.
Also refactored a couple of other "get user from HttpContext" code instances.

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [ ] Fixes Bug
- [ ] Feature solution
- [X] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1290