### PR TITLE
TASK: Refactor TabId access when constructing URLs

### DIFF
--- a/Dnn.CommunityForums/Entities/ForumGroupInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumGroupInfo.cs
@@ -68,7 +68,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         public string RawUrl { get; set; }
 
         [IgnoreColumn]
-        public int TabId => this.ModuleInfo.TabID;
+        public int TabId => this.GetTabId();
 
         [IgnoreColumn]
         public string ThemeLocation => Utilities.ResolveUrl(SettingsBase.GetModuleSettings(this.ModuleId).ThemeLocation);

--- a/Dnn.CommunityForums/Entities/ForumInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumInfo.cs
@@ -389,10 +389,10 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         public string ParentForumUrlPrefix => this.ParentForumId > 0 ? new Controllers.ForumController().GetById(this.ParentForumId, this.ModuleId).PrefixURL : string.Empty;
 
         [IgnoreColumn]
-        public int TabId => this.ModuleInfo.TabID;
+        public int TabId => this.GetTabId();
 
         [IgnoreColumn]
-        public string ForumURL => URL.ForumLink(this.TabId, this);
+        public string ForumURL => URL.ForumLink(this.GetTabId(), this);
 
         [IgnoreColumn]
         public List<DotNetNuke.Modules.ActiveForums.Entities.ForumInfo> SubForums
@@ -651,9 +651,9 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                 {
                     if (this.FeatureSettings.AllowRSS)
                     {
-                        var url = new Uri(Utilities.NavigateURL(this.TabId));
+                        var url = new Uri(Utilities.NavigateURL(this.GetTabId()));
                         this.rssLink =
-                            $"{url.Scheme}://{url.Host}:{url.Port}/DesktopModules/ActiveForums/feeds.aspx?portalid={this.PortalId}&forumid={this.ForumID}&tabid={this.TabId}&moduleid={this.ModuleId}" +
+                            $"{url.Scheme}://{url.Host}:{url.Port}/DesktopModules/ActiveForums/feeds.aspx?portalid={this.PortalId}&forumid={this.ForumID}&tabid={this.GetTabId()}&moduleid={this.ModuleId}" +
                             (this.SocialGroupId > 0 ? $"&GroupId={this.SocialGroupId}" : string.Empty);
                     }
                     else
@@ -822,7 +822,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                 case "forumgroupid":
                     return PropertyAccess.FormatString(this.ForumGroupId.ToString(), format);
                 case "forummainlink":
-                    return PropertyAccess.FormatString(Utilities.NavigateURL(this.TabId), format);
+                    return PropertyAccess.FormatString(Utilities.NavigateURL(this.GetTabId()), format);
                 case "grouplink":
                 case "forumgrouplink":
                     return PropertyAccess.FormatString(new ControlUtils().BuildUrl(
@@ -986,7 +986,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
 
         private int GetTabId()
         {
-            return this.ModuleInfo.TabID > 0 ? this.ModuleInfo.TabID : this.PortalSettings.ActiveTab.TabID == -1 || this.PortalSettings.ActiveTab.TabID == this.PortalSettings.HomeTabId ? this.TabId : this.PortalSettings.ActiveTab.TabID;
+            return this.PortalSettings.ActiveTab.TabID == -1 || this.PortalSettings.ActiveTab.TabID == this.PortalSettings.HomeTabId ? this.TabId : this.PortalSettings.ActiveTab.TabID;
         }
 
         internal string GetCacheKey() => string.Format(this.cacheKeyTemplate, this.ModuleId, this.ForumID);

--- a/Dnn.CommunityForums/Entities/LikeInfo.cs
+++ b/Dnn.CommunityForums/Entities/LikeInfo.cs
@@ -259,11 +259,6 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             return string.Empty;
         }
 
-        private int GetTabId()
-        {
-            return this.Forum.PortalSettings.ActiveTab.TabID == -1 || this.Forum.PortalSettings.ActiveTab.TabID == this.Forum.PortalSettings.HomeTabId ? this.Forum.TabId : this.Forum.PortalSettings.ActiveTab.TabID;
-        }
-
         internal string GetCacheKey() => string.Format(this.cacheKeyTemplate, this.ModuleId, this.ContentId);
 
         internal void UpdateCache() => DotNetNuke.Modules.ActiveForums.DataCache.ContentCacheStore(this.ModuleId, this.GetCacheKey(), this);

--- a/Dnn.CommunityForums/Entities/TopicInfo.cs
+++ b/Dnn.CommunityForums/Entities/TopicInfo.cs
@@ -615,7 +615,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
 
                 case "subjectlink":
                     {
-                        string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, GetTabId(), this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.TopicUrl, -1, -1, string.Empty, 1, -1, this.Forum.SocialGroupId);
+                        string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, this.GetTabId(), this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.TopicUrl, -1, -1, string.Empty, 1, -1, this.Forum.SocialGroupId);
                         string sPollImage = (this.Topic.TopicType == TopicTypes.Poll ? DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.GetTokenFormatString("[POLLIMAGE]", this.Forum.PortalSettings, accessingUser.Profile.PreferredLocale) : string.Empty);
                         string subject = Utilities.StripHTMLTag(System.Net.WebUtility.HtmlDecode(this.Subject)).Replace("\"", string.Empty).Replace("#", string.Empty).Replace("%", string.Empty).Replace("+", string.Empty); ;
                         string sBodyTitle = GetTopicTitle(this.Content.Body);
@@ -643,7 +643,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                                 @params.Add($"{ParamKeys.TopicId}={this.TopicId}");
                             }
 
-                            slink = "<a title=\"" + sBodyTitle + "\" href=\"" + Utilities.NavigateURL(GetTabId(), string.Empty, @params.ToArray()) + "\">" + subject + "</a>";
+                            slink = "<a title=\"" + sBodyTitle + "\" href=\"" + Utilities.NavigateURL(this.GetTabId(), string.Empty, @params.ToArray()) + "\">" + subject + "</a>";
                         }
                         else
                         {
@@ -666,7 +666,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                         }
 
                         string sLastReadURL = string.Empty;
-                        string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, GetTabId(), this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.TopicUrl, -1, -1, string.Empty, 1, -1, this.Forum.SocialGroupId);
+                        string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, this.GetTabId(), this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.TopicUrl, -1, -1, string.Empty, 1, -1, this.Forum.SocialGroupId);
                         int? userLastReplyRead = new Controllers.ForumUserController(this.ModuleId).GetByUserId(
                             accessingUser.PortalID,
                             accessingUser.UserID).GetLastReplyRead(this);
@@ -684,7 +684,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                                 @params.Add($"{Literals.GroupId}={this.Forum.SocialGroupId}");
                             }
 
-                            sLastReadURL = Utilities.NavigateURL(GetTabId(),
+                            sLastReadURL = Utilities.NavigateURL(this.GetTabId(),
                                 string.Empty,
                                 @params.ToArray());
                         }
@@ -701,7 +701,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                                 @params.Add($"{Literals.GroupId}={this.Forum.SocialGroupId}");
                             }
 
-                            sLastReadURL = Utilities.NavigateURL(GetTabId(), string.Empty, @params.ToArray());
+                            sLastReadURL = Utilities.NavigateURL(this.GetTabId(), string.Empty, @params.ToArray());
                         }
 
                         if (sTopicURL.EndsWith("/"))
@@ -727,8 +727,8 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                             @params.Add($"{Literals.GroupId}={this.Forum.SocialGroupId}");
                         }
 
-                        string sLastReplyURL = Utilities.NavigateURL(GetTabId(), string.Empty, @params.ToArray());
-                        string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, GetTabId(), this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.TopicUrl, -1, -1, string.Empty, 1, -1, this.Forum.SocialGroupId);
+                        string sLastReplyURL = Utilities.NavigateURL(this.GetTabId(), string.Empty, @params.ToArray());
+                        string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, this.GetTabId(), this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.TopicUrl, -1, -1, string.Empty, 1, -1, this.Forum.SocialGroupId);
                         if (!(string.IsNullOrEmpty(sTopicURL)))
                         {
                             if (sTopicURL.EndsWith("/"))
@@ -818,7 +818,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                         }
 
                         return PropertyAccess.FormatString(
-                            Utilities.NavigateURL(GetTabId(),
+                            Utilities.NavigateURL(this.GetTabId(),
                                 string.Empty,
                                 @params.ToArray()),
                             format);
@@ -842,7 +842,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                         }
 
                         return PropertyAccess.FormatString(
-                            Utilities.NavigateURL(GetTabId(),
+                            Utilities.NavigateURL(this.GetTabId(),
                                 string.Empty,
                                 @params.ToArray()),
                             format);
@@ -1089,7 +1089,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                             PageSize = 10;
                         }
 
-                        return PropertyAccess.FormatString(Utilities.GetLastPostSubject(this.LastReply.ReplyId, this.TopicId, this.ForumId, GetTabId(), this.LastReply.Content.Subject, length, pageSize: PageSize, replyCount: this.ReplyCount, canRead: true), format);
+                        return PropertyAccess.FormatString(Utilities.GetLastPostSubject(this.LastReply.ReplyId, this.TopicId, this.ForumId, this.GetTabId(), this.LastReply.Content.Subject, length, pageSize: PageSize, replyCount: this.ReplyCount, canRead: true), format);
                     }
 
                 case "lastpostauthordisplaynamelink":
@@ -1203,7 +1203,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                             }
 
                             return PropertyAccess.FormatString(
-                                Utilities.NavigateURL(GetTabId(), string.Empty, @params.ToArray()),
+                                Utilities.NavigateURL(this.GetTabId(), string.Empty, @params.ToArray()),
                                 format);
                         }
 
@@ -1244,7 +1244,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                             }
 
                             return PropertyAccess.FormatString(
-                                Utilities.NavigateURL(GetTabId(), string.Empty, @params.ToArray()),
+                                Utilities.NavigateURL(this.GetTabId(), string.Empty, @params.ToArray()),
                                 format);
                         }
 
@@ -1285,7 +1285,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                             }
 
                             return PropertyAccess.FormatString(
-                                Utilities.NavigateURL(GetTabId(), string.Empty, @params.ToArray()),
+                                Utilities.NavigateURL(this.GetTabId(), string.Empty, @params.ToArray()),
                                 format);
                         }
 
@@ -1442,7 +1442,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                             }
 
                             return PropertyAccess.FormatString(
-                                Utilities.NavigateURL(GetTabId(), string.Empty, editParams.ToArray()),
+                                Utilities.NavigateURL(this.GetTabId(), string.Empty, editParams.ToArray()),
                                 format);
                         }
 
@@ -1468,7 +1468,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                             };
 
                             return PropertyAccess.FormatString(
-                                Utilities.NavigateURL(GetTabId(), string.Empty, @params.ToArray()),
+                                Utilities.NavigateURL(this.GetTabId(), string.Empty, @params.ToArray()),
                                 format);
                         }
                         return string.Empty;


### PR DESCRIPTION
Replaced direct access to the TabId property with a call to the new GetTabId() method across multiple classes, including ForumGroupInfo, ForumInfo, LikeInfo, and TopicInfo. This change enhances encapsulation and maintainability. Updated URL constructions to consistently use GetTabId() for obtaining the TabId which permits the optional viewer module to show accurate URLs.

## PR Template Checklist

- [ ] Fixes Bug
- [ ] Feature solution
- [X] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1343