### PR TITLE
TASK: Replace 3rd-party SimulateIsNumeric with Utilities.IsNumeric

### DIFF
--- a/Dnn.CommunityForums/Controllers/UrlController.cs
+++ b/Dnn.CommunityForums/Controllers/UrlController.cs
@@ -28,7 +28,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
         internal static string BuildTopicUrlSegment(int portalId, int moduleId, int topicId, string subject, DotNetNuke.Modules.ActiveForums.Entities.ForumInfo forumInfo)
         {
             var cleanSubject = Utilities.CleanName(subject).ToLowerInvariant();
-            if (SimulateIsNumeric.IsNumeric(cleanSubject))
+            if (Utilities.IsNumeric(cleanSubject))
             {
                 cleanSubject = "Topic-" + cleanSubject;
             }

--- a/Dnn.CommunityForums/CustomControls/ServerControls/CategoryNavigator.cs
+++ b/Dnn.CommunityForums/CustomControls/ServerControls/CategoryNavigator.cs
@@ -176,7 +176,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             tb.HeaderTemplate = this.HeaderTemplate.Text;
             tb.FooterTemplate = this.FooterTemplate.Text;
             tb.CSSClass = this.CssClass;
-            if (HttpContext.Current.Request.QueryString[ParamKeys.Category] != null && SimulateIsNumeric.IsNumeric(HttpContext.Current.Request.QueryString[ParamKeys.Category]))
+            if (HttpContext.Current.Request.QueryString[ParamKeys.Category] != null && Utilities.IsNumeric(HttpContext.Current.Request.QueryString[ParamKeys.Category]))
             {
                 tb.SelectedCategory = int.Parse(HttpContext.Current.Request.QueryString[ParamKeys.Category]);
             }

--- a/Dnn.CommunityForums/CustomControls/ServerControls/TopicsNavigator.cs
+++ b/Dnn.CommunityForums/CustomControls/ServerControls/TopicsNavigator.cs
@@ -125,12 +125,12 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 tb.ForumIds = this.UserForumsList;
             }
 
-            if (this.Request.QueryString["atg"] != null && SimulateIsNumeric.IsNumeric(this.Request.QueryString["atg"]))
+            if (this.Request.QueryString["atg"] != null && Utilities.IsNumeric(this.Request.QueryString["atg"]))
             {
                 tb.TagId = int.Parse(this.Request.QueryString["atg"]);
             }
 
-            if (this.Request.QueryString[ParamKeys.Category] != null && SimulateIsNumeric.IsNumeric(this.Request.QueryString[ParamKeys.Category]))
+            if (this.Request.QueryString[ParamKeys.Category] != null && Utilities.IsNumeric(this.Request.QueryString[ParamKeys.Category]))
             {
                 tb.CategoryId = int.Parse(this.Request.QueryString[ParamKeys.Category]);
             }

--- a/Dnn.CommunityForums/Services/Controllers/TopicController.cs
+++ b/Dnn.CommunityForums/Services/Controllers/TopicController.cs
@@ -531,26 +531,26 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Controllers
                             }
                         }
 
-                        if (DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasAccess(originalTopic.Forum.Security.Categorize, string.Join(";", DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(this.ActiveModule.PortalID, this.UserInfo.Roles))))
-                        {
-                            if (!string.IsNullOrEmpty(dto.Topic.SelectedCategoriesAsString))
+                            if (DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasAccess(originalTopic.Forum.Security.Categorize, string.Join(";", DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(this.ActiveModule.PortalID, this.UserInfo.Roles))))
                             {
-                                string[] cats = dto.Topic.SelectedCategoriesAsString.Split(';');
-                                DataProvider.Instance().Tags_DeleteTopicToCategory(this.ActiveModule.PortalID, this.ForumModuleId, -1, topicId);
-                                foreach (string c in cats)
+                                if (!string.IsNullOrEmpty(dto.Topic.SelectedCategoriesAsString))
                                 {
-                                    int cid = -1;
-                                    if (!string.IsNullOrEmpty(c) && SimulateIsNumeric.IsNumeric(c))
+                                    string[] cats = dto.Topic.SelectedCategoriesAsString.Split(';');
+                                    DataProvider.Instance().Tags_DeleteTopicToCategory(this.ActiveModule.PortalID, this.ForumModuleId, -1, topicId);
+                                    foreach (string c in cats)
                                     {
-                                        cid = Convert.ToInt32(c);
-                                        if (cid > 0)
+                                        int cid = -1;
+                                        if (!string.IsNullOrEmpty(c) && Utilities.IsNumeric(c))
                                         {
-                                            DataProvider.Instance().Tags_AddTopicToCategory(this.ActiveModule.PortalID, this.ForumModuleId, cid, topicId);
+                                            cid = Convert.ToInt32(c);
+                                            if (cid > 0)
+                                            {
+                                                DataProvider.Instance().Tags_AddTopicToCategory(this.ActiveModule.PortalID, this.ForumModuleId, cid, topicId);
+                                            }
                                         }
                                     }
                                 }
                             }
-                        }
 
                         DotNetNuke.Modules.ActiveForums.Entities.TopicInfo updatedTopic = new DotNetNuke.Modules.ActiveForums.Controllers.TopicController(this.ForumModuleId).GetById(topicId);
                         return this.Request.CreateResponse(HttpStatusCode.OK, new DotNetNuke.Modules.ActiveForums.ViewModels.Topic(updatedTopic));

--- a/Dnn.CommunityForums/SimulateIsNumeric.cs
+++ b/Dnn.CommunityForums/SimulateIsNumeric.cs
@@ -27,8 +27,12 @@
 //  This class simulates the behavior of the classic VB 'IsNumeric' function.
 //----------------------------------------------------------------------------------------
 */
+using System;
+
+[Obsolete("Deprecated in Community Forums. Removing in 10.00.00. Not Used.")]
 public static class SimulateIsNumeric
 {
+    [Obsolete("Deprecated in Community Forums. Removing in 10.00.00. Not Used.")]
     public static bool IsNumeric(object expression)
     {
         if (expression == null)

--- a/Dnn.CommunityForums/class/SettingsBase.cs
+++ b/Dnn.CommunityForums/class/SettingsBase.cs
@@ -97,14 +97,14 @@ namespace DotNetNuke.Modules.ActiveForums
                 int tempPageId = 0;
                 if (this.Request.QueryString[ParamKeys.PageId] != null)
                 {
-                    if (SimulateIsNumeric.IsNumeric(this.Request.QueryString[ParamKeys.PageId]))
+                    if (Utilities.IsNumeric(this.Request.QueryString[ParamKeys.PageId]))
                     {
                         tempPageId = Convert.ToInt32(this.Request.QueryString[ParamKeys.PageId]);
                     }
                 }
                 else if (this.Request.QueryString[Literals.Page] != null)
                 {
-                    if (SimulateIsNumeric.IsNumeric(this.Request.QueryString[Literals.Page]))
+                    if (Utilities.IsNumeric(this.Request.QueryString[Literals.Page]))
                     {
                         tempPageId = Convert.ToInt32(this.Request.QueryString[Literals.Page]);
                     }
@@ -365,7 +365,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
                 if (this.Request.Params[Literals.ForumId] != null)
                 {
-                    if (SimulateIsNumeric.IsNumeric(this.Request.Params[Literals.ForumId]))
+                    if (Utilities.IsNumeric(this.Request.Params[Literals.ForumId]))
                     {
                         sParams = $"{ParamKeys.ForumId}={this.Request.Params[Literals.ForumId]}";
                     }
@@ -373,7 +373,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
                 if (this.Request.Params[Literals.PostId] != null)
                 {
-                    if (SimulateIsNumeric.IsNumeric(this.Request.Params[Literals.PostId]))
+                    if (Utilities.IsNumeric(this.Request.Params[Literals.PostId]))
                     {
                         sParams += $"|{ParamKeys.TopicId}={this.Request.Params[Literals.PostId]}";
                     }

--- a/Dnn.CommunityForums/class/TopicBase.cs
+++ b/Dnn.CommunityForums/class/TopicBase.cs
@@ -37,7 +37,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 {
                     if (this.Request.Params[ParamKeys.TopicId] != null)
                     {
-                        if (SimulateIsNumeric.IsNumeric(this.Request.Params[ParamKeys.TopicId]))
+                        if (Utilities.IsNumeric(this.Request.Params[ParamKeys.TopicId]))
                         {
                             this.topicId = Convert.ToInt32(this.Request.Params[ParamKeys.TopicId]);
                             return this.topicId;

--- a/Dnn.CommunityForums/class/Utilities.cs
+++ b/Dnn.CommunityForums/class/Utilities.cs
@@ -1746,5 +1746,10 @@ namespace DotNetNuke.Modules.ActiveForums
         {
             return DotNetNuke.Services.Localization.Localization.GetString(key, resourceFile, (DotNetNuke.Entities.Portals.PortalSettings)portalSettings, language);
         }
+
+        public static bool IsNumeric(object expression)
+        {
+            return expression != null && (double.TryParse(expression.ToString(), out _) || bool.TryParse(expression.ToString(), out _));
+        }
     }
 }

--- a/Dnn.CommunityForums/class/WhatsNewModuleSettings.cs
+++ b/Dnn.CommunityForums/class/WhatsNewModuleSettings.cs
@@ -133,14 +133,14 @@ namespace DotNetNuke.Modules.ActiveForums
 
             return new WhatsNewModuleSettings
             {
-                Rows = SimulateIsNumeric.IsNumeric(moduleSettings[RowsSettingsKey]) ? Convert.ToInt32(moduleSettings[RowsSettingsKey]) : DefaultRows,
+                Rows = Utilities.IsNumeric(moduleSettings[RowsSettingsKey]) ? Convert.ToInt32(moduleSettings[RowsSettingsKey]) : DefaultRows,
                 Forums = (moduleSettings[ForumsSettingsKey] != null) ? Convert.ToString(moduleSettings[ForumsSettingsKey]) : DefaultForums,
-                RSSEnabled = SimulateIsNumeric.IsNumeric(moduleSettings[RSSEnabledSettingsKey]) ? Convert.ToBoolean(moduleSettings[RSSEnabledSettingsKey]) : DefaultRSSEnabled,
-                RSSIgnoreSecurity = SimulateIsNumeric.IsNumeric(moduleSettings[RSSIgnoreSecuritySettingsKey]) ? Convert.ToBoolean(moduleSettings[RSSIgnoreSecuritySettingsKey]) : DefaultRSSIgnoreSecurity,
-                RSSIncludeBody = SimulateIsNumeric.IsNumeric(moduleSettings[RSSIncludeBodySettingsKey]) ? Convert.ToBoolean(moduleSettings[RSSIncludeBodySettingsKey]) : DefaultRSSIncludeBody,
-                RSSCacheTimeout = SimulateIsNumeric.IsNumeric(moduleSettings[RSSCacheTimeoutSettingsKey]) ? Convert.ToInt32(moduleSettings[RSSCacheTimeoutSettingsKey]) : DefaultRSSCacheTimeout,
-                TopicsOnly = SimulateIsNumeric.IsNumeric(moduleSettings[TopicsOnlySettingsKey]) ? Convert.ToBoolean(moduleSettings[TopicsOnlySettingsKey]) : DefaultTopicsOnly,
-                RandomOrder = SimulateIsNumeric.IsNumeric(moduleSettings[RandomOrderSettingsKey]) ? Convert.ToBoolean(moduleSettings[RandomOrderSettingsKey]) : DefaultRandomOrder,
+                RSSEnabled = Utilities.IsNumeric(moduleSettings[RSSEnabledSettingsKey]) ? Convert.ToBoolean(moduleSettings[RSSEnabledSettingsKey]) : DefaultRSSEnabled,
+                RSSIgnoreSecurity = Utilities.IsNumeric(moduleSettings[RSSIgnoreSecuritySettingsKey]) ? Convert.ToBoolean(moduleSettings[RSSIgnoreSecuritySettingsKey]) : DefaultRSSIgnoreSecurity,
+                RSSIncludeBody = Utilities.IsNumeric(moduleSettings[RSSIncludeBodySettingsKey]) ? Convert.ToBoolean(moduleSettings[RSSIncludeBodySettingsKey]) : DefaultRSSIncludeBody,
+                RSSCacheTimeout = Utilities.IsNumeric(moduleSettings[RSSCacheTimeoutSettingsKey]) ? Convert.ToInt32(moduleSettings[RSSCacheTimeoutSettingsKey]) : DefaultRSSCacheTimeout,
+                TopicsOnly = Utilities.IsNumeric(moduleSettings[TopicsOnlySettingsKey]) ? Convert.ToBoolean(moduleSettings[TopicsOnlySettingsKey]) : DefaultTopicsOnly,
+                RandomOrder = Utilities.IsNumeric(moduleSettings[RandomOrderSettingsKey]) ? Convert.ToBoolean(moduleSettings[RandomOrderSettingsKey]) : DefaultRandomOrder,
                 Tags = (moduleSettings[TagsSettingsKey] != null) ? Convert.ToString(moduleSettings[TagsSettingsKey]) : DefaultTags,
                 Header = (moduleSettings[HeaderSettingsKey] != null) ? Convert.ToString(moduleSettings[HeaderSettingsKey]) : DefaultHeader,
                 Footer = (moduleSettings[FooterSettingsKey] != null) ? Convert.ToString(moduleSettings[FooterSettingsKey]) : DefaultFooter,

--- a/Dnn.CommunityForums/components/Common/HandlerBase.cs
+++ b/Dnn.CommunityForums/components/Common/HandlerBase.cs
@@ -82,7 +82,7 @@ namespace DotNetNuke.Modules.ActiveForums.Handlers
         {
             get
             {
-                if (HttpContext.Current.Request.QueryString["PortalId"] != null && SimulateIsNumeric.IsNumeric(HttpContext.Current.Request.QueryString["PortalId"]))
+                if (HttpContext.Current.Request.QueryString["PortalId"] != null && Utilities.IsNumeric(HttpContext.Current.Request.QueryString["PortalId"]))
                 {
                     return int.Parse(HttpContext.Current.Request.QueryString["PortalId"]);
                 }
@@ -97,7 +97,7 @@ namespace DotNetNuke.Modules.ActiveForums.Handlers
         {
             get
             {
-                if (HttpContext.Current.Request.QueryString["ModuleId"] != null && SimulateIsNumeric.IsNumeric(HttpContext.Current.Request.QueryString["ModuleId"]))
+                if (HttpContext.Current.Request.QueryString["ModuleId"] != null && Utilities.IsNumeric(HttpContext.Current.Request.QueryString["ModuleId"]))
                 {
                     return int.Parse(HttpContext.Current.Request.QueryString["ModuleId"]);
                 }
@@ -112,7 +112,7 @@ namespace DotNetNuke.Modules.ActiveForums.Handlers
         {
             get
             {
-                if (HttpContext.Current.Request.QueryString["TabId"] != null && SimulateIsNumeric.IsNumeric(HttpContext.Current.Request.QueryString["TabId"]))
+                if (HttpContext.Current.Request.QueryString["TabId"] != null && Utilities.IsNumeric(HttpContext.Current.Request.QueryString["TabId"]))
                 {
                     return int.Parse(HttpContext.Current.Request.QueryString["TabId"]);
                 }
@@ -166,7 +166,7 @@ namespace DotNetNuke.Modules.ActiveForums.Handlers
         {
             get
             {
-                if (HttpContext.Current.Request.QueryString["opt"] != null && SimulateIsNumeric.IsNumeric(HttpContext.Current.Request.QueryString["opt"]))
+                if (HttpContext.Current.Request.QueryString["opt"] != null && Utilities.IsNumeric(HttpContext.Current.Request.QueryString["opt"]))
                 {
                     return int.Parse(HttpContext.Current.Request.QueryString["opt"]);
                 }

--- a/Dnn.CommunityForums/components/Extensions/ReWriter.cs
+++ b/Dnn.CommunityForums/components/Extensions/ReWriter.cs
@@ -184,7 +184,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 {
                     if (!string.IsNullOrEmpty(up))
                     {
-                        if (!SimulateIsNumeric.IsNumeric(up))
+                        if (!Utilities.IsNumeric(up))
                         {
                             newSearchURL += up + "/";
                         }
@@ -441,7 +441,7 @@ namespace DotNetNuke.Modules.ActiveForums
                         urlTail = urlTail.Substring(0, urlTail.IndexOf("/") - 1);
                     }
 
-                    if (SimulateIsNumeric.IsNumeric(urlTail))
+                    if (Utilities.IsNumeric(urlTail))
                     {
                         this.page = Convert.ToInt32(urlTail);
                     }

--- a/Dnn.CommunityForums/components/Helpers/JSON.cs
+++ b/Dnn.CommunityForums/components/Helpers/JSON.cs
@@ -46,7 +46,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 {
                     value = ((char)34).ToString() + ((char)34).ToString();
                 }
-                else if (!SimulateIsNumeric.IsNumeric(value) & !(value.ToLower() == "true" || value.ToLower() == "false") && isObject == false)
+                else if (!Utilities.IsNumeric(value) & !(value.ToLower() == "true" || value.ToLower() == "false") && isObject == false)
                 {
                     value = ((char)34).ToString() + JSON.EscapeJsonString(value) + ((char)34).ToString();
                 }

--- a/Dnn.CommunityForums/controls/admin_categories.ascx.cs
+++ b/Dnn.CommunityForums/controls/admin_categories.ascx.cs
@@ -59,7 +59,7 @@ namespace DotNetNuke.Modules.ActiveForums
                         case "DELETE":
                             {
                                 int tagId = Convert.ToInt32(e.Parameters[4].Split(':')[1]);
-                                if (SimulateIsNumeric.IsNumeric(tagId))
+                                if (Utilities.IsNumeric(tagId))
                                 {
                                     new DotNetNuke.Modules.ActiveForums.Controllers.TagController().DeleteById(tagId);
                                 }

--- a/Dnn.CommunityForums/controls/admin_filters.ascx.cs
+++ b/Dnn.CommunityForums/controls/admin_filters.ascx.cs
@@ -55,7 +55,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     switch (sAction.ToUpper())
                     {
                         case "DELETE":
-                            if (SimulateIsNumeric.IsNumeric(filterId))
+                            if (Utilities.IsNumeric(filterId))
                             {
                                 new DotNetNuke.Modules.ActiveForums.Controllers.FilterController().DeleteById(filterId);
                             }

--- a/Dnn.CommunityForums/controls/admin_tags.ascx.cs
+++ b/Dnn.CommunityForums/controls/admin_tags.ascx.cs
@@ -55,7 +55,7 @@ namespace DotNetNuke.Modules.ActiveForums
                         case "DELETE":
                             {
                                 int tagId = Convert.ToInt32(e.Parameters[4].Split(':')[1]);
-                                if (SimulateIsNumeric.IsNumeric(tagId))
+                                if (Utilities.IsNumeric(tagId))
                                 {
                                     new DotNetNuke.Modules.ActiveForums.Controllers.TagController().DeleteById(tagId);
                                 }

--- a/Dnn.CommunityForums/controls/af_grid.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_grid.ascx.cs
@@ -220,7 +220,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     case GridTypes.Tags:
 
                         var tagId = -1;
-                        if (this.Request.QueryString[ParamKeys.Tags] != null && SimulateIsNumeric.IsNumeric(this.Request.QueryString[ParamKeys.Tags]))
+                        if (this.Request.QueryString[ParamKeys.Tags] != null && Utilities.IsNumeric(this.Request.QueryString[ParamKeys.Tags]))
                         {
                             tagId = int.Parse(this.Request.QueryString[ParamKeys.Tags]);
                         }

--- a/Dnn.CommunityForums/controls/af_likes.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_likes.ascx.cs
@@ -105,7 +105,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
             try
             {
-                if (this.Request.QueryString[Literals.GroupId] != null && SimulateIsNumeric.IsNumeric(this.Request.QueryString[Literals.GroupId]))
+                if (this.Request.QueryString[Literals.GroupId] != null && Utilities.IsNumeric(this.Request.QueryString[Literals.GroupId]))
                 {
                     this.SocialGroupId = Convert.ToInt32(this.Request.QueryString[Literals.GroupId]);
                 }

--- a/Dnn.CommunityForums/controls/af_post.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_post.ascx.cs
@@ -588,21 +588,21 @@ namespace DotNetNuke.Modules.ActiveForums
                     if (this.Request.Params[ParamKeys.QuoteId] != null)
                     {
                         isQuote = true;
-                        if (SimulateIsNumeric.IsNumeric(this.Request.Params[ParamKeys.QuoteId]))
+                        if (Utilities.IsNumeric(this.Request.Params[ParamKeys.QuoteId]))
                         {
                             postId = Convert.ToInt32(this.Request.Params[ParamKeys.QuoteId]);
                         }
                     }
                     else if (this.Request.Params[ParamKeys.ReplyId] != null)
                     {
-                        if (SimulateIsNumeric.IsNumeric(this.Request.Params[ParamKeys.ReplyId]))
+                        if (Utilities.IsNumeric(this.Request.Params[ParamKeys.ReplyId]))
                         {
                             postId = Convert.ToInt32(this.Request.Params[ParamKeys.ReplyId]);
                         }
                     }
                     else if (this.Request.Params[ParamKeys.PostId] != null)
                     {
-                        if (SimulateIsNumeric.IsNumeric(this.Request.Params[ParamKeys.PostId]))
+                        if (Utilities.IsNumeric(this.Request.Params[ParamKeys.PostId]))
                         {
                             postId = Convert.ToInt32(this.Request.Params[ParamKeys.PostId]);
                         }
@@ -843,7 +843,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     DataProvider.Instance().Tags_DeleteTopicToCategory(this.PortalId, this.ForumModuleId, -1, this.TopicId);
                     foreach (var c in cats)
                     {
-                        if (string.IsNullOrEmpty(c) || !SimulateIsNumeric.IsNumeric(c))
+                        if (string.IsNullOrEmpty(c) || !Utilities.IsNumeric(c))
                         {
                             continue;
                         }

--- a/Dnn.CommunityForums/controls/af_profile.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_profile.ascx.cs
@@ -35,7 +35,7 @@ namespace DotNetNuke.Modules.ActiveForums
             int tUid = -1;
             if (this.Request.Params[ParamKeys.UserId] != null)
             {
-                if (SimulateIsNumeric.IsNumeric(this.Request.Params[ParamKeys.UserId]))
+                if (Utilities.IsNumeric(this.Request.Params[ParamKeys.UserId]))
                 {
                     tUid = Convert.ToInt32(this.Request.Params[ParamKeys.UserId]);
                     DotNetNuke.Entities.Users.UserInfo ui = DotNetNuke.Entities.Users.UserController.Instance.GetUser(this.PortalId, tUid);

--- a/Dnn.CommunityForums/controls/af_search.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_search.ascx.cs
@@ -105,7 +105,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
             try
             {
-                if (this.Request.QueryString[Literals.GroupId] != null && SimulateIsNumeric.IsNumeric(this.Request.QueryString[Literals.GroupId]))
+                if (this.Request.QueryString[Literals.GroupId] != null && Utilities.IsNumeric(this.Request.QueryString[Literals.GroupId]))
                 {
                     this.SocialGroupId = Convert.ToInt32(this.Request.QueryString[Literals.GroupId]);
                 }

--- a/Dnn.CommunityForums/controls/af_searchadvanced.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_searchadvanced.ascx.cs
@@ -198,7 +198,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
             try
             {
-                if (this.Request.QueryString[Literals.GroupId] != null && SimulateIsNumeric.IsNumeric(this.Request.QueryString[Literals.GroupId]))
+                if (this.Request.QueryString[Literals.GroupId] != null && Utilities.IsNumeric(this.Request.QueryString[Literals.GroupId]))
                 {
                     this.SocialGroupId = Convert.ToInt32(this.Request.QueryString[Literals.GroupId]);
                 }

--- a/Dnn.CommunityForums/controls/af_searchquick.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_searchquick.ascx.cs
@@ -49,7 +49,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     this.ForumTabId = this.TID;
                 }
 
-                if (this.Request.QueryString["GroupId"] != null && SimulateIsNumeric.IsNumeric(this.Request.QueryString["GroupId"]))
+                if (this.Request.QueryString["GroupId"] != null && Utilities.IsNumeric(this.Request.QueryString["GroupId"]))
                 {
                     this.SocialGroupId = Convert.ToInt32(this.Request.QueryString["GroupId"]);
                 }

--- a/Dnn.CommunityForums/feeds.aspx.cs
+++ b/Dnn.CommunityForums/feeds.aspx.cs
@@ -60,7 +60,7 @@ namespace DotNetNuke.Modules.ActiveForums
             int intPortalId = -1;
             if (this.Request.QueryString["portalid"] != null)
             {
-                if (SimulateIsNumeric.IsNumeric(this.Request.QueryString["portalid"]))
+                if (Utilities.IsNumeric(this.Request.QueryString["portalid"]))
                 {
                     intPortalId = Convert.ToInt32(this.Request.QueryString["portalid"]);
                 }
@@ -71,7 +71,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
             if (this.Request.QueryString["tabid"] != null)
             {
-                if (SimulateIsNumeric.IsNumeric(this.Request.QueryString["tabid"]))
+                if (Utilities.IsNumeric(this.Request.QueryString["tabid"]))
                 {
                     intTabId = Convert.ToInt32(this.Request.QueryString["tabid"]);
                 }
@@ -79,7 +79,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
             if (this.Request.QueryString["moduleid"] != null)
             {
-                if (SimulateIsNumeric.IsNumeric(this.Request.QueryString["moduleid"]))
+                if (Utilities.IsNumeric(this.Request.QueryString["moduleid"]))
                 {
                     this.moduleID = Convert.ToInt32(this.Request.QueryString["moduleid"]);
                 }
@@ -91,7 +91,7 @@ namespace DotNetNuke.Modules.ActiveForums
             int forumID = -1;
             if (this.Request.QueryString["ForumID"] != null)
             {
-                if (SimulateIsNumeric.IsNumeric(this.Request.QueryString["ForumId"]))
+                if (Utilities.IsNumeric(this.Request.QueryString["ForumId"]))
                 {
                     forumID = Int32.Parse(this.Request.QueryString["ForumID"]);
                 }

--- a/Dnn.CommunityForums/handlers/adminhelper.ashx.cs
+++ b/Dnn.CommunityForums/handlers/adminhelper.ashx.cs
@@ -58,7 +58,7 @@ namespace DotNetNuke.Modules.ActiveForums.Handlers
             {
                 if (this.Params != null)
                 {
-                    if (this.Params["action"] != null && SimulateIsNumeric.IsNumeric(this.Params["action"]))
+                    if (this.Params["action"] != null && Utilities.IsNumeric(this.Params["action"]))
                     {
                         action = (Actions)Convert.ToInt32(this.Params["action"].ToString());
                     }

--- a/Dnn.CommunityForumsTests/SimulateIsNumericTests.cs
+++ b/Dnn.CommunityForumsTests/SimulateIsNumericTests.cs
@@ -18,37 +18,36 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-namespace DotNetNuke.Modules.ActiveForums
+namespace DotNetNuke.Modules.ActiveForumsTests
 {
     using System;
 
-    public class ProfileBase : SettingsBase
+    using NUnit.Framework;
+
+    [TestFixture]
+    [Obsolete("Deprecated in Community Forums. Removing in 10.00.00. Not Used.")]
+    public class SimulateIsNumericTests
     {
-        private int uID = -1;
-
-		public DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo ForumUserInfo { get; set; }
-
-        [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. No longer Used.")]
-        public UserProfileInfo UserProfile { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-
-        public int UID
+        [Test]
+        [TestCase(0, ExpectedResult = true)]
+        [TestCase("abc", ExpectedResult = false)]
+        [TestCase(false, ExpectedResult = true)]
+        [TestCase(true, ExpectedResult = true)]
+        [TestCase(null, ExpectedResult = false)]
+        [TestCase(-10, ExpectedResult = true)]
+        [TestCase(01E1, ExpectedResult = true)]
+        [TestCase("0", ExpectedResult = true)]
+        public bool IsNumericTest(object obj)
         {
-            get
-            {
-                if (this.Request.Params[ParamKeys.UserId] != null)
-                {
-                    if (Utilities.IsNumeric(this.Request.Params[ParamKeys.UserId]))
-                    {
-                        this.uID = Convert.ToInt32(this.Request.Params[ParamKeys.UserId]);
-                    }
-                }
-                else
-                {
-                    this.uID = this.UserId;
-                }
+            // Arrange
 
-                return this.uID;
-            }
+            var expectedResult = true;
+
+            // Act
+            var actualResult = SimulateIsNumeric.IsNumeric(obj);
+
+            // Assert
+            return actualResult;
         }
     }
 }

--- a/Dnn.CommunityForumsTests/class/UtilitiesTests.cs
+++ b/Dnn.CommunityForumsTests/class/UtilitiesTests.cs
@@ -219,5 +219,27 @@ namespace DotNetNuke.Modules.ActiveForumsTests
             // Assert
             Assert.That(actualResult, Is.EqualTo(expectedResult));
         }
+
+        [Test]
+        [TestCase(0, ExpectedResult = true)]
+        [TestCase("abc", ExpectedResult = false)]
+        [TestCase(false, ExpectedResult = true)]
+        [TestCase(true, ExpectedResult = true)]
+        [TestCase(null, ExpectedResult = false)]
+        [TestCase(-10, ExpectedResult = true)]
+        [TestCase(01E1, ExpectedResult = true)]
+        [TestCase("0", ExpectedResult = true)]
+        public bool IsNumericTest(object obj)
+        {
+            // Arrange
+
+            var expectedResult = true;
+
+            // Act
+            var actualResult = DotNetNuke.Modules.ActiveForums.Utilities.IsNumeric(obj);
+
+            // Assert
+            return actualResult;
+        }
     }
 }


### PR DESCRIPTION

<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Replace 3rd-party SimulateIsNumeric with Utilities.IsNumeric.

## Changes made
- Refactor code to replace the deprecated `SimulateIsNumeric` class with the new `Utilities.IsNumeric` method 
- Mark `SimulateIsNumeric` class as obsolete and will be removed in version 10.00.00
- Added unit tests for the new method 


## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install and unit tests

## PR Template Checklist

- [ ] Fixes Bug
- [ ] Feature solution
- [X] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1309