### PR TITLE
Issues/mangled replies in search results 1336

### DIFF
--- a/Dnn.CommunityForums/App_LocalResources/LegacyTokenResources.resx
+++ b/Dnn.CommunityForums/App_LocalResources/LegacyTokenResources.resx
@@ -417,4 +417,7 @@
   <data name="[LIKESx3].Text" xml:space="preserve">
     <value>&lt;i id="af-topicview-likes-[FORUMPOST:CONTENTID]" class="fa [FORUMPOST:ISLIKED|fa-thumbs-o-up|fa-thumbs-up] fa-3x" style="cursor: pointer" onclick="{0}"&gt; [FORUMPOST:LIKECOUNT]&lt;/i&gt;|&lt;i id="af-topicview-likes" class="fa [FORUMPOST:ISLIKED|fa-thumbs-o-up|fa-thumbs-up] fa-2x"&gt; [FORUMPOST:LIKECOUNT]&lt;/i&gt;</value>
   </data>
+  <data name="[SUBJECTLINK].Text" xml:space="preserve">
+    <value>&lt;a href="{0}" class="dcf-topic-link"&gt;[FORUMTOPIC:SUBJECT]&lt;/a&gt;</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/Entities/ReplyInfo.cs
+++ b/Dnn.CommunityForums/Entities/ReplyInfo.cs
@@ -355,9 +355,6 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                     {
                         string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, this.GetTabId(), this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.Topic.TopicUrl, -1, -1, string.Empty, 1, this.ContentId, this.Forum.SocialGroupId);
                         string sPollImage = (this.Topic.TopicType == TopicTypes.Poll ? DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.GetTokenFormatString("[POLLIMAGE]", this.Forum.PortalSettings, accessingUser.Profile.PreferredLocale) : string.Empty);
-                        string subject = Utilities.StripHTMLTag(System.Net.WebUtility.HtmlDecode(this.Subject)).Replace("\"", string.Empty).Replace("#", string.Empty).Replace("%", string.Empty).Replace("+", string.Empty);
-                        ;
-                        string sBodyTitle = GetTopicTitle(this.Content.Body);
                         string slink;
                         var @params = new List<string> { $"{ParamKeys.TopicId}={this.TopicId}", $"{ParamKeys.ContentJumpId}={this.Topic.LastReplyId}", };
 
@@ -374,14 +371,14 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                                 @params.Add($"{ParamKeys.TopicId}={this.TopicId}");
                             }
 
-                            slink = "<a title=\"" + sBodyTitle + "\" href=\"" + Utilities.NavigateURL(this.GetTabId(), string.Empty, @params.ToArray()) + "\">" + subject + "</a>";
+                            slink = Utilities.NavigateURL(this.GetTabId(), string.Empty, @params.ToArray());
                         }
                         else
                         {
-                            slink = "<a title=\"" + sBodyTitle + "\" href=\"" + sTopicURL + "\">" + subject + "</a>";
+                            slink = sTopicURL;
                         }
 
-                        return PropertyAccess.FormatString(slink + sPollImage, format);
+                        return PropertyAccess.FormatString(slink, format) + sPollImage;
                     }
 
                 case "likeslink":
@@ -412,6 +409,8 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                     return PropertyAccess.FormatString(length > 0 && this.Summary.Length > length ? this.Summary.Substring(0, length) : this.Summary, format);
                 case "body":
                     return PropertyAccess.FormatString(length > 0 && this.Content.Body.Length > length ? this.Content.Body.Substring(0, length) : this.Content.Body, format);
+                case "bodytitle":
+                    return PropertyAccess.FormatString(GetTopicTitle(this.Content.Body), format);
                 case "link":
                     {
                         string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, this.GetTabId(), this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.Topic.TopicUrl, -1, -1, string.Empty, 1, this.ContentId, this.Forum.SocialGroupId);

--- a/Dnn.CommunityForums/Entities/TopicInfo.cs
+++ b/Dnn.CommunityForums/Entities/TopicInfo.cs
@@ -617,8 +617,6 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                     {
                         string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, GetTabId(), this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.TopicUrl, -1, -1, string.Empty, 1, -1, this.Forum.SocialGroupId);
                         string sPollImage = (this.Topic.TopicType == TopicTypes.Poll ? DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.GetTokenFormatString("[POLLIMAGE]", this.Forum.PortalSettings, accessingUser.Profile.PreferredLocale) : string.Empty);
-                        string subject = Utilities.StripHTMLTag(System.Net.WebUtility.HtmlDecode(this.Subject)).Replace("\"", string.Empty).Replace("#", string.Empty).Replace("%", string.Empty).Replace("+", string.Empty); ;
-                        string sBodyTitle = GetTopicTitle(this.Content.Body);
                         string slink;
                         var @params = new List<string>
                         {
@@ -643,14 +641,14 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                                 @params.Add($"{ParamKeys.TopicId}={this.TopicId}");
                             }
 
-                            slink = "<a title=\"" + sBodyTitle + "\" href=\"" + Utilities.NavigateURL(GetTabId(), string.Empty, @params.ToArray()) + "\">" + subject + "</a>";
+                            slink = Utilities.NavigateURL(GetTabId(), string.Empty, @params.ToArray());
                         }
                         else
                         {
-                            slink = "<a title=\"" + sBodyTitle + "\" href=\"" + sTopicURL + "\">" + subject + "</a>";
+                            slink = sTopicURL;
                         }
 
-                        return PropertyAccess.FormatString(slink + sPollImage, format);
+                        return PropertyAccess.FormatString(slink, format) + sPollImage;
                     }
 
                 case "lastreadurl":

--- a/Dnn.CommunityForums/Services/Tokens/TokenReplacer.cs
+++ b/Dnn.CommunityForums/Services/Tokens/TokenReplacer.cs
@@ -931,7 +931,6 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
             template = ReplaceTokenSynonym(template, "[AF:URL:LASTREPLY]", "[FORUMTOPIC:LASTREPLYURL]");
 
             template = ReplaceTokenSynonym(template, "[SUBJECT]", "[FORUMTOPIC:SUBJECT]");
-            template = ReplaceTokenSynonym(template, "[SUBJECTLINK]", "[FORUMTOPIC:SUBJECTLINK]");
 
             template = ReplaceTokenSynonymPrefix(template, "[BODY", "[FORUMTOPIC:BODY");
             template = ReplaceTokenSynonymPrefix(template, "[SUMMARY", "[FORUMTOPIC:SUMMARY");
@@ -951,6 +950,7 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
                 template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[ICONUNPINNED]", "[FORUMTOPIC:ICONUNPINNED", "[ICONPIN]-HideIcon");
             }
 
+            template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[SUBJECTLINK]", "[FORUMTOPIC:SUBJECTLINK", "[SUBJECTLINK]");
             template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[POSTICON]", "[FORUMTOPIC:POSTICON", "[POSTICON]");
             template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[POSTRATINGDISPLAY]", "[FORUMTOPIC:RATING", "[POSTRATING]");
             template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[NEXTTOPIC]", "[FORUMTOPIC:NEXTTOPICLINK", "[NEXTTOPICLINK]");
@@ -1024,7 +1024,7 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
             template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[LINK]", "[FORUMPOST:LINK", "[LINK]");
             template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[HYPERLINK]", "[FORUMPOST:LINK", "[LINK]");
             template = ReplaceTokenSynonym(template, "[SUBJECT]", "[FORUMPOST:SUBJECT]");
-            template = ReplaceTokenSynonym(template, "[SUBJECTLINK]", "[FORUMPOST:SUBJECTLINK]");
+            template = ReplaceLegacyTokenWithFormatString(template, portalSettings, language, "[SUBJECTLINK]", "[FORUMTOPIC:SUBJECTLINK", "[SUBJECTLINK]");
             template = ReplaceTokenSynonym(template, "[LINKURL]", "[FORUMPOST:LINK]");
             template = ReplaceTokenSynonym(template, "[FORUMLINK]", "[FORUM:FORUMLINK]");
 

--- a/Dnn.CommunityForums/config/templates/Likes.ascx
+++ b/Dnn.CommunityForums/config/templates/Likes.ascx
@@ -10,7 +10,7 @@
             <HeaderTemplate>
                 <div class="dcf-likes-header">
                     <h1 class="dcf-likes-title">[RESX:Likes] [RESX:For]</h1>
-                    <h2>[FORUMPOST:SUBJECTLINK]</h2>
+                    <h2>[FORUMPOST:SUBJECTLINK|<a href="{0}" class="dcf-topic-link">[FORUMPOST:SUBJECT]</a>]</h2>
                     <label>[FORUMPOST:SUMMARY:50]</label>
                     <div class="dcf-postinfo">
                         <label>[RESX:posted] [FORUMPOST:DATECREATED] [RESX:BY] [FORUMPOST:AUTHORDISPLAYNAMELINK|<a href="{0}" class="dcf-profile-link" rel="nofollow">[FORUMPOST:AUTHORDISPLAYNAME]</a></label>]

--- a/Dnn.CommunityForums/config/templates/SearchResults.ascx
+++ b/Dnn.CommunityForums/config/templates/SearchResults.ascx
@@ -8,70 +8,59 @@
         <br />
         <asp:PlaceHolder runat="server" ID="phKeywords">
             <span class="af-search-criteria">[RESX:SearchKeywords]<b>
-                    <asp:Literal runat="server" ID="litKeywords"></asp:Literal>
-                </b>
+                <asp:Literal runat="server" ID="litKeywords"></asp:Literal>
+            </b>
             </span>
-        </asp:placeholder>
-        <asp:placeholder runat="server" id="phUsername">
+        </asp:PlaceHolder>
+        <asp:PlaceHolder runat="server" ID="phUsername">
             <span class="af-search-criteria">[RESX:SearchByUser]<b>
-                    <asp:literal runat="server" id="litUserName"></asp:literal>
-                </b>
+                <asp:Literal runat="server" ID="litUserName"></asp:Literal>
+            </b>
             </span>
-        </asp:placeholder>
+        </asp:PlaceHolder>
         <asp:PlaceHolder runat="server" ID="phTag">
             <span class="af-search-criteria">[RESX:SearchByTag]<b>
-                    <asp:Literal runat="server" ID="litTag"></asp:literal>
-                </b>
+                <asp:Literal runat="server" ID="litTag"></asp:Literal>
+            </b>
             </span>
-        </asp:placeholder>
+        </asp:PlaceHolder>
     </div>
     <div class="af-search-bar afgrouprow afgrouprow-f">
         <span class="af-search-duration">
-            <asp:literal runat="server" id="litSearchDuration" />
-            <asp:literal runat="server" id="litSearchAge" />
+            <asp:Literal runat="server" ID="litSearchDuration" />
+            <asp:Literal runat="server" ID="litSearchAge" />
         </span>
         <span class="af-search-title">
             <label>[RESX:SearchTitle]</label>
         </span>
     </div>
-    <asp:panel id="pnlMessage" runat="server" visible="true" cssclass="af-search-noresults">
-        <asp:literal id="litMessage" runat="server" />
-    </asp:panel>
+    <asp:Panel ID="pnlMessage" runat="server" Visible="true" CssClass="af-search-noresults">
+        <asp:Literal ID="litMessage" runat="server" />
+    </asp:Panel>
     <div class="af-search-results" style="position: relative;">
 
         <!-- Post View -->
-        <asp:repeater runat="server" id="rptPosts" visible="False">
-            <HeaderTemplate></HeaderTemplate>
+        <asp:Repeater runat="server" ID="rptPosts" Visible="False">
+            <HeaderTemplate>
+                <div class="afgrid">
+            </HeaderTemplate>
             <ItemTemplate>
-                <div class="af-post">
-                    <div class="af-post-header">
-                        <div class="af-stats">
-                            <label>[RESX:SearchReplies]</label><span id="ReplyCount" runat="server">[FORUMTOPIC:REPLYCOUNT]</span><br />
-                            <label>[RESX:SearchViews]</label><span>[FORUMTOPIC:VIEWCOUNT]</span>
-                        </div>
-                        <div class="af-forum">
-                            <label>[RESX:SearchForum]</label>
-                            [FORUM:FORUMLINK|<a href="{0}" class="dcf-forum-link">[FORUM:FORUMNAME]</a>]
-                        </div>
-                        <div class="af-thread">
-                            <label>[RESX:SearchTopic]</label>
-                            [FORUMTOPIC:SUBJECTLINK|<a class="dcf-title dcf-title-4">{0}</a>]
-                        </div>
-                        <div class="af-postinfo">
-                            <label>[RESX:SearchPosted]</label>[FORUMPOST:DATECREATED] [FORUMPOST:AUTHORDISPLAYNAMELINK|[RESX:BY] <a href="{0}" class="af-profile-link" rel="nofollow">[FORUMPOST:AUTHORDISPLAYNAME]</a>]
-                        </div>
-                    </div>
-                    <div class="af-post-content">
-                        <a class="af-post-url" id="rptPostsContentUrl">[FORUMPOST:LINK|<a class="dcf-title dcf-title-4">{0}</a>]
-                        <div>[FORUMPOST:BODY:255]</div>
+                <div class="aftopicrow af-content">
+                    <div class="aftopicrow afsubject">
+                        <span class="aftopictitle">[FORUMPOST:SUBJECTLINK|<a href="{0}" title="[FORUMPOST:BODYTITLE]" class="dcf-topic-link">[FORUMPOST:SUBJECT]</a>]
+                        </span>
+                        <span class="aftopicsubtitle">[RESX:SearchPosted] [FORUMPOST:DATECREATED] [FORUMPOST:AUTHORDISPLAYNAMELINK|[RESX:BY] <a href="{0}" class="af-profile-link" rel="nofollow">[FORUMPOST:AUTHORDISPLAYNAME]</a>]</span>
+                        <span class="aftopicsubtitle">[FORUM:FORUMLINK|[RESX:IN] [RESX:SearchForum]<a href="{0}" class="dcf-forum-link">[FORUM:FORUMNAME]</a>]</span>
                     </div>
                 </div>
             </ItemTemplate>
-            <FooterTemplate></FooterTemplate>
-        </asp:repeater>
-        
+            <FooterTemplate>
+                </div>
+            </FooterTemplate>
+        </asp:Repeater>
+
         <!-- Topic View -->
-        <asp:repeater id="rptTopics" runat="server" visible="False">
+        <asp:Repeater ID="rptTopics" runat="server" Visible="False">
             <HeaderTemplate>
                 <div class="afgrid">
                     <div class="aftopicrow af-content">
@@ -84,17 +73,17 @@
             <ItemTemplate>
                 <div class="aftopicrow af-content">
                     <div class="aftopicrow afsubject">
-                        <span class="aftopictitle">
-                            [FORUMTOPIC:SUBJECTLINK|<a class="dcf-title dcf-title-4">{0}</a>]
-                        </span> 
+                        <span class="aftopictitle">[FORUMTOPIC:SUBJECTLINK|<a href="{0}" title="[FORUMTOPIC:BODYTITLE]" class="dcf-topic-link">[FORUMTOPIC:SUBJECT]</a>]
+                        </span>
                         <span class="aftopicsubtitle">[RESX:Started] [FORUMTOPIC:DATECREATED] [FORUMTOPIC:AUTHORDISPLAYNAMELINK|[RESX:BY] <a href="{0}" class="af-profile-link" rel="nofollow">[FORUMTOPIC:AUTHORDISPLAYNAME]</a>]</span>
                     </div>
                     <div class="aftopicrow af-colstats af-colstats-replies">[FORUMTOPIC:REPLYCOUNT]</div>
                     <div class="aftopicrow af-colstats af-colstats-views">[FORUMTOPIC:VIEWCOUNT]</div>
                     <div class="aftopicrow af-lastpost">
                         <div class="af_lastpost" style="white-space: nowrap;">
-                            [FORUM:FORUMLINK|In: <a href="{0}" class="dcf-forum-link">[FORUM:FORUMNAME]</a>]
-                            [FORUMTOPIC:LASTPOSTAUTHORDISPLAYNAMELINK|<br /> [RESX:BY] <a href="{0}" class="af-profile-link" rel="nofollow">[FORUMTOPIC:LASTPOSTAUTHORDISPLAYNAME]</a>
+                            [FORUM:FORUMLINK|[RESX:IN] [RESX:SearchForum]<a href="{0}" class="dcf-forum-link">[FORUM:FORUMNAME]</a>]
+                            [FORUMTOPIC:LASTPOSTAUTHORDISPLAYNAMELINK|<br />
+                            [RESX:BY] <a href="{0}" class="af-profile-link" rel="nofollow">[FORUMTOPIC:LASTPOSTAUTHORDISPLAYNAME]</a>
                             <br />
                             ]
                             [FORUMTOPIC:LASTPOSTDATE]
@@ -105,13 +94,13 @@
             <FooterTemplate>
                 </div>
             </FooterTemplate>
-        </asp:repeater>
+        </asp:Repeater>
 
     </div>
     <div class="af-search-footer">
         <am:pagernav id="PagerBottom" runat="server" />
         <span class="af-search-recordCount">
-            <asp:literal runat="server" id="litRecordCount" />
+            <asp:Literal runat="server" ID="litRecordCount" />
         </span>
     </div>
 </div>

--- a/Dnn.CommunityForums/config/templates/TopicResults.ascx
+++ b/Dnn.CommunityForums/config/templates/TopicResults.ascx
@@ -40,7 +40,7 @@
                 <div class="aftopicrow af-content">
                     <div class="aftopicrow afsubject">
                         <span class="aftopictitle">
-                            [FORUMTOPIC:SUBJECTLINK|<a class="dcf-title dcf-title-4">{0}</a>]
+                            [FORUMTOPIC:SUBJECTLINK|<a href="{0}" title="[FORUMTOPIC:BODYTITLE]" class="dcf-topic-link">[FORUMTOPIC:SUBJECT]</a>]
                         </span> 
                         <span class="aftopicsubtitle">[RESX:Started] [FORUMTOPIC:DATECREATED] [FORUMTOPIC:AUTHORDISPLAYNAMELINK|[RESX:BY] <a href="{0}" class="af-profile-link" rel="nofollow">[FORUMTOPIC:AUTHORDISPLAYNAME]</a>]</span>
                     </div>

--- a/Dnn.CommunityForums/controls/af_search.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_search.ascx.cs
@@ -201,7 +201,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     DotNetNuke.Modules.ActiveForums.Entities.IPostInfo post = null;
                     int topicId = Utilities.SafeConvertInt(((System.Data.DataRowView)repeaterItemEventArgs.Item.DataItem)["TopicId"].ToString(), 1);
                     int contentId = Utilities.SafeConvertInt(((System.Data.DataRowView)repeaterItemEventArgs.Item.DataItem)["ContentId"].ToString(), 1);
-                    var reply = new DotNetNuke.Modules.ActiveForums.Controllers.ReplyController(this.ForumModuleId).Find("WHERE ContentId = @0", contentId).FirstOrDefault();
+                    var reply = new DotNetNuke.Modules.ActiveForums.Controllers.ReplyController(this.ForumModuleId).GetByContentId(contentId);
                     if (reply != null)
                     {
                         post = (DotNetNuke.Modules.ActiveForums.Entities.IPostInfo)reply;
@@ -215,33 +215,34 @@ namespace DotNetNuke.Modules.ActiveForums
                         }
                     }
 
-                    foreach (Control control in repeaterItemEventArgs.Item.Controls)
+                    if (post != null)
                     {
-                        string itemTemplate = string.Empty;
-                        try
+                        foreach (Control control in repeaterItemEventArgs.Item.Controls)
                         {
-                            if (control.GetType().FullName == "System.Web.UI.LiteralControl")
+                            string itemTemplate = string.Empty;
+                            try
                             {
-                                itemTemplate = ((System.Web.UI.LiteralControl)control).Text;
+                                if (control.GetType().FullName == "System.Web.UI.LiteralControl")
+                                {
+                                    itemTemplate = ((System.Web.UI.LiteralControl)control).Text;
+                                }
+                                else if (control.GetType().FullName == "System.Web.UI.HtmlControls.HtmlGenericControl")
+                                {
+                                    itemTemplate = ((System.Web.UI.HtmlControls.HtmlGenericControl)control).InnerText;
+                                }
+                                else
+                                {
+                                    Exceptions.LogException(new KeyNotFoundException($"Unexpected control type: {control.GetType().FullName}"));
+                                }
                             }
-                            else if (control.GetType().FullName == "System.Web.UI.HtmlControls.HtmlGenericControl")
+                            catch (Exception ex)
                             {
-                                itemTemplate = ((System.Web.UI.HtmlControls.HtmlGenericControl)control).InnerText;
+                                Exceptions.LogException(ex);
                             }
-                            else
-                            {
-                                Exceptions.LogException(new KeyNotFoundException($"Unexpected control type: {control.GetType().FullName}"));
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            Exceptions.LogException(ex);
-                        }
 
-                        if (!string.IsNullOrEmpty(itemTemplate) && itemTemplate.Contains("["))
-                        {
-                            if (post != null)
+                            if (!string.IsNullOrEmpty(itemTemplate) && itemTemplate.Contains("["))
                             {
+                              
                                 itemTemplate = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.ReplacePostTokens(new StringBuilder(itemTemplate), post, this.PortalSettings, this.MainSettings, new Services.URLNavigator().NavigationManager(), this.ForumUser, this.Request.Url, this.Request.RawUrl).ToString();
                                 if (control.GetType().FullName == "System.Web.UI.LiteralControl")
                                 {

--- a/Dnn.CommunityForums/themes/community-bootstrap/templates/TopicsView.ascx
+++ b/Dnn.CommunityForums/themes/community-bootstrap/templates/TopicsView.ascx
@@ -69,7 +69,7 @@
                                     ]</td>
 								<td class="dcf-col dcf-col-subject w-100" title="[FORUMTOPIC:BODYTITLE]">
 									<div class="dcf-subject">
-										<h4 class="dcf-title h5 mt-0 mb-2">[FORUMTOPIC:SUBJECTLINK]</h4>
+										<h4 class="dcf-title h5 mt-0 mb-2">[FORUMTOPIC:SUBJECTLINK|<a href="{0}" title="[FORUMTOPIC:BODYTITLE]" class="dcf-topic-link">[FORUMTOPIC:SUBJECT]</a>]</h4>
 										<div class="dcf-topic-started">[RESX:StartedHeader]
 											<i class="fa fa-user fa-blue"></i>&nbsp;[FORUMTOPIC:AUTHORDISPLAYNAMELINK|<a href="{0}" class="af-profile-link" rel="nofollow">[FORUMTOPIC:AUTHORDISPLAYNAME]</a>|[FORUMTOPIC:AUTHORDISPLAYNAME]][AF:UI:MINIPAGER]
 										</div>
@@ -163,7 +163,7 @@
 								</td>
 								<td class="dcf-col dcf-col-subject">
 									<div class="dcf-subject" title="[FORUMTOPIC:BODYTITLE]">
-										<h4 class="dcf-title h5 mt-0 mb-2">[FORUMTOPIC:SUBJECTLINK]
+										<h4 class="dcf-title h5 mt-0 mb-2">[FORUMTOPIC:SUBJECTLINK|<a href="{0}" title="[FORUMTOPIC:BODYTITLE]" class="dcf-topic-link">[FORUMTOPIC:SUBJECT]</a>]
                                             [FORUMTOPIC:ICONPINNED|&nbsp;&nbsp;<i id="af-topicsview-pin-{0}" class="fa fa-thumb-tack fa-fw fa-red"></i>]
                                             [FORUMTOPIC:ICONUNPINNED|&nbsp;&nbsp;<i id="af-topicsview-pin-{0}" class="fa fa-fw fa-red"></i>]
                                             [FORUMTOPIC:ICONLOCKED|&nbsp;&nbsp;<i id="af-topicsview-lock-{0}" class="fa fa-lock fa-fw fa-red"></i>]

--- a/Dnn.CommunityForums/themes/community-default/templates/TopicsView.ascx
+++ b/Dnn.CommunityForums/themes/community-default/templates/TopicsView.ascx
@@ -53,7 +53,7 @@
                                 ]</td>
 							<td class="dcf-col dcf-col-subject" title="[FORUMTOPIC:BODYTITLE]">
 								<div class="dcf-subject">
-										<h4 class="dcf-title dcf-title-4">[FORUMTOPIC:SUBJECTLINK]</h4>
+										<h4 class="dcf-title dcf-title-4">[FORUMTOPIC:SUBJECTLINK|<a href="{0}" class="dcf-topic-link">[FORUMTOPIC:SUBJECT]</a>]</h4>
 										<div class="dcf-topic-started">[RESX:StartedHeader] <i class="fa fa-user fa-blue"></i>&nbsp;[FORUMTOPIC:AUTHORDISPLAYNAMELINK|<a href="{0}" class="af-profile-link" rel="nofollow">[FORUMTOPIC:AUTHORDISPLAYNAME]</a>|[FORUMTOPIC:AUTHORDISPLAYNAME]][AF:UI:MINIPAGER]</div>
 
 									<div class="dcf-forum-description">[FORUMTOPIC:BODYTITLE]</div>
@@ -133,7 +133,7 @@
 					<td class="dcf-col dcf-col-subject">
 						<div class="dcf-subject" title="[FORUMTOPIC:BODYTITLE]">
 
-							<h4 class="dcf-title dcf-title-4">[FORUMTOPIC:SUBJECTLINK]
+							<h4 class="dcf-title dcf-title-4">[FORUMTOPIC:SUBJECTLINK|<a href="{0}" title="[FORUMTOPIC:BODYTITLE]" class="dcf-topic-link">[FORUMTOPIC:SUBJECT]</a>]
                                 [FORUMTOPIC:ICONPINNED|&nbsp;&nbsp;<i id="af-topicsview-pin-{0}" class="fa fa-thumb-tack fa-fw fa-red"></i>]
                                 [FORUMTOPIC:ICONUNPINNED|&nbsp;&nbsp;<i id="af-topicsview-pin-{0}" class="fa fa-fw fa-red"></i>]
                                 [FORUMTOPIC:ICONLOCKED|&nbsp;&nbsp;<i id="af-topicsview-lock-{0}" class="fa fa-lock fa-fw fa-red"></i>]


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Fixes mangled results in search page when display replies/posts rather than topics

## Changes made
- Lookup for replies needs to use GetByContentId() not Find() in order for object model to be populated properly
- Cleaner layout for displaying posts/replies
- [FORUM*:SUBJECTLINK] should not return an <a> tag, just a valid URL; update templates with <a> tag and add legacy mapping

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

Before:
![image](https://github.com/user-attachments/assets/589d31ed-7fd7-4a81-96c3-d7a7dcbb8d0f)

After:
![image](https://github.com/user-attachments/assets/be2b9dae-ab4a-4520-8a99-99eb34156071)

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1336