### PR TITLE
FIX: TabId property stackoverflow in ForumInfo/ForumGroupInfo

### DIFF
--- a/Dnn.CommunityForums/Controllers/PermissionController.cs
+++ b/Dnn.CommunityForums/Controllers/PermissionController.cs
@@ -66,10 +66,10 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
         internal void UpdateSecurityForSocialGroupForum(DotNetNuke.Modules.ActiveForums.Entities.ForumInfo forum)
         {
             var permissions = this.GetById(forum.PermissionsId, forum.ModuleId);
-            Hashtable htSettings = DotNetNuke.Entities.Modules.ModuleController.Instance.GetModule(moduleId: forum.ModuleId, tabId: forum.TabId, ignoreCache: false).TabModuleSettings;
+            Hashtable htSettings = DotNetNuke.Entities.Modules.ModuleController.Instance.GetModule(moduleId: forum.ModuleId, tabId: forum.GetTabId(), ignoreCache: false).TabModuleSettings;
             if (htSettings == null || htSettings.Count == 0)
             {
-                htSettings = DotNetNuke.Entities.Modules.ModuleController.Instance.GetModule(moduleId: forum.ModuleId, tabId: forum.TabId, ignoreCache: false).ModuleSettings;
+                htSettings = DotNetNuke.Entities.Modules.ModuleController.Instance.GetModule(moduleId: forum.ModuleId, tabId: forum.GetTabId(), ignoreCache: false).ModuleSettings;
             }
 
             if (htSettings == null || htSettings.Count == 0 || !htSettings.ContainsKey("ForumConfig"))

--- a/Dnn.CommunityForums/Controllers/ReplyController.cs
+++ b/Dnn.CommunityForums/Controllers/ReplyController.cs
@@ -192,11 +192,11 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             // if existing topic, update associated journal item
             if (ri.ReplyId > 0)
             {
-                string fullURL = new ControlUtils().BuildUrl(portalId, ri.Forum.TabId, moduleId, ri.Forum.ForumGroup.PrefixURL, ri.Forum.PrefixURL, ri.Forum.ForumGroupId, ri.ForumId, ri.TopicId, ri.Topic.TopicUrl, -1, -1, string.Empty, 1, ri.ReplyId, ri.Forum.SocialGroupId);
+                string fullURL = new ControlUtils().BuildUrl(portalId, ri.Forum.GetTabId(), moduleId, ri.Forum.ForumGroup.PrefixURL, ri.Forum.PrefixURL, ri.Forum.ForumGroupId, ri.ForumId, ri.TopicId, ri.Topic.TopicUrl, -1, -1, string.Empty, 1, ri.ReplyId, ri.Forum.SocialGroupId);
 
                 if (fullURL.Contains("~/"))
                 {
-                    fullURL = Utilities.NavigateURL(ri.Forum.TabId, string.Empty, new string[] { $"{ParamKeys.TopicId}={ri.TopicId}", $"{ParamKeys.ContentJumpId}={ri.ReplyId}", });
+                    fullURL = Utilities.NavigateURL(ri.Forum.GetTabId(), string.Empty, new string[] { $"{ParamKeys.TopicId}={ri.TopicId}", $"{ParamKeys.ContentJumpId}={ri.ReplyId}", });
                 }
 
                 if (fullURL.EndsWith("/"))
@@ -204,7 +204,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                     fullURL += Utilities.UseFriendlyURLs(moduleId) ? $"#{ri.ReplyId}" : $"{ParamKeys.ContentJumpId}={ri.ReplyId}";
                 }
 
-                new Social().UpdateJournalItemForPost(ri.PortalId, ri.ModuleId, ri.Forum.TabId, ri.ForumId, ri.TopicId, ri.ReplyId, ri.Author.AuthorId, fullURL, ri.Content.Subject, string.Empty, ri.Content.Body);
+                new Social().UpdateJournalItemForPost(ri.PortalId, ri.ModuleId, ri.Forum.GetTabId(), ri.ForumId, ri.TopicId, ri.ReplyId, ri.Author.AuthorId, fullURL, ri.Content.Subject, string.Empty, ri.Content.Body);
             }
 
             int replyId = Convert.ToInt32(DotNetNuke.Modules.ActiveForums.DataProvider.Instance().Reply_Save(portalId, ri.TopicId, ri.ReplyId, ri.ReplyToId, ri.StatusId, ri.IsApproved, ri.IsDeleted, ri.Content.Subject.Trim(), ri.Content.Body.Trim(), ri.Content.DateCreated, ri.Content.DateUpdated, ri.Content.AuthorId, ri.Content.AuthorName, ri.Content.IPAddress));

--- a/Dnn.CommunityForums/Controllers/TopicController.cs
+++ b/Dnn.CommunityForums/Controllers/TopicController.cs
@@ -200,10 +200,10 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
 
             if (ti.Forum.FeatureSettings.ModApproveTemplateId > 0 & ti.Author.AuthorId > 0)
             {
-                DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(ti.Forum.FeatureSettings.ModApproveTemplateId, ti.PortalId, ti.ModuleId, ti.Forum.TabId, ti.ForumId, topicId, 0, ti.Author);
+                DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(ti.Forum.FeatureSettings.ModApproveTemplateId, ti.PortalId, ti.ModuleId, ti.Forum.GetTabId(), ti.ForumId, topicId, 0, ti.Author);
             }
 
-            DotNetNuke.Modules.ActiveForums.Controllers.TopicController.QueueApprovedTopicAfterAction(portalId: ti.PortalId, tabId: ti.Forum.TabId, moduleId: ti.Forum.ModuleId, forumGroupId: ti.Forum.ForumGroupId, forumId: ti.ForumId, topicId: topicId,  replyId: -1,  contentId: ti.ContentId, userId: userId, authorId: ti.Content.AuthorId);
+            DotNetNuke.Modules.ActiveForums.Controllers.TopicController.QueueApprovedTopicAfterAction(portalId: ti.PortalId, tabId: ti.Forum.GetTabId(), moduleId: ti.Forum.ModuleId, forumGroupId: ti.Forum.ForumGroupId, forumId: ti.ForumId, topicId: topicId,  replyId: -1,  contentId: ti.ContentId, userId: userId, authorId: ti.Content.AuthorId);
             return ti;
         }
 
@@ -240,7 +240,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
 
             if (oldForum.FeatureSettings.ModMoveTemplateId > 0 & ti?.Author?.AuthorId > 0)
             {
-                DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(oldForum.FeatureSettings.ModMoveTemplateId, ti.PortalId, ti.ModuleId, ti.Forum.TabId, forumId: ti.Forum.ForumID, topicId: ti.TopicId, replyId: -1, author: ti.Author);
+                DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(oldForum.FeatureSettings.ModMoveTemplateId, ti.PortalId, ti.ModuleId, ti.Forum.GetTabId(), forumId: ti.Forum.ForumID, topicId: ti.TopicId, replyId: -1, author: ti.Author);
             }
 
             new DotNetNuke.Modules.ActiveForums.Controllers.ProcessQueueController().Add(ProcessType.UpdateForumLastUpdated, ti.PortalId, tabId: -1, moduleId: ti.ModuleId, forumGroupId: oldForum.ForumGroupId, forumId: oldForum.ForumID, topicId: topicId, replyId: -1, contentId: ti.ContentId, authorId: ti.Content.AuthorId, userId: userId, requestUrl: null);
@@ -283,8 +283,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             // if existing topic, update associated journal item
             if (ti.TopicId > 0)
             {
-                string sUrl = new ControlUtils().BuildUrl(ti.PortalId, ti.Forum.TabId, ti.ModuleId, ti.Forum.ForumGroup.PrefixURL, ti.Forum.PrefixURL, ti.Forum.ForumGroupId, ti.ForumId, ti.TopicId, ti.TopicUrl, -1, -1, string.Empty, 1, -1, ti.Forum.SocialGroupId);
-                new Social().UpdateJournalItemForPost(ti.PortalId, ti.ModuleId, ti.Forum.TabId, ti.ForumId, ti.TopicId, 0, ti.Author.AuthorId, sUrl, ti.Content.Subject, string.Empty, ti.Content.Body);
+                string sUrl = new ControlUtils().BuildUrl(ti.PortalId, ti.Forum.GetTabId(), ti.ModuleId, ti.Forum.ForumGroup.PrefixURL, ti.Forum.PrefixURL, ti.Forum.ForumGroupId, ti.ForumId, ti.TopicId, ti.TopicUrl, -1, -1, string.Empty, 1, -1, ti.Forum.SocialGroupId);
+                new Social().UpdateJournalItemForPost(ti.PortalId, ti.ModuleId, ti.Forum.GetTabId(), ti.ForumId, ti.TopicId, 0, ti.Author.AuthorId, sUrl, ti.Content.Subject, string.Empty, ti.Content.Body);
             }
 
             // TODO: convert to use DAL2?

--- a/Dnn.CommunityForums/Controllers/UrlController.cs
+++ b/Dnn.CommunityForums/Controllers/UrlController.cs
@@ -95,13 +95,13 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
         internal static string BuildForumUrl(INavigationManager navigationManager, DotNetNuke.Abstractions.Portals.IPortalSettings portalSettings, SettingsInfo mainSettings, DotNetNuke.Modules.ActiveForums.Entities.ForumInfo forumInfo)
         {
             // Build the forum Url
-            return mainSettings.UseShortUrls ? navigationManager.NavigateURL(forumInfo.TabId, portalSettings, string.Empty, new[] { $"{ParamKeys.ForumId}={forumInfo.ForumID}" })
-                : navigationManager.NavigateURL(forumInfo.TabId, portalSettings, string.Empty, new[] { $"{ParamKeys.ForumId}={forumInfo.ForumID}", $"{ParamKeys.ViewType}={Views.Topics}" });
+            return mainSettings.UseShortUrls ? navigationManager.NavigateURL(forumInfo.GetTabId(), portalSettings, string.Empty, new[] { $"{ParamKeys.ForumId}={forumInfo.ForumID}" })
+                : navigationManager.NavigateURL(forumInfo.GetTabId(), portalSettings, string.Empty, new[] { $"{ParamKeys.ForumId}={forumInfo.ForumID}", $"{ParamKeys.ViewType}={Views.Topics}" });
         }
 
         internal static string BuildModeratorUrl(INavigationManager navigationManager, DotNetNuke.Abstractions.Portals.IPortalSettings portalSettings, SettingsInfo mainSettings, DotNetNuke.Modules.ActiveForums.Entities.ForumInfo forumInfo)
         {
-            return navigationManager.NavigateURL(forumInfo.TabId, portalSettings, string.Empty, new[] { $"{ParamKeys.ViewType}={Views.ModerateTopics}", $"{ParamKeys.ForumId}={forumInfo.ForumID}" });
+            return navigationManager.NavigateURL(forumInfo.GetTabId(), portalSettings, string.Empty, new[] { $"{ParamKeys.ViewType}={Views.ModerateTopics}", $"{ParamKeys.ForumId}={forumInfo.ForumID}" });
         }
     }
 }

--- a/Dnn.CommunityForums/CustomControls/UserControls/ForumView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/ForumView.cs
@@ -356,11 +356,11 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
         {
             if (template.Contains("[SUBFORUMS]") && template.Contains("[/SUBFORUMS]"))
             {
-                template = this.GetSubForums(template, fi.ForumID, fi.TabId);
+                template = this.GetSubForums(template, fi.ForumID, fi.GetTabId());
             }
             else
             {
-                template = template.Replace("[SUBFORUMS]", this.GetSubForums(template: string.Empty, forumId: fi.ForumID, tabId: fi.TabId));
+                template = template.Replace("[SUBFORUMS]", this.GetSubForums(template: string.Empty, forumId: fi.ForumID, tabId: fi.GetTabId()));
             }
 
             string[] css = null;

--- a/Dnn.CommunityForums/Entities/ForumGroupInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumGroupInfo.cs
@@ -42,6 +42,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         private DotNetNuke.Modules.ActiveForums.SettingsInfo mainSettings;
         private PortalSettings portalSettings;
         private ModuleInfo moduleInfo;
+        private int? tabId;
 
         public int ForumGroupId { get; set; }
 
@@ -66,9 +67,12 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
 
         [IgnoreColumn]
         public string RawUrl { get; set; }
-
+        
         [IgnoreColumn]
-        public int TabId => this.GetTabId();
+        public int TabId
+        {
+            set => this.tabId = value;
+        }
 
         [IgnoreColumn]
         public string ThemeLocation => Utilities.ResolveUrl(SettingsBase.GetModuleSettings(this.ModuleId).ThemeLocation);
@@ -223,10 +227,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         [IgnoreColumn]
         public DotNetNuke.Services.Tokens.CacheLevel Cacheability
         {
-            get
-            {
-                return DotNetNuke.Services.Tokens.CacheLevel.notCacheable;
-            }
+            get => DotNetNuke.Services.Tokens.CacheLevel.notCacheable;
         }
 
         /// <inheritdoc/>
@@ -281,9 +282,23 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             return string.Empty;
         }
 
-        private int GetTabId()
+        internal int GetTabId()
         {
-            return this.PortalSettings.ActiveTab.TabID == -1 || this.PortalSettings.ActiveTab.TabID == this.PortalSettings.HomeTabId ? this.TabId : this.PortalSettings.ActiveTab.TabID;
+            if (this.PortalSettings.ActiveTab.TabID == -1 || this.PortalSettings.ActiveTab.TabID == this.PortalSettings.HomeTabId)
+            {
+                if (!this.tabId.Equals(null))
+                {
+                    return (int)this.tabId;
+                }
+                else
+                {
+                    return this.ModuleInfo.TabID;
+                }
+            }
+            else
+            {
+                return this.PortalSettings.ActiveTab.TabID;
+            }
         }
 
         internal string GetCacheKey() => string.Format(this.cacheKeyTemplate, this.ModuleId, this.ForumGroupId);

--- a/Dnn.CommunityForums/Entities/ForumInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumInfo.cs
@@ -50,6 +50,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         private ModuleInfo moduleInfo;
         private int? subscriberCount;
         private int? lastPostTopicId;
+        private int? tabId;
         private string lastPostTopicUrl;
         private string rssLink;
         private List<PropertyInfo> properties;
@@ -67,7 +68,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             this.PortalSettings = Utilities.GetPortalSettings(portalId);
             this.UpdateCache();
         }
-        
+
         public ForumInfo(DotNetNuke.Entities.Portals.PortalSettings portalSettings)
         {
             this.PortalSettings = portalSettings;
@@ -389,7 +390,10 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         public string ParentForumUrlPrefix => this.ParentForumId > 0 ? new Controllers.ForumController().GetById(this.ParentForumId, this.ModuleId).PrefixURL : string.Empty;
 
         [IgnoreColumn]
-        public int TabId => this.GetTabId();
+        public int TabId
+        {
+            set => this.tabId = value;
+        }
 
         [IgnoreColumn]
         public string ForumURL => URL.ForumLink(this.GetTabId(), this);
@@ -984,9 +988,23 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
             return string.Empty;
         }
 
-        private int GetTabId()
+        internal int GetTabId()
         {
-            return this.PortalSettings.ActiveTab.TabID == -1 || this.PortalSettings.ActiveTab.TabID == this.PortalSettings.HomeTabId ? this.TabId : this.PortalSettings.ActiveTab.TabID;
+            if (this.PortalSettings.ActiveTab.TabID == -1 || this.PortalSettings.ActiveTab.TabID == this.PortalSettings.HomeTabId)
+            {
+                if (!this.tabId.Equals(null))
+                {
+                    return (int)this.tabId;
+                }
+                else
+                {
+                    return this.ModuleInfo.TabID;
+                }
+            }
+            else
+            {
+                return this.PortalSettings.ActiveTab.TabID;
+            }
         }
 
         internal string GetCacheKey() => string.Format(this.cacheKeyTemplate, this.ModuleId, this.ForumID);

--- a/Dnn.CommunityForums/Entities/ReplyInfo.cs
+++ b/Dnn.CommunityForums/Entities/ReplyInfo.cs
@@ -673,7 +673,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         [IgnoreColumn]
         private int GetTabId()
         {
-            return this.Forum.PortalSettings.ActiveTab.TabID == -1 || this.Forum.PortalSettings.ActiveTab.TabID == this.Forum.PortalSettings.HomeTabId ? this.Forum.TabId : this.Forum.PortalSettings.ActiveTab.TabID;
+            return this.Forum.PortalSettings.ActiveTab.TabID == -1 || this.Forum.PortalSettings.ActiveTab.TabID == this.Forum.PortalSettings.HomeTabId ? this.Forum.GetTabId() : this.Forum.PortalSettings.ActiveTab.TabID;
         }
 
         [IgnoreColumn]

--- a/Dnn.CommunityForums/Entities/TopicInfo.cs
+++ b/Dnn.CommunityForums/Entities/TopicInfo.cs
@@ -1483,7 +1483,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         [IgnoreColumn]
         private int GetTabId()
         {
-            return this.Forum.PortalSettings.ActiveTab.TabID == -1 || this.Forum.PortalSettings.ActiveTab.TabID == this.Forum.PortalSettings.HomeTabId ? this.Forum.TabId : this.Forum.PortalSettings.ActiveTab.TabID;
+            return this.Forum.PortalSettings.ActiveTab.TabID == -1 || this.Forum.PortalSettings.ActiveTab.TabID == this.Forum.PortalSettings.HomeTabId ? this.Forum.GetTabId() : this.Forum.PortalSettings.ActiveTab.TabID;
         }
 
         [IgnoreColumn]

--- a/Dnn.CommunityForums/Services/Controllers/TopicController.cs
+++ b/Dnn.CommunityForums/Services/Controllers/TopicController.cs
@@ -171,7 +171,7 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Controllers
                             {
                                 new DotNetNuke.Modules.ActiveForums.Controllers.ProcessQueueController().Add(ProcessType.TopicPinned,
                                     portalId: ti.PortalId,
-                                    tabId: ti.Forum.TabId,
+                                    tabId: ti.Forum.GetTabId(),
                                     moduleId: ti.ModuleId,
                                     forumGroupId: ti.Forum.ForumGroupId,
                                     forumId: ti.ForumId,

--- a/Dnn.CommunityForums/Services/ModerationService.cs
+++ b/Dnn.CommunityForums/Services/ModerationService.cs
@@ -185,7 +185,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 rc.Reply_Delete(this.PortalSettings.PortalId, this.forumId, this.topicId, this.replyId, ms.DeleteBehavior);
                 if (fi.FeatureSettings.ModDeleteTemplateId > 0 && reply?.Content?.AuthorId > 0)
                 {
-                    DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(fi.FeatureSettings.ModDeleteTemplateId, fi.PortalId, fi.ModuleId, fi.TabId, fi.ForumID, this.topicId, this.replyId, reply.Author);
+                    DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(fi.FeatureSettings.ModDeleteTemplateId, fi.PortalId, fi.ModuleId, fi.GetTabId(), fi.ForumID, this.topicId, this.replyId, reply.Author);
                 }
             }
             else
@@ -198,7 +198,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 new DotNetNuke.Modules.ActiveForums.Controllers.TopicController(this.moduleId).DeleteById(this.topicId);
                 if (fi.FeatureSettings.ModDeleteTemplateId > 0 && ti?.Content?.AuthorId > 0)
                 {
-                    DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(fi.FeatureSettings.ModDeleteTemplateId, fi.PortalId, fi.ModuleId, fi.TabId, fi.ForumID, this.topicId, this.replyId, ti.Author);
+                    DotNetNuke.Modules.ActiveForums.Controllers.EmailController.SendEmail(fi.FeatureSettings.ModDeleteTemplateId, fi.PortalId, fi.ModuleId, fi.GetTabId(), fi.ForumID, this.topicId, this.replyId, ti.Author);
                 }
             }
 

--- a/Dnn.CommunityForums/Services/Tokens/TokenReplacer.cs
+++ b/Dnn.CommunityForums/Services/Tokens/TokenReplacer.cs
@@ -79,7 +79,7 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
             forumInfo.ForumGroup.RequestUri = requestUri;
             forumUser.RequestUri = requestUri;
             this.PropertySource[PropertySource_resx] = new ResourceStringTokenReplacer();
-            this.PropertySource[PropertySource_dcf] = new ForumsModuleTokenReplacer(portalSettings, forumInfo.TabId, forumInfo.ModuleId, GetTabId(portalSettings, forumInfo), GetModuleId(portalSettings, forumInfo), requestUri, rawUrl);
+            this.PropertySource[PropertySource_dcf] = new ForumsModuleTokenReplacer(portalSettings, forumInfo.GetTabId(), forumInfo.ModuleId, GetTabId(portalSettings, forumInfo), GetModuleId(portalSettings, forumInfo), requestUri, rawUrl);
             this.PropertySource[PropertySource_forum] = forumInfo;
             this.PropertySource[PropertySource_forumgroup] = forumInfo.ForumGroup;
             this.PropertySource[PropertySource_forumuser] = forumUser;
@@ -109,7 +109,7 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
             forumGroupInfo.RequestUri = requestUri;
             forumUser.RequestUri = requestUri;
             this.PropertySource[PropertySource_resx] = new ResourceStringTokenReplacer();
-            this.PropertySource[PropertySource_dcf] = new ForumsModuleTokenReplacer(portalSettings, forumGroupInfo.TabId, forumGroupInfo.ModuleId, GetTabId(portalSettings, forumGroupInfo), GetModuleId(portalSettings, forumGroupInfo), requestUri, rawUrl);
+            this.PropertySource[PropertySource_dcf] = new ForumsModuleTokenReplacer(portalSettings, forumGroupInfo.GetTabId(), forumGroupInfo.ModuleId, GetTabId(portalSettings, forumGroupInfo), GetModuleId(portalSettings, forumGroupInfo), requestUri, rawUrl);
             this.PropertySource[PropertySource_forumgroup] = forumGroupInfo;
             this.PropertySource[PropertySource_forumuser] = forumUser;
             this.PropertySource[PropertySource_user] = forumUser.UserInfo;
@@ -136,7 +136,7 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
 
         private static int GetTabId(PortalSettings portalSettings, ForumInfo forumInfo)
         {
-            return portalSettings?.ActiveTab == null || portalSettings?.ActiveTab?.TabID == -1 || portalSettings?.ActiveTab?.TabID == portalSettings?.HomeTabId ? forumInfo.TabId : portalSettings.ActiveTab.TabID;
+            return portalSettings?.ActiveTab == null || portalSettings?.ActiveTab?.TabID == -1 || portalSettings?.ActiveTab?.TabID == portalSettings?.HomeTabId ? forumInfo.GetTabId() : portalSettings.ActiveTab.TabID;
         }
 
         private static int GetModuleId(PortalSettings portalSettings, ForumGroupInfo forumGroupInfo)
@@ -146,7 +146,7 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
 
         private static int GetTabId(PortalSettings portalSettings, ForumGroupInfo forumGroupInfo)
         {
-            return portalSettings?.ActiveTab == null || portalSettings.ActiveTab.TabID == -1 || portalSettings?.ActiveTab?.TabID == portalSettings.HomeTabId ? forumGroupInfo.TabId : portalSettings.ActiveTab.TabID;
+            return portalSettings?.ActiveTab == null || portalSettings.ActiveTab.TabID == -1 || portalSettings?.ActiveTab?.TabID == portalSettings.HomeTabId ? forumGroupInfo.GetTabId() : portalSettings.ActiveTab.TabID;
         }
 
         public TokenReplacer(PortalSettings portalSettings, ForumUserInfo forumUser, TopicInfo topicInfo, Uri requestUri, string rawUrl)
@@ -160,7 +160,7 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
             topicInfo.RequestUri = requestUri;
             forumUser.RequestUri = requestUri;
             this.PropertySource[PropertySource_resx] = new ResourceStringTokenReplacer();
-            this.PropertySource[PropertySource_dcf] = new ForumsModuleTokenReplacer(portalSettings, topicInfo.Forum.TabId, topicInfo.Forum.ModuleId, GetTabId(portalSettings, topicInfo.Forum),  GetModuleId(portalSettings, topicInfo.Forum), requestUri, rawUrl);
+            this.PropertySource[PropertySource_dcf] = new ForumsModuleTokenReplacer(portalSettings, topicInfo.Forum.GetTabId(), topicInfo.Forum.ModuleId, GetTabId(portalSettings, topicInfo.Forum),  GetModuleId(portalSettings, topicInfo.Forum), requestUri, rawUrl);
             this.PropertySource[PropertySource_forum] = topicInfo.Forum;
             this.PropertySource[PropertySource_forumgroup] = topicInfo.Forum.ForumGroup;
             this.PropertySource[PropertySource_forumtopic] = topicInfo;
@@ -200,7 +200,7 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
             postInfo.RequestUri = requestUri;
             forumUser.RequestUri = requestUri;
             this.PropertySource[PropertySource_resx] = new ResourceStringTokenReplacer();
-            this.PropertySource[PropertySource_dcf] = new ForumsModuleTokenReplacer(portalSettings, postInfo.Forum.TabId, postInfo.Forum.ModuleId, GetTabId(portalSettings, postInfo.Forum),  GetModuleId(portalSettings, postInfo.Forum), requestUri, rawUrl);
+            this.PropertySource[PropertySource_dcf] = new ForumsModuleTokenReplacer(portalSettings, postInfo.Forum.GetTabId(), postInfo.Forum.ModuleId, GetTabId(portalSettings, postInfo.Forum),  GetModuleId(portalSettings, postInfo.Forum), requestUri, rawUrl);
             this.PropertySource[PropertySource_forum] = postInfo.Forum;
             this.PropertySource[PropertySource_forumgroup] = postInfo.Forum.ForumGroup;
             this.PropertySource[PropertySource_forumtopic] = postInfo.Topic;
@@ -241,7 +241,7 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
             likeInfo.RequestUri = requestUri;
             forumUser.RequestUri = requestUri;
             this.PropertySource[PropertySource_resx] = new ResourceStringTokenReplacer();
-            this.PropertySource[PropertySource_dcf] = new ForumsModuleTokenReplacer(portalSettings, likeInfo.Forum.TabId, likeInfo.Forum.ModuleId, portalSettings.ActiveTab.TabID == -1 || portalSettings.ActiveTab.TabID == portalSettings.HomeTabId ? likeInfo.Forum.TabId : portalSettings.ActiveTab.TabID, portalSettings.ActiveTab.ModuleID == -1 ? likeInfo.Forum.ModuleId : portalSettings.ActiveTab.ModuleID, requestUri, rawUrl);
+            this.PropertySource[PropertySource_dcf] = new ForumsModuleTokenReplacer(portalSettings, likeInfo.Forum.GetTabId(), likeInfo.Forum.ModuleId, portalSettings.ActiveTab.TabID == -1 || portalSettings.ActiveTab.TabID == portalSettings.HomeTabId ? likeInfo.Forum.GetTabId() : portalSettings.ActiveTab.TabID, portalSettings.ActiveTab.ModuleID == -1 ? likeInfo.Forum.ModuleId : portalSettings.ActiveTab.ModuleID, requestUri, rawUrl);
             this.PropertySource[PropertySource_like] = likeInfo;
             this.PropertySource[PropertySource_forum] = likeInfo.Forum;
             this.PropertySource[PropertySource_forumgroup] = likeInfo.Forum.ForumGroup;

--- a/Dnn.CommunityForums/class/TemplateUtils.cs
+++ b/Dnn.CommunityForums/class/TemplateUtils.cs
@@ -127,6 +127,8 @@ namespace DotNetNuke.Modules.ActiveForums
 
             // Load Subject and body from topic or reply
             var postInfo = (topicId > 0 && replyId > 0) ? (IPostInfo)new DotNetNuke.Modules.ActiveForums.Controllers.ReplyController(moduleID).GetById(replyId) : new DotNetNuke.Modules.ActiveForums.Controllers.TopicController(moduleID).GetById(topicId);
+            postInfo.Forum.TabId = tabID;
+            postInfo.Forum.ForumGroup.TabId = tabID;
             string subject = postInfo.Content.Subject;
             templateStringbuilder.Replace("[POSTEDORREPLIEDTO]", (replyId <= 0 ? Utilities.GetSharedResource("[RESX:posted]") : Utilities.GetSharedResource("[RESX:repliedto]")));
             templateStringbuilder.Replace("[POSTEDTO]", (replyId <= 0 ? Utilities.GetSharedResource("[RESX:postedto]") : string.Empty));


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Updates were made in #1344 to refactor TabId property for ForumInfo and ForumGroupInfo; however, these changes resulted in a StackOverflowException because a property was referencing a method which in turn referenced the property :(


## Changes made
- Update the TabId property and GetTabId() method in ForumInfo / ForumGroupInfo

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1343