### PR TITLE
FIX: Don't show private message link / icon to unauthenticated users

### DIFF
--- a/Dnn.CommunityForums/Entities/ForumUserInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumUserInfo.cs
@@ -639,7 +639,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                 case "useremail":
                     return PropertyAccess.FormatString(string.IsNullOrEmpty(this.Email) ? string.Empty : this.Email, format);
                 case "useridforpmlink":
-                    return PropertyAccess.FormatString(this.UserId > 0 ? this.UserId.ToString() : string.Empty, format);
+                    return PropertyAccess.FormatString(accessingUser.UserID > 0 && this.UserId > 0 ? this.UserId.ToString() : string.Empty, format);
                 case "useridforeditlink":
                     return PropertyAccess.FormatString((accessingUser.IsAdmin || accessingUser.IsSuperUser) && this.UserId > 0 ? this.UserId.ToString() : string.Empty, format);
                 case "displaynameforjson":


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Unauthenticated users shouldn't be able to message other users.
 

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

Before
![image](https://github.com/user-attachments/assets/aff18d5e-7e9c-423a-9b83-2a6a274d1b57)

After

![image](https://github.com/user-attachments/assets/b5c17742-3434-4c0d-b9ed-bf8f3104bbc5)


## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1403