### PR TITLE
FIX: HasEditIntervalPassed method issue  

### DIFF
--- a/Dnn.CommunityForums/Controllers/PermissionController.cs
+++ b/Dnn.CommunityForums/Controllers/PermissionController.cs
@@ -954,7 +954,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             return sRoles;
         }
 
-        public static string CheckForumIdsForViewForRSS(int moduleId, string forumIds, string userPermSet)
+        public static string CheckForumIdsForViewForRSS(int moduleId, string forumIds, HashSet<int> userRoleIds)
         {
             string cacheKey = string.Format(CacheKeys.ViewRolesForForumList, moduleId, forumIds);
             string sForums = (string)DataCache.SettingsCacheRetrieve(moduleId, cacheKey);
@@ -966,7 +966,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                     foreach (string forumId in forumIds.Split(":".ToCharArray(), StringSplitOptions.RemoveEmptyEntries))
                     {
                         DotNetNuke.Modules.ActiveForums.Entities.ForumInfo forum = new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().GetById(Convert.ToInt32(forumId), moduleId);
-                        if (forum.FeatureSettings.AllowRSS && DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasRequiredPerm(forum.Security?.ViewRoleIds, DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(userPermSet)))
+                        if (forum.FeatureSettings.AllowRSS && DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasRequiredPerm(forum.Security?.ViewRoleIds, userRoleIds))
                         {
                             sForums += forum.ForumID.ToString() + ":";
                         }

--- a/Dnn.CommunityForums/CustomControls/UserControls/WhatsNewRSS.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/WhatsNewRSS.cs
@@ -137,7 +137,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             {
                 return this.authorizedForums ??
                        (this.authorizedForums =
-                        DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.CheckForumIdsForViewForRSS(-1, this.Settings.Forums, this.CurrentUser.UserPermSet));
+                        DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.CheckForumIdsForViewForRSS(-1, this.Settings.Forums, this.CurrentUser.UserRoleIds));
             }
         }
 

--- a/Dnn.CommunityForums/Entities/ForumGroupInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumGroupInfo.cs
@@ -283,23 +283,23 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
 
         internal int GetTabId()
         {
-            if (this.PortalSettings.ActiveTab.TabID == -1 || this.PortalSettings.ActiveTab.TabID == this.PortalSettings.HomeTabId)
+            if (this.PortalSettings.ActiveTab?.TabID == -1 || this.PortalSettings.ActiveTab?.TabID == this.PortalSettings.HomeTabId)
             {
-                if (!this.tabId.Equals(null))
+                if (this.tabId.HasValue)
                 {
                     return (int)this.tabId;
                 }
-                else
-                {
-                    return this.ModuleInfo.TabID;
-                }
-            }
-            else
-            {
-                return this.PortalSettings.ActiveTab.TabID;
-            }
-        }
 
+                return this.ModuleInfo.TabID;
+            }
+
+            if (this.PortalSettings.ActiveTab != null)
+            {
+                return (int)this.PortalSettings.ActiveTab.TabID;
+            }
+
+            return DotNetNuke.Common.Utilities.Null.NullInteger;
+        }
 
         internal string GetCacheKey() => string.Format(this.cacheKeyTemplate, this.ModuleId, this.ForumGroupId);
 

--- a/Dnn.CommunityForums/Entities/ForumInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumInfo.cs
@@ -18,6 +18,8 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using DotNetNuke.Common.Utilities;
+
 namespace DotNetNuke.Modules.ActiveForums.Entities
 {
     using System;
@@ -989,21 +991,22 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
 
         internal int GetTabId()
         {
-            if (this.PortalSettings.ActiveTab.TabID == -1 || this.PortalSettings.ActiveTab.TabID == this.PortalSettings.HomeTabId)
+            if (this.PortalSettings.ActiveTab?.TabID == -1 || this.PortalSettings.ActiveTab?.TabID == this.PortalSettings.HomeTabId)
             {
-                if (!this.tabId.Equals(null))
+                if (this.tabId.HasValue)
                 {
                     return (int)this.tabId;
                 }
-                else
-                {
-                    return this.ModuleInfo.TabID;
-                }
+
+                return this.ModuleInfo.TabID;
             }
-            else
+
+            if (this.PortalSettings.ActiveTab != null)
             {
-                return this.PortalSettings.ActiveTab.TabID;
+                return (int)this.PortalSettings.ActiveTab.TabID;
             }
+
+            return DotNetNuke.Common.Utilities.Null.NullInteger;
         }
 
         internal string GetCacheKey() => string.Format(this.cacheKeyTemplate, this.ModuleId, this.ForumID);

--- a/Dnn.CommunityForums/WhatsNew.ascx.cs
+++ b/Dnn.CommunityForums/WhatsNew.ascx.cs
@@ -75,7 +75,7 @@ namespace DotNetNuke.Modules.ActiveForums
             {
                 return this.authorizedForums ??
                        (this.authorizedForums =
-                       DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.CheckForumIdsForViewForRSS(-1, this.Settings.Forums, this.CurrentUser.UserPermSet));
+                       DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.CheckForumIdsForViewForRSS(-1, this.Settings.Forums, this.CurrentUser.UserRoleIds));
             }
         }
 

--- a/Dnn.CommunityForums/class/Utilities.cs
+++ b/Dnn.CommunityForums/class/Utilities.cs
@@ -191,7 +191,7 @@ namespace DotNetNuke.Modules.ActiveForums
                    || forumUser == null
                    || forumUser.IsAdmin
                    || forumUser.IsSuperUser
-                   || Utilities.IsTrusted((int)forumInfo.FeatureSettings.DefaultTrustValue, userTrustLevel: forumUser.TrustLevel, DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasPerm(forumInfo.Security.Trust, forumUser.UserRoles), forumInfo.FeatureSettings.AutoTrustLevel, forumUser.PostCount)
+                   || Utilities.IsTrusted((int)forumInfo.FeatureSettings.DefaultTrustValue, userTrustLevel: forumUser.TrustLevel, DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasRequiredPerm(forumInfo.Security.TrustRoleIds, forumUser.UserRoleIds), forumInfo.FeatureSettings.AutoTrustLevel, forumUser.PostCount)
                    || DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasRequiredPerm(forumInfo.Security.ModerateRoleIds, forumUser.UserRoleIds)
                    || (postInfo?.Content?.DateCreated != null && DateTime.UtcNow.Subtract(postInfo.Content.DateCreated).TotalMinutes > editInterval);
         }

--- a/Dnn.CommunityForumsTests/Controllers/PermissionControllerTests.cs
+++ b/Dnn.CommunityForumsTests/Controllers/PermissionControllerTests.cs
@@ -750,8 +750,8 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Controllers
             // Act
             // Assert
             /* not yet testable */
-            Assert.That(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.CheckForumIdsForViewForRSS(this.mockModule.Object.ModuleID, string.Empty, string.Empty), Is.EqualTo(string.Empty));
-            Assert.Throws<NullReferenceException>(() => DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.CheckForumIdsForViewForRSS(this.mockModule.Object.ModuleID, "1", "1;2;3|||"));
+            Assert.That(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.CheckForumIdsForViewForRSS(this.mockModule.Object.ModuleID, string.Empty, new HashSet<int>()), Is.EqualTo(string.Empty));
+            Assert.Throws<NullReferenceException>(() => DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.CheckForumIdsForViewForRSS(this.mockModule.Object.ModuleID, "1",  new HashSet<int>() { 1, 2, 3 }));
         }
 
         [Test]

--- a/Dnn.CommunityForumsTests/Entities/TopicItemTests.cs
+++ b/Dnn.CommunityForumsTests/Entities/TopicItemTests.cs
@@ -40,8 +40,8 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Entities
                     ForumName = "Test Forum",
                     TotalTopics = 0,
                     Security = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetEmptyPermissions(this.mockModule.Object.ModuleID),
-                    ForumGroup = new DotNetNuke.Modules.ActiveForums.Entities.ForumGroupInfo { GroupName = "Test Forum Group" }
-                }
+                    ForumGroup = new DotNetNuke.Modules.ActiveForums.Entities.ForumGroupInfo { GroupName = "Test Forum Group" },
+                },
             };
 
             var mockTopic = new Mock<DotNetNuke.Modules.ActiveForums.Entities.TopicInfo>
@@ -56,8 +56,8 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Entities
                         ContentId = 1,
                         ModuleId = 1,
                         Subject = "Test Topic",
-                        Body = "Test Topic"
-                    }
+                        Body = "Test Topic",
+                    },
                 },
             };
 
@@ -72,7 +72,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Entities
                     {
                         PreferredLocale = "en-US",
                     },
-                }
+                },
             };
             var mockUser = new Mock<DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo>(DotNetNuke.Entities.Portals.PortalController.Instance.GetCurrentPortalSettings(), mockUserInfo.Object)
             {

--- a/Dnn.CommunityForumsTests/Services/Tokens/TokenReplacerTests.cs
+++ b/Dnn.CommunityForumsTests/Services/Tokens/TokenReplacerTests.cs
@@ -396,7 +396,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Services.Tokens
                     {
                         PreferredLocale = "en-US",
                     },
-                }
+                },
             };
             var mockUser = new Mock<DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo>(DotNetNuke.Entities.Portals.PortalController.Instance.GetCurrentPortalSettings(), mockUserInfo.Object)
             {

--- a/Dnn.CommunityForumsTests/class/UtilitiesTests.cs
+++ b/Dnn.CommunityForumsTests/class/UtilitiesTests.cs
@@ -115,7 +115,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests
                     {
                         PreferredLocale = "en-US",
                     },
-                }
+                },
             };
             var mockUser = new Mock<DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo>(DotNetNuke.Entities.Portals.PortalController.Instance.GetCurrentPortalSettings(), mockUserInfo.Object)
             {
@@ -194,14 +194,15 @@ namespace DotNetNuke.Modules.ActiveForumsTests
             {
                 Object =
                 {
+                    PortalID = DotNetNuke.Entities.Portals.PortalController.Instance.GetCurrentPortalSettings().PortalId,
                     UserID = isAnonymous ? -1 : DotNetNuke.Tests.Utilities.Constants.UserID_User12,
                     IsSuperUser = isSuperUser && !isAnonymous,
                 },
-            };
-            var mockUser = new Mock<DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo>
+            }; var mockUser = new Mock<DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo>(DotNetNuke.Entities.Portals.PortalController.Instance.GetCurrentPortalSettings(), mockUserInfo.Object)
             {
                 Object =
                 {
+                    PortalId = DotNetNuke.Entities.Portals.PortalController.Instance.GetCurrentPortalSettings().PortalId,
                     UserId = mockUserInfo.Object.UserID,
                     UserInfo = mockUserInfo.Object,
                 },


### PR DESCRIPTION

<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Fixes some minor issues encountered in pre-release testing, particularly
- HasEditIntervalPassed method in Utilities was not checking roleIds correctly (PR #1394)
- rewrote TabId handling for Forum and ForumGroup property accessors (PR #1344)
-  tweak some unit tests that weren't passing and needed more mock object initialization
 - fix this issue with RSS/What's Next module
 
![image](https://github.com/user-attachments/assets/353da396-9690-4619-9f88-d856519f82c9)


## Changes made

- Updated `ForumGroupInfo.cs` and `ForumInfo.cs` to use null-conditional operators and `HasValue` for safer property access.
- Enhanced permission checking logic in `Utilities.cs` for better clarity and maintainability.
- Modified test setups in `TopicItemTests.cs`, `TokenReplacerTests.cs`, and `UtilitiesTests.cs` to include additional properties for more comprehensive testing.
- Overall improvements to code safety, readability, and test coverage.

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #950 
