### PR TITLE
FIX: Flood control preventing new user from posting

### DIFF
--- a/Dnn.CommunityForums/class/Utilities.cs
+++ b/Dnn.CommunityForums/class/Utilities.cs
@@ -191,8 +191,8 @@ namespace DotNetNuke.Modules.ActiveForums
             3) user is an admin or superuser
             4) user is designated as a trusted user for the forum
             5) user has moderator (edit, delete, approve) permissions for the forum
-            6) time span for since user's last post or reply exceeds flood interval
-            */
+            6) user has never posted
+            7) time span for since user's last post or reply exceeds flood interval*/
             return floodInterval <= 0
                    || forumUser == null
                    || forumUser.IsAnonymous
@@ -200,6 +200,7 @@ namespace DotNetNuke.Modules.ActiveForums
                    || forumUser.IsSuperUser
                    || Utilities.IsTrusted((int)forumInfo.FeatureSettings.DefaultTrustValue, userTrustLevel: forumUser.TrustLevel, DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(forumInfo.Security.Trust, forumUser.UserRoles), forumInfo.FeatureSettings.AutoTrustLevel, forumUser.PostCount)
                    || DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(forumInfo.Security.Moderate, forumUser.UserRoles)
+                   || (forumUser.DateLastPost == null)
                    || (forumUser.DateLastPost != null && SimulateDateDiff.DateDiff(SimulateDateDiff.DateInterval.Second, (DateTime)forumUser.DateLastPost, DateTime.UtcNow) > floodInterval)
                    || (forumUser.DateLastReply != null && SimulateDateDiff.DateDiff(SimulateDateDiff.DateInterval.Second, (DateTime)forumUser.DateLastReply, DateTime.UtcNow) > floodInterval);
         }

--- a/Dnn.CommunityForumsTests/class/UtilitiesTests.cs
+++ b/Dnn.CommunityForumsTests/class/UtilitiesTests.cs
@@ -78,9 +78,10 @@ namespace DotNetNuke.Modules.ActiveForumsTests
         [TestCase(0, 0, false, false, ExpectedResult = true)] // flood interval disables
         [TestCase(20, 25, false, false, ExpectedResult = true)]
         [TestCase(200, 25, false, true, ExpectedResult = true)] // user is an admin
+        [TestCase(200, null, false, false, ExpectedResult = true)] // user is an admin
         [TestCase(200, 25, true, false, ExpectedResult = true)] // interval is 200, anonymous, last post is 25, expect true
         [TestCase(200, 25, false, false, ExpectedResult = false)] // interval is 200, not anonymous, last post is 25, expect false
-        public bool HasFloodIntervalPassedTest1(int floodInterval, int secondsSinceLastPost, bool isAnonymous, bool isSuperUser)
+        public bool HasFloodIntervalPassedTest1(int floodInterval, object secondsSinceLastPost, bool isAnonymous, bool isSuperUser)
         {
             //Arrange
             var mockUserInfo = new Mock<DotNetNuke.Entities.Users.UserInfo>
@@ -98,10 +99,14 @@ namespace DotNetNuke.Modules.ActiveForumsTests
                     UserId = mockUserInfo.Object.UserID,
                     IsAuthenticated = !isAnonymous,
                     UserInfo = mockUserInfo.Object,
-                    DateLastPost = DateTime.UtcNow.AddSeconds(-1 * secondsSinceLastPost),
-                    DateLastReply = DateTime.UtcNow.AddSeconds(-1 * secondsSinceLastPost),
                 },
             };
+
+            if (secondsSinceLastPost != null)
+            {
+                mockUser.Object.DateLastPost = DateTime.UtcNow.AddSeconds(-1 * (int)secondsSinceLastPost);
+                mockUser.Object.DateLastReply = DateTime.UtcNow.AddSeconds(-1 * (int)secondsSinceLastPost);
+            }
 
             var featureSettings = new System.Collections.Hashtable
             {


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
New users (having null DateLastPost value) should pass flood control test.

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install 
Also added new unit test for this.
Before:
![image](https://github.com/user-attachments/assets/6e76ef9d-3b45-45ef-8c15-8dab09cc1138)
After:
![image](https://github.com/user-attachments/assets/2177949f-494d-409a-b15a-cc1b58b3eecc)

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1319