### PR TITLE
FIX: Allow Enter key in search box without interfering with other controls on page

### DIFF
--- a/Dnn.CommunityForums/config/templates/ToolbarSearchPopup.ascx
+++ b/Dnn.CommunityForums/config/templates/ToolbarSearchPopup.ascx
@@ -1,7 +1,7 @@
 <script type="text/javascript">
     //prevent submit from Enter key
     $(document).ready(function () {
-        $(window).keydown(function (event) {
+        $('.dcf-search-input').keydown(function (event) {
             if (event.keyCode === 13) {
                 event.preventDefault();
                 return false;
@@ -25,7 +25,7 @@
     <div class="dcf-search-popup aftb-search-popup">
         <div class="dcf-search-input">
             <input class="dcf-search-input" type="text" placeholder="[RESX:SearchFor]" maxlength="50" onkeydown="CheckEnterPressed(this, event)">
-            <button id="btnSearch" class="dcf-search-button">[RESX:Search]</button>
+            <button id="btnSearch" type="submit" class="dcf-search-button">[RESX:Search]</button>
         </div>
         <div class="dcf-search-options">
             <a class="dcf-search-option-advanced" href="[AF:TB:AdvancedSearchURL]">[RESX:SearchAdvanced]</a>


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Scope suppression of enter key to just the search box not entire page

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1360