### PR TITLE
TASK: Remove 3rd-party SimulateDateDiff

### DIFF
--- a/Dnn.CommunityForums/CustomControls/ServerControls/QuickReply.cs
+++ b/Dnn.CommunityForums/CustomControls/ServerControls/QuickReply.cs
@@ -186,7 +186,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
         private void SaveQuickReply()
         {
             DotNetNuke.Modules.ActiveForums.Entities.ForumInfo forumInfo = DotNetNuke.Modules.ActiveForums.Controllers.ForumController.Forums_Get(this.portalId, this.moduleId, this.ForumId, false, this.TopicId);
-            if (!Utilities.HasFloodIntervalPassed(floodInterval: this.MainSettings.FloodInterval, forumUser: this.ForumUser, forumInfo: forumInfo))
+            if (!Utilities.HasFloodIntervalPassed(floodInterval: this.ForumInfo.MainSettings.FloodInterval, forumUser: this.ForumUser, forumInfo: forumInfo))
             {
                 this.plhMessage.Controls.Add(new InfoMessage { Message = "<div class=\"afmessage\">" + string.Format(this.GetSharedResource("[RESX:Error:FloodControl]"), this.MainSettings.FloodInterval) + "</div>" });
                 return;

--- a/Dnn.CommunityForums/Entities/ForumUserInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumUserInfo.cs
@@ -64,8 +64,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             this.ModuleId = moduleId;
         }
 
-        [IgnoreColumn]
-        public bool IsAuthenticated { get; set; } = false;
+        [IgnoreColumn] public bool IsAuthenticated => this.UserId > DotNetNuke.Common.Utilities.Null.NullInteger;
 
         public int ProfileId { get; set; }
 

--- a/Dnn.CommunityForums/SimulateDateDiff.cs
+++ b/Dnn.CommunityForums/SimulateDateDiff.cs
@@ -27,8 +27,13 @@
 //  This class simulates the behavior of the classic VB 'DateDiff' function.
 //----------------------------------------------------------------------------------------
 */
+
+using System;
+
+[Obsolete("Deprecated in Community Forums. Removing in 10.00.00. Not Used.")]
 public static class SimulateDateDiff
 {
+    [Obsolete("Deprecated in Community Forums. Removing in 10.00.00. Not Used.")]
     public enum DateInterval
     {
         Day,
@@ -43,6 +48,7 @@ public static class SimulateDateDiff
         Year,
     }
 
+    [Obsolete("Deprecated in Community Forums. Removing in 10.00.00. Not Used.")]
     public static long DateDiff(DateInterval intervalType, System.DateTime dateOne, System.DateTime dateTwo)
     {
         switch (intervalType)

--- a/Dnn.CommunityForums/controls/af_post.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_post.ascx.cs
@@ -375,7 +375,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 this.Response.Redirect(this.NavigateUrl(this.TabId), false);
                 this.Context.ApplicationInstance.CompleteRequest();
             }
-            else if (!this.canModEdit && ti.Content.AuthorId == this.UserId && this.canEdit && this.MainSettings.EditInterval > 0 & SimulateDateDiff.DateDiff(SimulateDateDiff.DateInterval.Minute, ti.Content.DateCreated, DateTime.UtcNow) > this.MainSettings.EditInterval)
+            else if (!this.canModEdit && ti.Content.AuthorId == this.UserId && this.canEdit && this.MainSettings.EditInterval > 0 && DateTime.UtcNow.Subtract(ti.Content.DateCreated).TotalMinutes > this.MainSettings.EditInterval)
             {
                 var im = new InfoMessage
                 {
@@ -461,7 +461,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 this.Response.Redirect(this.NavigateUrl(this.TabId), false);
                 this.Context.ApplicationInstance.CompleteRequest();
             }
-            else if (!this.canModEdit && ri.Content.AuthorId == this.UserId && this.canEdit && this.MainSettings.EditInterval > 0 & SimulateDateDiff.DateDiff(SimulateDateDiff.DateInterval.Minute, ri.Content.DateCreated, DateTime.UtcNow) > this.MainSettings.EditInterval)
+            else if (!this.canModEdit && ri.Content.AuthorId == this.UserId && this.canEdit && !Utilities.HasEditIntervalPassed(editInterval: this.ForumInfo.MainSettings.EditInterval, forumUser: this.ForumUser, forumInfo: this.ForumInfo, postInfo: ri))
             {
                 var im = new Controls.InfoMessage
                 {

--- a/Dnn.CommunityForums/controls/af_quickreply.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_quickreply.ascx.cs
@@ -236,19 +236,12 @@ namespace DotNetNuke.Modules.ActiveForums
         private void SaveQuickReply()
         {
             DotNetNuke.Modules.ActiveForums.Entities.ForumInfo forumInfo = DotNetNuke.Modules.ActiveForums.Controllers.ForumController.Forums_Get(this.PortalId, this.ForumModuleId, this.ForumId, false, this.TopicId);
-            if (!Utilities.HasFloodIntervalPassed(floodInterval: this.MainSettings.FloodInterval, forumUser: this.ForumUser, forumInfo: forumInfo))
+            if (!Utilities.HasFloodIntervalPassed(floodInterval: this.ForumInfo.MainSettings.FloodInterval, forumUser: this.ForumUser, forumInfo: forumInfo))
             {
-                var upi = new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ForumModuleId).GetByUserId(this.PortalId, this.UserId);
-                if (upi?.DateLastPost!=null)
-                {
-                    if (SimulateDateDiff.DateDiff(SimulateDateDiff.DateInterval.Second, (DateTime)upi.DateLastPost, DateTime.UtcNow) < this.MainSettings.FloodInterval)
-                    {
-                        Controls.InfoMessage im = new Controls.InfoMessage();
-                        im.Message = "<div class=\"afmessage\">" + string.Format(Utilities.GetSharedResource("[RESX:Error:FloodControl]"), this.MainSettings.FloodInterval) + "</div>";
-                        this.plhMessage.Controls.Add(im);
-                        return;
-                    }
-                }
+                Controls.InfoMessage im = new Controls.InfoMessage();
+                im.Message = "<div class=\"afmessage\">" + string.Format(Utilities.GetSharedResource("[RESX:Error:FloodControl]"), this.MainSettings.FloodInterval) + "</div>";
+                this.plhMessage.Controls.Add(im);
+                return;
             }
 
             if (!this.Request.IsAuthenticated)

--- a/Dnn.CommunityForumsTests/Services/Tokens/TokenReplacerTests.cs
+++ b/Dnn.CommunityForumsTests/Services/Tokens/TokenReplacerTests.cs
@@ -111,7 +111,6 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Services.Tokens
                 {
                     PortalId = DotNetNuke.Entities.Portals.PortalController.Instance.GetCurrentPortalSettings().PortalId,
                     UserId = mockUserInfo.Object.UserID,
-                    IsAuthenticated = true,
                     UserInfo = mockUserInfo.Object,
                     UserRoles = $"{DotNetNuke.Tests.Utilities.Constants.RoleID_RegisteredUsers}{emptyPermissions}",
                 },
@@ -210,7 +209,6 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Services.Tokens
                 {
                     PortalId = DotNetNuke.Entities.Portals.PortalController.Instance.GetCurrentPortalSettings().PortalId,
                     UserId = mockUserInfo.Object.UserID,
-                    IsAuthenticated = true,
                     UserInfo = mockUserInfo.Object,
                     UserRoles = $"{DotNetNuke.Tests.Utilities.Constants.RoleID_RegisteredUsers}{emptyPermissions}",
                 },
@@ -318,7 +316,6 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Services.Tokens
                 {
                     PortalId = DotNetNuke.Entities.Portals.PortalController.Instance.GetCurrentPortalSettings().PortalId,
                     UserId = mockUserInfo.Object.UserID,
-                    IsAuthenticated = true,
                     UserInfo = mockUserInfo.Object,
                     UserRoles = $"{DotNetNuke.Tests.Utilities.Constants.RoleID_RegisteredUsers}{emptyPermissions}",
                 },
@@ -405,7 +402,6 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Services.Tokens
                 {
                     PortalId = DotNetNuke.Entities.Portals.PortalController.Instance.GetCurrentPortalSettings().PortalId,
                     UserId = mockUserInfo.Object.UserID,
-                    IsAuthenticated = true,
                     UserInfo = mockUserInfo.Object,
                     UserRoles = $"{DotNetNuke.Tests.Utilities.Constants.RoleID_RegisteredUsers}{emptyPermissions}",
                 },

--- a/Dnn.CommunityForumsTests/class/UtilitiesTests.cs
+++ b/Dnn.CommunityForumsTests/class/UtilitiesTests.cs
@@ -18,6 +18,8 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using System.Collections;
+
 namespace DotNetNuke.Modules.ActiveForumsTests
 {
     using System;
@@ -29,6 +31,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests
     using System.Threading.Tasks;
 
     using DotNetNuke.Modules.ActiveForums;
+    using DotNetNuke.Modules.ActiveForums.Entities;
     using Moq;
     using NUnit.Framework;
 
@@ -79,25 +82,46 @@ namespace DotNetNuke.Modules.ActiveForumsTests
         [TestCase(20, 25, false, false, ExpectedResult = true)]
         [TestCase(200, 25, false, true, ExpectedResult = true)] // user is an admin
         [TestCase(200, null, false, false, ExpectedResult = true)] // user is an admin
-        [TestCase(200, 25, true, false, ExpectedResult = true)] // interval is 200, anonymous, last post is 25, expect true
+        [TestCase(200, 25, true, false, ExpectedResult = true)] // interval is 200, anonymous, last post is 25, expect true (anonymous users will require captcha)
         [TestCase(200, 25, false, false, ExpectedResult = false)] // interval is 200, not anonymous, last post is 25, expect false
+        [TestCase(20, 25, false, false, ExpectedResult = true)] // interval is 20, not anonymous, last post is 25, expect true
         public bool HasFloodIntervalPassedTest1(int floodInterval, object secondsSinceLastPost, bool isAnonymous, bool isSuperUser)
         {
             //Arrange
+            var featureSettings = new System.Collections.Hashtable
+            {
+                { ForumSettingKeys.DefaultTrustLevel, TrustTypes.NotTrusted },
+            };
+            var mockPermissions = new Mock<DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo>();
+            var mockForum = new Mock<DotNetNuke.Modules.ActiveForums.Entities.ForumInfo>(DotNetNuke.Entities.Portals.PortalController.Instance.GetCurrentPortalSettings())
+            {
+                Object =
+                {
+                    PortalSettings = DotNetNuke.Entities.Portals.PortalController.Instance.GetCurrentPortalSettings(),
+                    ForumID = 1,
+                    ForumName = "Test Forum",
+                    TotalTopics = 0,
+                    Security = mockPermissions.Object,
+                    ForumGroup = new DotNetNuke.Modules.ActiveForums.Entities.ForumGroupInfo
+                    {
+                        GroupName = "Test Forum Group",
+                    },
+                    FeatureSettings = new DotNetNuke.Modules.ActiveForums.Entities.FeatureSettings(featureSettings),
+                },
+            };
             var mockUserInfo = new Mock<DotNetNuke.Entities.Users.UserInfo>
             {
                 Object =
                 {
                     UserID = isAnonymous ? -1 : DotNetNuke.Tests.Utilities.Constants.UserID_User12,
-                    IsSuperUser = isSuperUser,
-                }
+                    IsSuperUser = isSuperUser && !isAnonymous,
+                },
             };
             var mockUser = new Mock<DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo>
             {
                 Object =
                 {
                     UserId = mockUserInfo.Object.UserID,
-                    IsAuthenticated = !isAnonymous,
                     UserInfo = mockUserInfo.Object,
                 },
             };
@@ -108,11 +132,27 @@ namespace DotNetNuke.Modules.ActiveForumsTests
                 mockUser.Object.DateLastReply = DateTime.UtcNow.AddSeconds(-1 * (int)secondsSinceLastPost);
             }
 
+            // Act
+            bool actualResult = DotNetNuke.Modules.ActiveForums.Utilities.HasFloodIntervalPassed(floodInterval, mockUser.Object, mockForum.Object);
+
+            // Assert
+            return actualResult;
+        }
+
+        [Test]
+        [TestCase(0, 0, false, false, ExpectedResult = true)] // edit interval disabled
+        [TestCase(20, 25, false, false, ExpectedResult = true)]
+        [TestCase(200, 25, false, true, ExpectedResult = true)] // user is a superuser; expect true
+        [TestCase(20, 25, true, false, ExpectedResult = true)] // interval is 20, anonymous, post created 25 minutes ago, expect true
+        [TestCase(30, 25, false, false, ExpectedResult = false)] // interval is 30, not anonymous, last post created 25 minutes ago, expect false
+        public bool HasEditIntervalPassedTest(int editInterval, int minutesSincePostCreated, bool isAnonymous, bool isSuperUser)
+        {
+
+            // Arrange
             var featureSettings = new System.Collections.Hashtable
             {
                 { ForumSettingKeys.DefaultTrustLevel, TrustTypes.NotTrusted },
             };
-
             var mockPermissions = new Mock<DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo>();
             var mockForum = new Mock<DotNetNuke.Modules.ActiveForums.Entities.ForumInfo>(DotNetNuke.Entities.Portals.PortalController.Instance.GetCurrentPortalSettings())
             {
@@ -131,8 +171,43 @@ namespace DotNetNuke.Modules.ActiveForumsTests
                 },
             };
 
+            var mockTopic = new Mock<DotNetNuke.Modules.ActiveForums.Entities.TopicInfo>
+            {
+                Object =
+                {
+                    ForumId = 1,
+                    TopicId = 1,
+                    Forum = mockForum.Object,
+                    Content = new DotNetNuke.Modules.ActiveForums.Entities.ContentInfo
+                    {
+                        ContentId = 1,
+                        ModuleId = 1,
+                        Subject = "Test Topic",
+                        Body = "Test Topic",
+                        DateCreated = DateTime.UtcNow.AddMinutes(-1 * minutesSincePostCreated),
+                    },
+                },
+            };
+
+            var mockUserInfo = new Mock<DotNetNuke.Entities.Users.UserInfo>
+            {
+                Object =
+                {
+                    UserID = isAnonymous ? -1 : DotNetNuke.Tests.Utilities.Constants.UserID_User12,
+                    IsSuperUser = isSuperUser && !isAnonymous,
+                },
+            };
+            var mockUser = new Mock<DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo>
+            {
+                Object =
+                {
+                    UserId = mockUserInfo.Object.UserID,
+                    UserInfo = mockUserInfo.Object,
+                },
+            };
+
             // Act
-            bool actualResult = Utilities.HasFloodIntervalPassed(floodInterval, mockUser.Object, mockForum.Object);
+            bool actualResult = DotNetNuke.Modules.ActiveForums.Utilities.HasEditIntervalPassed(editInterval, mockUser.Object, mockForum.Object, mockTopic.Object);
 
             // Assert
             return actualResult;


### PR DESCRIPTION
### Description of PR...

Removes reliance on 3rd-party code for 'SimulateDateDiff'
 
## Changes made

- Marked `SimulateDateDiff` class as obsolete; updated `DateDiff` method.
- Refactor flood and edit interval checks
- Updated `ambtnSubmit_Click` to use `this.ForumInfo.MainSettings.FloodInterval`.
- Changed `IsAuthenticated` in `ForumUserInfo.cs` to a computed property.
- Refactored `HasFloodIntervalPassed` to use `DateTime.UtcNow.Subtract(...)`.
- Introduced `HasEditIntervalPassed` method for edit interval checks.
- Updated `LoadTopic` and `LoadReply` methods to use the new edit interval check.
- Simplified flood interval check in `af_quickreply.ascx.cs`.
- Added new test cases for `HasFloodIntervalPassed` and `HasEditIntervalPassed` in `UtilitiesTests.cs`.


## How did you test these updates?  
Local install and unit tests

## PR Template Checklist

- [ ] Fixes Bug
- [ ] Feature solution
- [X] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1286