### PR TITLE
BUG: Remove old scheduler entry no longer needed

### DIFF
--- a/Dnn.CommunityForums/DnnCommunityForums.dnn
+++ b/Dnn.CommunityForums/DnnCommunityForums.dnn
@@ -419,10 +419,15 @@
                 <name>08.02.08.SqlDataProvider</name>
                 <version>08.02.08</version>
             </script>
+            <script type="Install">
+                <path>sql</path>
+                <name>09.00.00.SqlDataProvider</name>
+                <version>09.00.00</version>
+            </script>
             <script type="UnInstall">
               <path>sql</path>
               <name>Uninstall.SqlDataProvider</name>
-              <version>08.02.08</version>
+              <version>09.00.00</version>
             </script>
           </scripts>
         </component>

--- a/Dnn.CommunityForums/sql/09.00.00.SqlDataProvider
+++ b/Dnn.CommunityForums/sql/09.00.00.SqlDataProvider
@@ -1,0 +1,9 @@
+/* issue 1397 begin - remove already-replaced schedule */
+SET NOCOUNT ON
+GO 
+/* remove old scheduler -- note that was to have been removed in 8.1, but there was a typo in the sql */
+IF EXISTS (Select * From {databaseOwner}{objectQualifier}Schedule WHERE TypeFullName = 'DotNetNuke.Modules.ActiveForums.Queue.Scheduler, DotNetNuke.Modules.ActiveForums')
+	DELETE FROM {databaseOwner}{objectQualifier}Schedule WHERE TypeFullName = 'DotNetNuke.Modules.ActiveForums.Queue.Scheduler, DotNetNuke.Modules.ActiveForums'
+GO
+/* issue 1397 end - remove already-replaced schedule */
+/* ---------------- */


### PR DESCRIPTION


<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
- SQL data provider scripts: Removed old scheduler entries that are no longer needed.

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1397