### PR TITLE
FIX: Intermittent exception when replying

### DIFF
--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
@@ -315,9 +315,12 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 TopicData = this.drForum["TopicData"].ToString(),
                 NextTopic = Utilities.SafeConvertInt(this.drForum["NextTopic"]),
                 PrevTopic = Utilities.SafeConvertInt(this.drForum["PrevTopic"]),
+                ContentId = Utilities.SafeConvertInt(this.drForum["ContentId"]),
                 Content = new DotNetNuke.Modules.ActiveForums.Entities.ContentInfo
                 {
                     ModuleId = this.ForumModuleId,
+                    ContentId = Utilities.SafeConvertInt(this.drForum["ContentId"]),
+                    IPAddress = this.drForum["IPAddress"].ToString(),
                     Subject = System.Net.WebUtility.HtmlDecode(this.drForum["Subject"].ToString()),
                     Summary = System.Net.WebUtility.HtmlDecode(this.drForum["Summary"].ToString()),
                     Body = System.Net.WebUtility.HtmlDecode(this.drForum["Body"].ToString()),
@@ -347,7 +350,6 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
             this.topic.Forum = this.ForumInfo;
 
-
             this.topic.LastReply.Author = new DotNetNuke.Modules.ActiveForums.Entities.AuthorInfo(this.PortalId, this.ForumModuleId, this.topic.LastReply.Content.AuthorId);
             this.topic.LastReply.Author.ForumUser.UserInfo.DisplayName = this.drForum["LastPostDisplayName"].ToString();
             this.topic.LastReply.Author.ForumUser.UserInfo.FirstName = this.drForum["LastPostFirstName"].ToString();
@@ -355,6 +357,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             this.topic.LastReply.Author.ForumUser.UserInfo.Username = this.drForum["LastPostUserName"].ToString();
             this.topic.LastReply.Author.ForumUser.PortalId = this.PortalId;
             this.topic.LastReply.Author.ForumUser.ModuleId = this.ForumModuleId;
+            this.topic.UpdateCache();
 
             this.topicTemplateId = Utilities.SafeConvertInt(this.drForum["TopicTemplateId"]);
             this.tags = this.drForum["Tags"].ToString();
@@ -1031,13 +1034,6 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
             bool isReply = !dr.GetInt("ReplyId").Equals(0);
 
-            // most topic values come in first result set and are set in LoadData(); however some, like IP Address and contentId, comes in this result set.
-            if (!isReply)
-            {
-                this.topic.Content.IPAddress = dr.GetString("IPAddress");
-                this.topic.ContentId = dr.GetInt("ContentId");
-                this.topic.Content.ContentId = dr.GetInt("ContentId");
-            }
 
             // Replace Tags Control
             var tags = dr.GetString("Tags");

--- a/Dnn.CommunityForums/DnnCommunityForums.csproj
+++ b/Dnn.CommunityForums/DnnCommunityForums.csproj
@@ -1254,6 +1254,7 @@
     <None Include="sql\07.00.09.SqlDataProvider" />
     <None Include="sql\07.00.09.SqlDataProvider" />
     <None Include="sql\07.00.10.SqlDataProvider" />
+    <None Include="sql\08.02.08.SqlDataProvider" />
     <None Include="sql\08.02.04.SqlDataProvider" />
     <None Include="sql\08.02.03.SqlDataProvider" />
     <None Include="sql\08.02.02.SqlDataProvider" />

--- a/Dnn.CommunityForums/DnnCommunityForums.dnn
+++ b/Dnn.CommunityForums/DnnCommunityForums.dnn
@@ -414,10 +414,15 @@
                 <name>08.02.04.SqlDataProvider</name>
                 <version>08.02.04</version>
             </script>
+            <script type="Install">
+                <path>sql</path>
+                <name>08.02.08.SqlDataProvider</name>
+                <version>08.02.08</version>
+            </script>
             <script type="UnInstall">
               <path>sql</path>
               <name>Uninstall.SqlDataProvider</name>
-              <version>08.02.07</version>
+              <version>08.02.08</version>
             </script>
           </scripts>
         </component>

--- a/Dnn.CommunityForums/controls/af_post.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_post.ascx.cs
@@ -569,88 +569,93 @@ namespace DotNetNuke.Modules.ActiveForums
                     this.Response.Redirect(this.NavigateUrl(this.TabId), false);
                     this.Context.ApplicationInstance.CompleteRequest();
                 }
-
-                this.ctlForm.Subject = Utilities.GetSharedResource("[RESX:SubjectPrefix]") + " " + System.Net.WebUtility.HtmlDecode(ti.Content.Subject);
-                this.ctlForm.TopicSubject = System.Net.WebUtility.HtmlDecode(ti.Content.Subject);
-                var body = string.Empty;
-
-                if (ti.IsLocked && (this.ForumUser.CurrentUserType == CurrentUserTypes.Anon || this.ForumUser.CurrentUserType == CurrentUserTypes.Auth))
+                else
                 {
-                    this.Response.Redirect(this.NavigateUrl(this.TabId), false);
-                    this.Context.ApplicationInstance.CompleteRequest();
-                }
-
-                if (this.Request.Params[ParamKeys.QuoteId] != null | this.Request.Params[ParamKeys.ReplyId] != null | this.Request.Params[ParamKeys.PostId] != null)
-                {
-                    // Setup form for Quote or Reply with body display
-                    var isQuote = false;
-                    var postId = 0;
-                    if (this.Request.Params[ParamKeys.QuoteId] != null)
+                    this.ctlForm.Subject = Utilities.GetSharedResource("[RESX:SubjectPrefix]") + " " + System.Net.WebUtility.HtmlDecode(ti.Content.Subject);
+                    this.ctlForm.TopicSubject = System.Net.WebUtility.HtmlDecode(ti.Content.Subject);
+                    if (ti.IsLocked && (this.ForumUser.CurrentUserType == CurrentUserTypes.Anon || this.ForumUser.CurrentUserType == CurrentUserTypes.Auth))
                     {
-                        isQuote = true;
-                        if (Utilities.IsNumeric(this.Request.Params[ParamKeys.QuoteId]))
-                        {
-                            postId = Convert.ToInt32(this.Request.Params[ParamKeys.QuoteId]);
-                        }
-                    }
-                    else if (this.Request.Params[ParamKeys.ReplyId] != null)
-                    {
-                        if (Utilities.IsNumeric(this.Request.Params[ParamKeys.ReplyId]))
-                        {
-                            postId = Convert.ToInt32(this.Request.Params[ParamKeys.ReplyId]);
-                        }
-                    }
-                    else if (this.Request.Params[ParamKeys.PostId] != null)
-                    {
-                        if (Utilities.IsNumeric(this.Request.Params[ParamKeys.PostId]))
-                        {
-                            postId = Convert.ToInt32(this.Request.Params[ParamKeys.PostId]);
-                        }
+                        this.Response.Redirect(this.NavigateUrl(this.TabId), false);
+                        this.Context.ApplicationInstance.CompleteRequest();
                     }
 
-                    if (postId != 0)
+                    if (this.Request.Params[ParamKeys.QuoteId] != null | this.Request.Params[ParamKeys.ReplyId] != null | this.Request.Params[ParamKeys.PostId] != null)
                     {
-                        var post = postId == this.TopicId ? ti : (DotNetNuke.Modules.ActiveForums.Entities.IPostInfo)new DotNetNuke.Modules.ActiveForums.Controllers.ReplyController(this.ForumModuleId).GetById(postId);
-                        if (post != null)
+                        // Setup form for Quote or Reply with body display
+                        var isQuote = false;
+                        var postId = 0;
+                        if (this.Request.Params[ParamKeys.QuoteId] != null)
                         {
-                            var sPostedBy = Utilities.GetSharedResource("[RESX:PostedBy]") + " {0} {1} {2}";
-                            sPostedBy = string.Format(sPostedBy, DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetDisplayName(this.PortalSettings, this.MainSettings, false, false, post.Author.AuthorId, post.Author.Username, post.Author.FirstName, post.Author.LastName, post.Author.DisplayName), Utilities.GetSharedResource("On.Text"), Utilities.GetUserFormattedDateTime(post.Content.DateCreated, this.PortalId, this.UserId));
-                            body = post.Content.Body;
-                            if (this.allowHTML && this.editorType != EditorTypes.TEXTBOX)
+                            isQuote = true;
+                            if (Utilities.IsNumeric(this.Request.Params[ParamKeys.QuoteId]))
                             {
-                                if (body.ToUpperInvariant().Contains("<CODE") || body.ToUpperInvariant().Contains("[CODE]"))
-                                {
-                                    body = CodeParser.ParseCode(System.Net.WebUtility.HtmlDecode(body));
-                                }
+                                postId = Convert.ToInt32(this.Request.Params[ParamKeys.QuoteId]);
                             }
-                            else
+                        }
+                        else if (this.Request.Params[ParamKeys.ReplyId] != null)
+                        {
+                            if (Utilities.IsNumeric(this.Request.Params[ParamKeys.ReplyId]))
                             {
-                                body = Utilities.PrepareForEdit(this.PortalId, this.ForumModuleId, this.ImagePath, body, this.allowHTML, this.editorType);
+                                postId = Convert.ToInt32(this.Request.Params[ParamKeys.ReplyId]);
                             }
-
-                            if (isQuote)
+                        }
+                        else if (this.Request.Params[ParamKeys.PostId] != null)
+                        {
+                            if (Utilities.IsNumeric(this.Request.Params[ParamKeys.PostId]))
                             {
-                                this.ctlForm.EditorMode = SubmitForm.EditorModes.Quote;
+                                postId = Convert.ToInt32(this.Request.Params[ParamKeys.PostId]);
+                            }
+                        }
+
+                        if (postId != 0)
+                        {
+                            var post = postId == this.TopicId ? ti : (DotNetNuke.Modules.ActiveForums.Entities.IPostInfo)new DotNetNuke.Modules.ActiveForums.Controllers.ReplyController(this.ForumModuleId).GetById(postId);
+                            if (post != null)
+                            {
+                                var sPostedBy = Utilities.GetSharedResource("[RESX:PostedBy]") + " {0} {1} {2}";
+                                sPostedBy = string.Format(sPostedBy, DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetDisplayName(this.PortalSettings, this.MainSettings, false, false, post.Author.AuthorId, post.Author.Username, post.Author.FirstName, post.Author.LastName, post.Author.DisplayName), Utilities.GetSharedResource("On.Text"), Utilities.GetUserFormattedDateTime(post.Content.DateCreated, this.PortalId, this.UserId));
+                                var body = post.Content.Body;
                                 if (this.allowHTML && this.editorType != EditorTypes.TEXTBOX)
                                 {
-                                    body = "<blockquote>" + System.Environment.NewLine + sPostedBy + System.Environment.NewLine + "<br />" + System.Environment.NewLine + body + System.Environment.NewLine + "</blockquote><br /><br />";
+                                    if (body.ToUpperInvariant().Contains("<CODE") || body.ToUpperInvariant().Contains("[CODE]"))
+                                    {
+                                        body = CodeParser.ParseCode(System.Net.WebUtility.HtmlDecode(body));
+                                    }
                                 }
                                 else
                                 {
-                                    body = "[quote]" + System.Environment.NewLine + sPostedBy + System.Environment.NewLine + body + System.Environment.NewLine + "[/quote]" + System.Environment.NewLine;
+                                    body = Utilities.PrepareForEdit(this.PortalId, this.ForumModuleId, this.ImagePath, body, this.allowHTML, this.editorType);
+                                }
+
+                                if (isQuote)
+                                {
+                                    this.ctlForm.EditorMode = SubmitForm.EditorModes.Quote;
+                                    if (this.allowHTML && this.editorType != EditorTypes.TEXTBOX)
+                                    {
+                                        body = "<blockquote>" + System.Environment.NewLine + sPostedBy + System.Environment.NewLine + "<br />" + System.Environment.NewLine + body + System.Environment.NewLine + "</blockquote><br /><br />";
+                                    }
+                                    else
+                                    {
+                                        body = "[quote]" + System.Environment.NewLine + sPostedBy + System.Environment.NewLine + body + System.Environment.NewLine + "[/quote]" + System.Environment.NewLine;
+                                    }
+                                }
+                                else
+                                {
+                                    this.ctlForm.EditorMode = SubmitForm.EditorModes.ReplyWithBody;
+                                    body = sPostedBy + "<br />" + body;
+                                }
+
+                                this.ctlForm.Body = body;
+
+                                if (this.ctlForm.EditorMode != SubmitForm.EditorModes.EditReply && this.canModApprove)
+                                {
+                                    this.ctlForm.ShowModOptions = false;
                                 }
                             }
                             else
                             {
-                                this.ctlForm.EditorMode = SubmitForm.EditorModes.ReplyWithBody;
-                                body = sPostedBy + "<br />" + body;
-                            }
-
-                            this.ctlForm.Body = body;
-
-                            if (this.ctlForm.EditorMode != SubmitForm.EditorModes.EditReply && this.canModApprove)
-                            {
-                                this.ctlForm.ShowModOptions = false;
+                                var im = new InfoMessage { Message = this.GetSharedResource("[RESX:Message:LoadTopicFailed]") };
+                                this.plhContent.Controls.Add(im);
                             }
                         }
                         else
@@ -658,11 +663,6 @@ namespace DotNetNuke.Modules.ActiveForums
                             var im = new InfoMessage { Message = this.GetSharedResource("[RESX:Message:LoadTopicFailed]") };
                             this.plhContent.Controls.Add(im);
                         }
-                    }
-                    else
-                    {
-                        var im = new InfoMessage { Message = this.GetSharedResource("[RESX:Message:LoadTopicFailed]") };
-                        this.plhContent.Controls.Add(im);
                     }
                 }
             }

--- a/Dnn.CommunityForums/sql/08.02.08.SqlDataProvider
+++ b/Dnn.CommunityForums/sql/08.02.08.SqlDataProvider
@@ -1,0 +1,159 @@
+SET NOCOUNT ON 
+GO
+
+/* issues 1333 - begin - intermittant exceptions when replying  */
+
+/*activeforums_UI_TopicView*/
+IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_UI_TopicView]') AND type in (N'P', N'PC'))
+DROP PROCEDURE {databaseOwner}[{objectQualifier}activeforums_UI_TopicView]
+GO
+CREATE PROCEDURE {databaseOwner}{objectQualifier}activeforums_UI_TopicView
+@PortalId int,
+@ModuleId int,
+@ForumId int,
+@TopicId int,
+@UserId int,
+@RowIndex int, 
+@MaxRows int,
+@IsSuperUser bit = 0,
+@Sort varchar(10) = 'ASC'
+AS
+--Forum/Group/Topic Info
+DECLARE @LastPostId int
+DECLARE @ReplyCount int
+SET @ReplyCount = (Select Count(ReplyId) from {databaseOwner}{objectQualifier}activeforums_Replies WHERE TopicId = @TopicId AND IsDeleted = 0 AND IsApproved = 1)
+DECLARE @Tags nvarchar(1000)
+SET @Tags= RTRIM(IsNull({databaseOwner}{objectQualifier}activeforums_Topics_GetTags(@TopicId),''))
+BEGIN
+SELECT     
+	v.ForumGroupId, 
+	v.ModuleId, 
+	v.GroupName, 
+	v.GroupActive, 
+	v.GroupHidden, 
+	v.ForumId, 
+	v.ParentForumId, 
+	v.ForumName, 
+	v.ForumDesc, 
+	v.ForumActive, 
+	v.ForumHidden, 
+	v.TotalTopics, 
+	ISNULL(v.TotalReplies, 0) AS TotalReplies,
+	v.LastPostId,
+	v.GroupSettingsKey,
+	v.ForumSettingsKey,
+	TopicTemplateId = IsNull((SELECT SettingValue FROM {databaseOwner}{objectQualifier}activeforums_Settings WHERE SettingName = 'TOPICTEMPLATEID' and GroupKey = v.ForumSettingsKey),0),
+	
+						  IsNull((SELECT     SettingValue
+							FROM          {databaseOwner}{objectQualifier}activeforums_Settings AS {objectQualifier}activeforums_Settings_1
+							WHERE      (SettingName = 'ALLOWRSS') AND (GroupKey = v.ForumSettingsKey)),0) AS AllowRSS,
+						  IsNull((SELECT     SettingValue
+							FROM          {databaseOwner}{objectQualifier}activeforums_Settings AS {objectQualifier}activeforums_Settings_3
+							WHERE      (SettingName = 'ALLOWHTML') AND (GroupKey = v.ForumSettingsKey)),0) AS AllowHTML,
+						  IsNull((SELECT     SettingValue
+							FROM          {databaseOwner}{objectQualifier}activeforums_Settings AS activeforums_Settings_3
+							WHERE      (SettingName = 'ALLOWLIKES') AND (GroupKey = v.ForumSettingsKey)),0) AS AllowLikes,
+						  IsNull((SELECT     SettingValue
+							FROM          {databaseOwner}{objectQualifier}activeforums_Settings AS {objectQualifier}activeforums_Settings_2
+							WHERE      (SettingName = 'ALLOWSCRIPT') AND (GroupKey = v.ForumSettingsKey)),0) AS AllowScript,
+							IsNull((SELECT     SettingValue
+							FROM          {databaseOwner}{objectQualifier}activeforums_Settings
+							WHERE      (SettingName = 'ALLOWTAGS') AND (GroupKey = v.ForumSettingsKey)),0) AS AllowTags,
+							 FT.TopicId,
+						  (SELECT     ISNULL(AVG(Rating), 0) AS Expr1
+							FROM          {databaseOwner}{objectQualifier}activeforums_Topics_Ratings
+							WHERE      (TopicId = @TopicId)) AS TopicRating,
+						CASE WHEN FT.LastReplyId is NULL THEN IsNull(T.DateCreated,'') ELSE IsNull(R.DateCreated,'') END AS LastPostDate, 
+						CASE WHEN FT.LastReplyId is NULL THEN IsNull(T.AuthorId,'') ELSE IsNull(R.AuthorId,'') END AS LastPostAuthorId, 
+						CASE WHEN FT.LastReplyId is NULL THEN IsNull(T.AuthorName,'') ELSE IsNull(R.AuthorName,'') END AS LastPostAuthorName,
+						CASE WHEN FT.LastReplyId is NULL THEN IsNull(T.UserName,'') ELSE IsNull(R.Username,'') END AS LastPostUserName,
+						CASE WHEN FT.LastReplyId is NULL THEN IsNull(T.FirstName,'') ELSE IsNull(R.FirstName,'') END AS LastPostFirstName, 
+						CASE WHEN FT.LastReplyId is NULL THEN IsNull(T.LastName,'') ELSE IsNull(R.LastName,'') END AS LastPostLastName, 
+						CASE WHEN FT.LastReplyId is NULL THEN IsNull(T.DisplayName,'') ELSE IsNull(R.DisplayName,'') END AS LastPostDisplayName, 
+                        T.Subject, T.Summary, T.Body, T.AuthorId, T.AuthorName, T.Username, T.FirstName, T.LastName, 
+					  T.DisplayName, T.DateCreated, T.DateUpdated, T.ViewCount, @ReplyCount as ReplyCount, T.IsPinned, T.IsLocked, T.StatusId, T.TopicIcon, T.TopicType, @Tags as Tags,ISNULL(t.TopicData,'') as TopicData,
+					  {databaseOwner}{objectQualifier}activeforums_Poll.PollID,
+					aft.NextTopic, 
+					aft.PrevTopic,
+					t.URL,
+					T.AuthorName as TopicAuthor,
+                     aft.IsAnnounce, aft.AnnounceStart, aft.AnnounceEnd, aft.IsApproved, aft.IsDeleted, aft.IsRejected, aft.IsArchived, aft.IsLocked, aft.IsPinned, aft.TopicIcon, aft.TopicType, aft.Priority,
+                    aft.ContentId, C.IPAddress,
+					COALESCE((SELECT COUNT(*)
+							  FROM         {databaseOwner}{objectQualifier}activeforums_Subscriptions
+							  WHERE     (ForumId = @ForumId) AND (TopicId = @TopicId)), 0) AS TopicSubscriberCount,
+					COALESCE((SELECT COUNT(*)
+							  FROM         {databaseOwner}{objectQualifier}activeforums_Subscriptions
+							  WHERE     (ForumId = @ForumId) AND (TopicId = 0)), 0) AS ForumSubscriberCount
+FROM
+	{databaseOwner}{objectQualifier}activeforums_Topics aft INNER JOIN          
+	{databaseOwner}{objectQualifier}activeforums_ForumTopics AS FT ON aft.TopicId = FT.TopicId INNER JOIN
+					  {databaseOwner}{objectQualifier}vw_activeforums_GroupForum AS v ON FT.ForumId = v.ForumId INNER JOIN
+					  {databaseOwner}{objectQualifier}vw_activeforums_ForumTopics AS T ON FT.TopicId = T.TopicId LEFT OUTER JOIN
+					  {databaseOwner}{objectQualifier}vw_activeforums_ForumReplies AS R ON FT.LastReplyId = R.ReplyId AND FT.LastReplyId IS NOT NULL LEFT OUTER JOIN
+					  {databaseOwner}{objectQualifier}activeforums_Poll ON T.TopicId = {databaseOwner}{objectQualifier}activeforums_Poll.TopicId
+                      LEFT OUTER JOIN {databaseOwner}{objectQualifier}activeforums_Content AS C ON C.ContentId = aft.ContentId
+WHERE     (v.ForumActive = 1) AND (v.ModuleId = @ModuleId) AND (v.ForumId = @ForumId) AND (FT.TopicId = @TopicId)
+END
+--Forum Security
+BEGIN
+	Select p.* from {databaseOwner}{objectQualifier}activeforums_Permissions as p INNER JOIN {databaseOwner}{objectQualifier}activeforums_Forums as f ON f.PermissionsId = p.PermissionsId WHERE f.ForumId = @ForumId
+	
+END
+--Get Topic and Replies
+	SELECT	ForumId, TopicId, ReplyId, [Subject], Summary, AuthorId, StatusId, AuthorName, UserName, FirstName, LastName, 
+			DisplayName, DateCreated, DateUpdated, Body, TopicCount, ReplyCount, ViewCount, AnswerCount,
+			RewardPoints, UserDateCreated, DateLastActivity, UserCaption, [Signature], SignatureDisabled,
+			UserPostCount, UserTotalPoints,IPAddress,Avatar,AvatarType,AvatarDisabled,MemberSince,
+			ContentId,IsUserOnline,ReplyToId,	UserRoles = {databaseOwner}{objectQualifier}activeforums_UserProfiles_GetUserRoles(AuthorId, @PortalID, GETUTCDATE(),0),IsApproved,
+			@Tags as Tags
+			
+	FROM
+			(
+			SELECT	T.ForumId, T.TopicId, T.ReplyId, T.Subject, T.Summary, T.AuthorId, T.StatusId, IsNull(T.AuthorName,'anon') as AuthorName, IsNull(T.Username,IsNull(T.AuthorName,'anon')) as Username,
+			IsNull(T.FirstName,'') as FirstName, IsNull(T.LastName,'') as LastName,
+            IsNull(T.DisplayName,T.AuthorName) as DisplayName,
+			T.DateCreated, T.DateUpdated, C.Body, IsNull(P.TopicCount,0) as TopicCount, IsNull(P.ReplyCount,0) as ReplyCount,
+			IsNull(P.ViewCount,0) as ViewCount, IsNull(P.AnswerCount,0) as AnswerCount, IsNull(P.RewardPoints,0) as RewardPoints,
+			IsNull(P.DateCreated,'') AS UserDateCreated, IsNull(P.DateLastActivity,'') as DateLastActivity, 
+			IsNull(P.UserCaption,'') as UserCaption, IsNull(P.Signature,'') as [Signature], IsNull(P.SignatureDisabled,0) as SignatureDisabled, 
+			UserPostCount = (IsNull(P.TopicCount,0) + IsNull(P.ReplyCount,0)), 
+			UserTotalPoints = (IsNull(P.TopicCount,0) + IsNull(P.ReplyCount,0) + IsNull(P.AnswerCount,0) + IsNull(P.RewardPoints,0)),
+			C.IPAddress, IsNull(P.Avatar,'') as Avatar, IsNull(P.AvatarType,0) as AvatarType, IsNull(P.AvatarDisabled,0) as AvatarDisabled,
+			IsNull(P.DateCreated,'') as MemberSince,
+			C.ContentId, IsUserOnline = (CASE WHEN DATEDIFF(mi,p.DateLastActivity,GETUTCDATE()) <=1 THEN 1 ELSE 0 END),T.ReplyToId,
+			1 AS IsApproved /* only approved content is returned from vw_activeforums_TopicView */,
+			ROW_NUMBER() OVER (Order By 
+								CASE
+									WHEN @Sort = 'DESC' THEN T.DateCreated END DESC,
+								CASE 
+									WHEN @Sort = 'ASC' THEN T.DateCreated END ASC
+								) as RowRank
+			FROM	{databaseOwner}{objectQualifier}vw_activeforums_TopicView AS T INNER JOIN
+					{databaseOwner}{objectQualifier}activeforums_Content AS C ON T.ContentId = C.ContentId LEFT OUTER JOIN
+					{databaseOwner}{objectQualifier}activeforums_UserProfiles AS P ON C.AuthorId = P.UserId AND P.PortalId = @PortalId
+			WHERE     (T.TopicId = @TopicId)
+			)
+		AS TopicWithRowNumbers
+		WHERE RowRank > @RowIndex AND RowRank <= (@RowIndex + @MaxRows)
+
+--Get Attachments
+SELECT     A.AttachId, A.ContentId, A.UserID, A.[FileName], A.ContentType, A.FileSize, A.FileID
+FROM        {databaseOwner}{objectQualifier}activeforums_Attachments AS A inner join
+			{databaseOwner}{objectQualifier}vw_activeforums_TopicView AS T ON A.ContentId = T.ContentId
+WHERE     (T.TopicId = @TopicId AND (A.AllowDownload = 1 OR A.AllowDownload IS NULL))
+
+--Update View Count
+UPDATE {databaseOwner}{objectQualifier}activeforums_Topics SET ViewCount = (ViewCount+1) WHERE TopicId = @TopicId
+If @UserId > 0
+BEGIN
+SELECT @LastPostId = IsNull(LastReplyId,0) FROM {databaseOwner}{objectQualifier}activeforums_ForumTopics WHERE ForumId = @ForumId AND TopicId = @TopicId
+exec {databaseOwner}{objectQualifier}activeforums_Forums_Tracking_UpdateUser @ModuleId, @UserId, @ForumId	
+SET @LastPostId = IsNull(@LastPostId,0)
+exec {databaseOwner}{objectQualifier}activeforums_Topics_Tracking_UpdateUser @ForumId, @TopicId, @LastPostId, @UserId
+exec {databaseOwner}{objectQualifier}activeforums_UserProfiles_UpdateActivity @PortalId, @UserId
+END
+
+GO
+
+/* issues 13 - end - intermittant exceptions when replying */


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Fixes intermittent exception when replying to a topic; this exception occurs when a topic has more replies than the "items per page" setting, 2) the topic view sort is "Most Recent First" so that only replies (but not the original topic) are shown on the page, and 3) caching is freshly cleared.

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1333