### PR TITLE
FIX: Add bracket encoding/decoding to not interfere with token replacement

### DIFF
--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
@@ -577,7 +577,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 sOutput = TemplateUtils.ReplaceSubSection(sOutput, "<asp:placeholder id=\"plhTopic\" runat=\"server\" />", "[AF:CONTROL:CALLBACK]", "[/AF:CONTROL:CALLBACK]");
                 sOutput = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.MapLegacyTopicTokenSynonyms(new StringBuilder(sOutput), this.PortalSettings, this.ForumUser.UserInfo?.Profile?.PreferredLocale).ToString();
                 sOutput = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.ReplaceTopicTokens(new StringBuilder(sOutput), this.topic, this.PortalSettings, this.MainSettings, new Services.URLNavigator().NavigationManager(), this.ForumUser, this.Request.Url, this.Request.RawUrl).ToString();
-
+                sOutput = Utilities.DecodeBrackets(sOutput);
                 sOutput = Utilities.LocalizeControl(sOutput);
                 sOutput = Utilities.StripTokens(sOutput);
 

--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicsView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicsView.cs
@@ -635,7 +635,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     stringBuilder.Replace("[AF:UI:MINIPAGER]", this.GetSubPages(this.TabId, topicInfo.ReplyCount, this.ForumId, topicInfo.TopicId));
                 }
 
-                sTopics += stringBuilder.ToString();
+                sTopics += Utilities.DecodeBrackets(stringBuilder.ToString());
                 rowcount += 1;
             }
 

--- a/Dnn.CommunityForums/Entities/ReplyInfo.cs
+++ b/Dnn.CommunityForums/Entities/ReplyInfo.cs
@@ -341,7 +341,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                 case "subject":
                     {
                         string sPollImage = (this.Topic.TopicType == TopicTypes.Poll ? DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.GetTokenFormatString("[POLLIMAGE]", this.Forum.PortalSettings, accessingUser.Profile.PreferredLocale) : string.Empty);
-                        return PropertyAccess.FormatString(length > 0 && this.Subject.Length > length ? string.Concat(Utilities.StripHTMLTag(this.Subject).Replace("[", "&#91").Replace("]", "&#93"), "...") : Utilities.StripHTMLTag(this.Subject).Replace("[", "&#91").Replace("]", "&#93") + sPollImage, format);
+                        return PropertyAccess.FormatString(Utilities.EncodeBrackets(length > 0 && this.Subject.Length > length ? string.Concat(Utilities.StripHTMLTag(this.Subject).Replace("[", "&#91").Replace("]", "&#93"), "...") : Utilities.StripHTMLTag(this.Subject).Replace("[", "&#91").Replace("]", "&#93") + sPollImage), format);
                     }
 
                 case "subjectlink":
@@ -399,11 +399,11 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                     }
 
                 case "summary":
-                    return PropertyAccess.FormatString(length > 0 && this.Summary.Length > length ? this.Summary.Substring(0, length) : this.Summary, format);
+                    return PropertyAccess.FormatString(Utilities.EncodeBrackets(length > 0 && this.Summary.Length > length ? this.Summary.Substring(0, length) : this.Summary), format);
                 case "body":
-                    return PropertyAccess.FormatString(length > 0 && this.Content.Body.Length > length ? this.Content.Body.Substring(0, length) : this.Content.Body, format);
+                    return PropertyAccess.FormatString(length > 0 && this.Content.Body.Length > length ? this.Content.Body.Substring(0, length) : this.Content.Body, Utilities.EncodeBrackets(format));
                 case "bodytitle":
-                    return PropertyAccess.FormatString(GetTopicTitle(this.Content.Body), format);
+                    return PropertyAccess.FormatString(Utilities.EncodeBrackets(GetTopicTitle(this.Content.Body)), format);
                 case "link":
                     {
                         string sTopicURL = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, this.GetTabId(), this.Forum.ModuleId, this.Forum.ForumGroup.PrefixURL, this.Forum.PrefixURL, this.Forum.ForumGroupId, this.Forum.ForumID, this.TopicId, this.Topic.TopicUrl, -1, -1, string.Empty, 1, this.ContentId, this.Forum.SocialGroupId);

--- a/Dnn.CommunityForums/Entities/TopicInfo.cs
+++ b/Dnn.CommunityForums/Entities/TopicInfo.cs
@@ -602,7 +602,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                 case "subject":
                     {
                         string sPollImage = (this.Topic.TopicType == TopicTypes.Poll ? DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.GetTokenFormatString("[POLLIMAGE]", this.Forum.PortalSettings, accessingUser.Profile.PreferredLocale) : string.Empty);
-                        return PropertyAccess.FormatString(length > 0 && this.Subject.Length > length ? string.Concat(Utilities.StripHTMLTag(this.Subject).Replace("[", "&#91").Replace("]", "&#93"), "...") : Utilities.StripHTMLTag(this.Subject).Replace("[", "&#91").Replace("]", "&#93") + sPollImage, format);
+                        return PropertyAccess.FormatString(Utilities.EncodeBrackets(length > 0 && this.Subject.Length > length ? string.Concat(Utilities.StripHTMLTag(this.Subject).Replace("[", "&#91").Replace("]", "&#93"), "...") : Utilities.StripHTMLTag(this.Subject).Replace("[", "&#91").Replace("]", "&#93") + sPollImage), format);
                     }
 
                 case "subjectlink":
@@ -734,14 +734,15 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
 
                     return string.Empty;
                 case "bodytitle":
-                    return PropertyAccess.FormatString(GetTopicTitle(this.Content.Body), format);
+                    return PropertyAccess.FormatString(Utilities.EncodeBrackets(GetTopicTitle(this.Content.Body)), format);
                 case "summary":
                     return PropertyAccess.FormatString(
+                        Utilities.EncodeBrackets(
                         !string.IsNullOrEmpty(this.Summary)
                         ? length > 0 && this.Summary.Length > length ? this.Summary.Substring(0, length) : this.Summary
-                        : length > 0 && this.Content.Body.Length > length ? this.Content.Body.Substring(0, length) : this.Content.Body, format);
+                        : length > 0 && this.Content.Body.Length > length ? this.Content.Body.Substring(0, length) : this.Content.Body), format);
                 case "body":
-                    return PropertyAccess.FormatString(length > 0 && this.Content.Body.Length > length ? this.Content.Body.Substring(0, length) : this.Content.Body, format);
+                    return PropertyAccess.FormatString(Utilities.EncodeBrackets(length > 0 && this.Content.Body.Length > length ? this.Content.Body.Substring(0, length) : this.Content.Body), format);
                 case "lastreplyid":
                     return PropertyAccess.FormatString(this.LastReplyId.ToString(), format);
                 case "replycount":

--- a/Dnn.CommunityForums/Services/Tokens/TokenReplacer.cs
+++ b/Dnn.CommunityForums/Services/Tokens/TokenReplacer.cs
@@ -23,6 +23,7 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
     using System;
     using System.Data.SqlTypes;
     using System.Linq;
+    using System.Security.AccessControl;
     using System.Text;
     using System.Text.RegularExpressions;
     using System.Web.UI.WebControls;
@@ -65,6 +66,7 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
             this.TokenContext = context;
 
         }
+
         public TokenReplacer(PortalSettings portalSettings, ForumUserInfo forumUser, ForumInfo forumInfo, Uri requestUri, string rawUrl)
         {
             forumInfo.RawUrl = rawUrl;
@@ -153,6 +155,8 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
             topicInfo.Forum.RequestUri = requestUri;
             topicInfo.Forum.ForumGroup.RequestUri = requestUri;
             topicInfo.RequestUri = requestUri;
+            topicInfo.Author.ForumUser.RawUrl = rawUrl;
+            topicInfo.Author.ForumUser.RequestUri = requestUri;
             forumUser.RequestUri = requestUri;
             this.PropertySource[PropertySource_resx] = new ResourceStringTokenReplacer();
             this.PropertySource[PropertySource_dcf] = new ForumsModuleTokenReplacer(portalSettings, topicInfo.Forum.GetTabId(), topicInfo.Forum.ModuleId, GetTabId(portalSettings, topicInfo.Forum), GetModuleId(portalSettings, topicInfo.Forum), requestUri, rawUrl);
@@ -187,11 +191,13 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
             postInfo.Forum.RawUrl = rawUrl;
             postInfo.Forum.ForumGroup.RawUrl = rawUrl;
             postInfo.Topic.RawUrl = rawUrl;
+            postInfo.Author.ForumUser.RawUrl = rawUrl;
             postInfo.RawUrl = rawUrl;
             forumUser.RawUrl = rawUrl;
             postInfo.Forum.RequestUri = requestUri;
             postInfo.Forum.ForumGroup.RequestUri = requestUri;
             postInfo.Topic.RequestUri = requestUri;
+            postInfo.Author.ForumUser.RequestUri = requestUri;
             postInfo.RequestUri = requestUri;
             forumUser.RequestUri = requestUri;
             this.PropertySource[PropertySource_resx] = new ResourceStringTokenReplacer();
@@ -228,11 +234,13 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
             likeInfo.Forum.RawUrl = rawUrl;
             likeInfo.Forum.ForumGroup.RawUrl = rawUrl;
             likeInfo.Topic.RawUrl = rawUrl;
+            likeInfo.Author.ForumUser.RawUrl = rawUrl;
             likeInfo.RawUrl = rawUrl;
             forumUser.RawUrl = rawUrl;
             likeInfo.Forum.RequestUri = requestUri;
             likeInfo.Forum.ForumGroup.RequestUri = requestUri;
             likeInfo.Topic.RequestUri = requestUri;
+            likeInfo.Author.ForumUser.RequestUri = requestUri;
             likeInfo.RequestUri = requestUri;
             forumUser.RequestUri = requestUri;
             this.PropertySource[PropertySource_resx] = new ResourceStringTokenReplacer();

--- a/Dnn.CommunityForums/class/Utilities.cs
+++ b/Dnn.CommunityForums/class/Utilities.cs
@@ -561,12 +561,12 @@ namespace DotNetNuke.Modules.ActiveForums
             return RegexUtils.GetCachedRegex(System.Environment.NewLine).Replace(text, " <br /> ");
         }
 
-        private static string EncodeBrackets(string text)
+        internal static string EncodeBrackets(string text)
         {
             return text.Replace("[", "&#91;").Replace("]", "&#93;");
         }
 
-        private static string DecodeBrackets(string text)
+        internal static string DecodeBrackets(string text)
         {
             return text.Replace("&#91;", "[").Replace("&#93;", "]");
         }

--- a/Dnn.CommunityForums/controls/af_grid.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_grid.ascx.cs
@@ -120,7 +120,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     var topic = new DotNetNuke.Modules.ActiveForums.Controllers.TopicController(this.ForumModuleId).GetById(topicId);
                     if (topic != null)
                     {
-                        itemTemplate = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.ReplaceTopicTokens(new StringBuilder(itemTemplate), topic, this.PortalSettings, this.MainSettings, new Services.URLNavigator().NavigationManager(), this.ForumUser, this.Request.Url, this.Request.RawUrl).ToString();
+                        itemTemplate = Utilities.DecodeBrackets(DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.ReplaceTopicTokens(new StringBuilder(itemTemplate), topic, this.PortalSettings, this.MainSettings, new Services.URLNavigator().NavigationManager(), this.ForumUser, this.Request.Url, this.Request.RawUrl).ToString());
                         ((LiteralControl)repeaterItemEventArgs.Item.Controls[0]).Text = itemTemplate;
                     }
                 }

--- a/Dnn.CommunityForums/controls/af_search.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_search.ascx.cs
@@ -180,7 +180,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     var topic = new DotNetNuke.Modules.ActiveForums.Controllers.TopicController(this.ForumModuleId).GetById(topicId);
                     if (topic != null)
                     {
-                        itemTemplate = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.ReplaceTopicTokens(new StringBuilder(itemTemplate), topic, this.PortalSettings, this.MainSettings, new Services.URLNavigator().NavigationManager(), this.ForumUser, this.Request.Url, this.Request.RawUrl).ToString();
+                        itemTemplate = Utilities.DecodeBrackets(DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.ReplaceTopicTokens(new StringBuilder(itemTemplate), topic, this.PortalSettings, this.MainSettings, new Services.URLNavigator().NavigationManager(), this.ForumUser, this.Request.Url, this.Request.RawUrl).ToString());
                         ((LiteralControl)repeaterItemEventArgs.Item.Controls[0]).Text = itemTemplate;
                     }
                 }


### PR DESCRIPTION




<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Add bracket encoding/decoding to not interfere with token replacement

## Changes made
- Change `Utilities.EncodeBrackets` and `Utilities.DecodeBrackets` methods to internal rather than private. 
- Modify `GetProperty` method for topic & reply entities to encode brackets in content. 
- Modify `BindTopic` (topic view), `ParseTopics` (topics view), `TopicRepeaterOnItemDataBound` in `af_grid.ascx.cs` and `af_search.ascx.cs` to decode brackets after token replacement for correct display formatting.

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

![image](https://github.com/user-attachments/assets/8328ae09-88d7-4d5d-852b-5907052c854d)


## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1384