### PR TITLE
TASK: Upgrade permissions to contain just role ids

### DIFF
--- a/Dnn.CommunityForums/Classic.ascx.cs
+++ b/Dnn.CommunityForums/Classic.ascx.cs
@@ -58,6 +58,9 @@ namespace DotNetNuke.Modules.ActiveForums
             //ForumsConfig.Install_LikeNotificationType_080200();
             //ForumsConfig.Install_PinNotificationType_080200();
             //ForumsConfig.Sort_PermissionSets_080200();
+            //ForumsConfig.Upgrade_PermissionSets_090000();
+            //DotNetNuke.Modules.ActiveForums.Helpers.UpgradeModuleSettings.DeleteObsoleteModuleSettings_090000();
+
 #endif
 
             try

--- a/Dnn.CommunityForums/Controllers/ForumController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumController.cs
@@ -395,7 +395,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                                 continue;
                             }
 
-                            DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermissions(moduleId, permissionsId: permissionsId, requestedAccess: (DotNetNuke.Modules.ActiveForums.SecureActions)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.SecureActions), requestedAccess), objectId: groupAdmin, objectType: DotNetNuke.Modules.ActiveForums.ObjectType.GroupId);
+                            DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermissions(moduleId, permissionsId: permissionsId, requestedAccess: (DotNetNuke.Modules.ActiveForums.SecureActions)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.SecureActions), requestedAccess), objectId: groupAdmin);
                         }
                     }
 
@@ -411,7 +411,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                                 continue;
                             }
 
-                            DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermissions(moduleId, permissionsId, requestedAccess: (DotNetNuke.Modules.ActiveForums.SecureActions)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.SecureActions), requestedAccess), groupMember, DotNetNuke.Modules.ActiveForums.ObjectType.RoleId);
+                            DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermissions(moduleId, permissionsId, requestedAccess: (DotNetNuke.Modules.ActiveForums.SecureActions)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.SecureActions), requestedAccess), objectId: groupMember);
                         }
                     }
 
@@ -429,7 +429,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                                     continue;
                                 }
 
-                                DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermissions(moduleId, permissionsId, requestedAccess: (DotNetNuke.Modules.ActiveForums.SecureActions)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.SecureActions), requestedAccess), DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRegisteredUsersRoleId(portalSettings).ToString(), DotNetNuke.Modules.ActiveForums.ObjectType.RoleId);
+                                DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermissions(moduleId, permissionsId, requestedAccess: (DotNetNuke.Modules.ActiveForums.SecureActions)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.SecureActions), requestedAccess), objectId: DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRegisteredUsersRoleId(portalSettings).ToString());
                             }
                         }
 
@@ -445,7 +445,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                                     continue;
                                 }
 
-                                DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermissions(moduleId, permissionsId, requestedAccess: (DotNetNuke.Modules.ActiveForums.SecureActions)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.SecureActions), requestedAccess), DotNetNuke.Common.Globals.glbRoleAllUsers, DotNetNuke.Modules.ActiveForums.ObjectType.RoleId);
+                                DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermissions(moduleId, permissionsId, requestedAccess: (DotNetNuke.Modules.ActiveForums.SecureActions)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.SecureActions), requestedAccess), objectId: DotNetNuke.Common.Globals.glbRoleAllUsers);
                             }
                         }
                     }

--- a/Dnn.CommunityForums/Controllers/PermissionController.cs
+++ b/Dnn.CommunityForums/Controllers/PermissionController.cs
@@ -27,6 +27,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
     using System.Collections.Generic;
     using System.Collections.Specialized;
     using System.Linq;
+    using System.Web.Security;
     using System.Xml;
 
     using DotNetNuke.Abstractions.Portals;
@@ -34,7 +35,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
 
     internal class PermissionController : DotNetNuke.Modules.ActiveForums.Controllers.RepositoryControllerBase<DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo>
     {
-        private const string emptyPermissions = ";|||";
+        private const string emptyPermissions = "";
 
         internal override string cacheKeyTemplate => CacheKeys.PermissionsInfo;
 
@@ -117,43 +118,43 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                             switch (sPerm)
                             {
                                 case "view":
-                                    permissions.View = AddPermToSet(roleId.ToString(), DotNetNuke.Modules.ActiveForums.ObjectType.RoleId, permissions.View);
+                                    permissions.View = AddPermToSet(roleId.ToString(), permissions.View);
                                     break;
                                 case "read":
-                                    permissions.Read = AddPermToSet(roleId.ToString(), DotNetNuke.Modules.ActiveForums.ObjectType.RoleId, permissions.Read);
+                                    permissions.Read = AddPermToSet(roleId.ToString(), permissions.Read);
                                     break;
                                 case "create":
-                                    permissions.Create = AddPermToSet(roleId.ToString(), DotNetNuke.Modules.ActiveForums.ObjectType.RoleId, permissions.Create);
+                                    permissions.Create = AddPermToSet(roleId.ToString(), permissions.Create);
                                     break;
                                 case "reply":
-                                    permissions.Reply = AddPermToSet(roleId.ToString(), DotNetNuke.Modules.ActiveForums.ObjectType.RoleId, permissions.Reply);
+                                    permissions.Reply = AddPermToSet(roleId.ToString(), permissions.Reply);
                                     break;
                                 case "edit":
-                                    permissions.Edit = AddPermToSet(roleId.ToString(), DotNetNuke.Modules.ActiveForums.ObjectType.RoleId, permissions.Edit);
+                                    permissions.Edit = AddPermToSet(roleId.ToString(), permissions.Edit);
                                     break;
                                 case "delete":
-                                    permissions.Delete = AddPermToSet(roleId.ToString(), DotNetNuke.Modules.ActiveForums.ObjectType.RoleId, permissions.Delete);
+                                    permissions.Delete = AddPermToSet(roleId.ToString(), permissions.Delete);
                                     break;
                                 case "lock":
-                                    permissions.Lock = AddPermToSet(roleId.ToString(), DotNetNuke.Modules.ActiveForums.ObjectType.RoleId, permissions.Lock);
+                                    permissions.Lock = AddPermToSet(roleId.ToString(), permissions.Lock);
                                     break;
                                 case "pin":
-                                    permissions.Pin = AddPermToSet(roleId.ToString(), DotNetNuke.Modules.ActiveForums.ObjectType.RoleId, permissions.Pin);
+                                    permissions.Pin = AddPermToSet(roleId.ToString(), permissions.Pin);
                                     break;
                                 case "attach":
-                                    permissions.Attach = AddPermToSet(roleId.ToString(), DotNetNuke.Modules.ActiveForums.ObjectType.RoleId, permissions.Attach);
+                                    permissions.Attach = AddPermToSet(roleId.ToString(), permissions.Attach);
                                     break;
                                 case "subscribe":
-                                    permissions.Subscribe = AddPermToSet(roleId.ToString(), DotNetNuke.Modules.ActiveForums.ObjectType.RoleId, permissions.Subscribe);
+                                    permissions.Subscribe = AddPermToSet(roleId.ToString(), permissions.Subscribe);
                                     break;
                                 case "moderate":
-                                    permissions.Moderate = AddPermToSet(roleId.ToString(), DotNetNuke.Modules.ActiveForums.ObjectType.RoleId, permissions.Moderate);
+                                    permissions.Moderate = AddPermToSet(roleId.ToString(), permissions.Moderate);
                                     break;
                                 case "move":
-                                    permissions.Move = AddPermToSet(roleId.ToString(), DotNetNuke.Modules.ActiveForums.ObjectType.RoleId, permissions.Move);
+                                    permissions.Move = AddPermToSet(roleId.ToString(), permissions.Move);
                                     break;
                                 case "ban":
-                                    permissions.Ban = AddPermToSet(roleId.ToString(), DotNetNuke.Modules.ActiveForums.ObjectType.RoleId, permissions.Ban);
+                                    permissions.Ban = AddPermToSet(roleId.ToString(), permissions.Ban);
                                     break;
                             }
                         }
@@ -247,9 +248,9 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             };
             foreach (var access in requestedAccessList)
             {
-                permissionInfo = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermSet(permissionInfo, access, registeredUsersRoleId, DotNetNuke.Modules.ActiveForums.ObjectType.RoleId);
-                permissionInfo = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermSet(permissionInfo, access, DotNetNuke.Common.Globals.glbRoleAllUsers, DotNetNuke.Modules.ActiveForums.ObjectType.RoleId);
-                permissionInfo = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermSet(permissionInfo, access, DotNetNuke.Common.Globals.glbRoleUnauthUser, DotNetNuke.Modules.ActiveForums.ObjectType.RoleId);
+                permissionInfo = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermSet(permissionInfo, access, registeredUsersRoleId);
+                permissionInfo = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermSet(permissionInfo, access, DotNetNuke.Common.Globals.glbRoleAllUsers);
+                permissionInfo = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermSet(permissionInfo, access, DotNetNuke.Common.Globals.glbRoleUnauthUser);
             }
 
             requestedAccessList = new[]
@@ -263,7 +264,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             };
             foreach (var access in requestedAccessList)
             {
-                permissionInfo = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermSet(permissionInfo, access, registeredUsersRoleId, DotNetNuke.Modules.ActiveForums.ObjectType.RoleId);
+                permissionInfo = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermSet(permissionInfo, access, registeredUsersRoleId);
             }
 
             permissionInfo.ModuleId = moduleId;
@@ -350,6 +351,11 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             }
 
             return roleIds;
+        }
+        
+        internal static string GetRoleIds(HashSet<int> roleIds)
+        {
+            return string.Join(";", roleIds.Distinct().OrderBy(r => r));
         }
 
         internal static HashSet<int> GetRoleIdsFromRoleString(string roleString)
@@ -463,6 +469,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
         [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Use GetPortalRoleIds(int PortalId, string[] Roles).")]
         public static string GetRoleIds(string[] roles, int portalId) => GetPortalRoleIds(portalId, roles);
 
+
         internal static string GetPortalRoleIds(int portalId, string[] roles)
         {
             string roleIds = (string)DataCache.SettingsCacheRetrieve(-1, string.Format(CacheKeys.RoleIDs, portalId));
@@ -484,7 +491,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                     }
                 }
 
-                roleIds = string.Join(";", rolesIdHashSet.Distinct().OrderBy(r => r));
+                roleIds = GetRoleIds(rolesIdHashSet);
                 DataCache.SettingsCacheStore(-1, string.Format(CacheKeys.RoleIDs, portalId), roleIds);
             }
 
@@ -666,21 +673,21 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
         [Obsolete("Deprecated in Community Forums. Removing in 10.00.00. Not Used.")]
         public static void AddObjectToPermissions(int moduleId, int permissionsId, string requestedAccess, string objectId, int objectType)
         {
-            AddObjectToPermissions(moduleId, permissionsId, (DotNetNuke.Modules.ActiveForums.SecureActions)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.SecureActions), requestedAccess), objectId, (DotNetNuke.Modules.ActiveForums.ObjectType)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.ObjectType), objectType.ToString()));
+            AddObjectToPermissions(moduleId, permissionsId, (DotNetNuke.Modules.ActiveForums.SecureActions)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.SecureActions), requestedAccess), objectId);
         }
 
-        internal static void AddObjectToPermissions(int moduleId, int permissionsId, DotNetNuke.Modules.ActiveForums.SecureActions requestedAccess, string objectId, DotNetNuke.Modules.ActiveForums.ObjectType objectType)
+        internal static void AddObjectToPermissions(int moduleId, int permissionsId, DotNetNuke.Modules.ActiveForums.SecureActions requestedAccess, string objectId)
         {
             var pc = new DotNetNuke.Modules.ActiveForums.Controllers.PermissionController();
             string permSet = GetPermSetForRequestedAccess(moduleId, permissionsId, requestedAccess);
-            permSet = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddPermToSet(objectId, objectType, permSet);
+            permSet = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddPermToSet(objectId, permSet);
             pc.SavePermSet(moduleId, permissionsId, requestedAccess, permSet);
         }
 
-        internal static DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo AddObjectToPermSet(DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo permissionInfo, DotNetNuke.Modules.ActiveForums.SecureActions requestedAccess, string objectId, DotNetNuke.Modules.ActiveForums.ObjectType objectType)
+        internal static DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo AddObjectToPermSet(DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo permissionInfo, DotNetNuke.Modules.ActiveForums.SecureActions requestedAccess, string objectId)
         {
             var permSet = GetPermSetForRequestedAccess(permissionInfo, requestedAccess);
-            permSet = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddPermToSet(objectId, (DotNetNuke.Modules.ActiveForums.ObjectType)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.ObjectType), objectType.ToString()), permSet);
+            permSet = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddPermToSet(objectId, permSet);
             SetPermSetForRequestedAccess(permissionInfo, requestedAccess, permSet);
             return permissionInfo;
         }
@@ -688,105 +695,90 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
         [Obsolete("Deprecated in Community Forums. Removing in 10.00.00. Not Used.")]
         internal static DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo AddObjectToPermSet(DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo permissionInfo, DotNetNuke.Modules.ActiveForums.SecureActions requestedAccess, string objectId, int objectType)
         {
-            return AddObjectToPermSet(permissionInfo, requestedAccess, objectId, (DotNetNuke.Modules.ActiveForums.ObjectType)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.ObjectType), objectType.ToString()));
+            return AddObjectToPermSet(permissionInfo, requestedAccess, objectId);
         }
 
         [Obsolete("Deprecated in Community Forums. Removing in 10.00.00. Not Used.")]
         public static void RemoveObjectFromPermissions(int moduleId, int permissionsId, string requestedAccess, string objectId, int objectType)
         {
-            RemoveObjectFromPermissions(moduleId, permissionsId, (DotNetNuke.Modules.ActiveForums.SecureActions)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.SecureActions), requestedAccess), objectId, (DotNetNuke.Modules.ActiveForums.ObjectType)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.ObjectType), objectType.ToString()));
+            RemoveObjectFromPermissions(moduleId, permissionsId, (DotNetNuke.Modules.ActiveForums.SecureActions)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.SecureActions), requestedAccess), objectId);
         }
 
-        internal static void RemoveObjectFromPermissions(int moduleId, int permissionsId, DotNetNuke.Modules.ActiveForums.SecureActions requestedAccess, string objectId,  DotNetNuke.Modules.ActiveForums.ObjectType objectType)
+        internal static void RemoveObjectFromPermissions(int moduleId, int permissionsId, DotNetNuke.Modules.ActiveForums.SecureActions requestedAccess, string objectId)
         {
             var pc = new DotNetNuke.Modules.ActiveForums.Controllers.PermissionController();
             string permSet = GetPermSetForRequestedAccess(moduleId, permissionsId, requestedAccess);
-            permSet = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.RemovePermFromSet(objectId, objectType, permSet);
+            permSet = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.RemovePermFromSet(objectId, permSet);
             pc.SavePermSet(moduleId, permissionsId, requestedAccess, permSet);
         }
-
-        internal static string RemovePermFromSet(string objectId, DotNetNuke.Modules.ActiveForums.ObjectType objectType, string permissionSet)
+        
+        internal static string RemovePermFromSet(string objectId, string permissionSet)
         {
-            if (string.IsNullOrEmpty(permissionSet))
-            {
-                return string.Empty;
-            }
+            return GetRoleIds(RemoveRoleIdFromRoleIds(Convert.ToInt32(objectId), GetRoleIdsFromPermSet(permissionSet)));
+        }
 
-            var permSet = permissionSet.Split('|');
-            var index = (int)objectType;
-
-            if (index < 0 || index >= permSet.Length)
-            {
-                return permissionSet;
-            }
-
-            string[] permSection = permSet[index].Split(';');
-            permSet[index] = string.Join(";", permSection.Where(s => s != objectId));
-
-            return string.Join("|", permSet);
+        internal static HashSet<int> RemoveRoleIdFromRoleIds(int roleId, HashSet<int> roleIds)
+        {
+            roleIds.Remove(roleId);
+            return roleIds;
         }
 
         [Obsolete("Deprecated in Community Forums. Removing in 10.00.00. Not Used.")]
         public static string RemovePermFromSet(string objectId, int objectType, string permissionSet)
         {
-            return RemovePermFromSet(objectId, (DotNetNuke.Modules.ActiveForums.ObjectType)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.ObjectType), objectType.ToString()), permissionSet);
+            return RemovePermFromSet(objectId, permissionSet);
         }
 
-        public static string SortPermissionSetMembers(string permissionSet)
+        internal static string SortPermissionSetMembers(string permissionSet)
         {
             if (string.IsNullOrEmpty(permissionSet))
             {
                 return string.Empty;
             }
 
-            string newSet = string.Empty;
-
-            string[] permSet = permissionSet.Split('|');
-            for (int section = 0; section < 2; section++)
-            {
-                var members = permSet[section].Split(";".ToCharArray(), StringSplitOptions.RemoveEmptyEntries).ToArray();
+            var permSet = permissionSet;
+            var members = permSet.Split(";".ToCharArray(), StringSplitOptions.RemoveEmptyEntries).ToArray();
                 Array.Sort(members);
-                permSet[section] = string.Join(";", members);
-                if (!string.IsNullOrEmpty(permSet[section]))
+                permSet = string.Join(";", members);
+                if (!string.IsNullOrEmpty(permSet))
                 {
-                    permSet[section] += ";";
+                    permSet += ";";
                 }
 
-                newSet += string.Concat(permSet[section], "|");
-            }
-
-            return newSet;
+            return permSet;
         }
 
         [Obsolete("Deprecated in Community Forums. Removing in 10.00.00. Not Used.")]
         public static string AddPermToSet(string objectId, int objectType, string permissionSet)
         {
-            return AddPermToSet(objectId, (DotNetNuke.Modules.ActiveForums.ObjectType)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.ObjectType), objectType.ToString()), permissionSet);
+            return AddPermToSet(objectId, permissionSet);
         }
 
-        internal static string AddPermToSet(string objectId, DotNetNuke.Modules.ActiveForums.ObjectType objectType, string permissionSet)
+        internal static string AddPermToSet(string objectId, string permissionSet)
         {
-            string newSet = RemovePermFromSet(objectId, objectType, permissionSet);
-            string[] permSet = newSet.Split('|');
-            permSet[(int)objectType] += string.Concat(objectId, ";");
-            newSet = string.Concat(permSet[0] + "|" + (permSet.Length > 1 ? permSet[1] : string.Empty) + "|" + (permSet.Length > 2 ? permSet[2] : string.Empty), "|");
-            return newSet;
+            return GetRoleIds(AddRoleIdToRoleIds(Convert.ToInt32(objectId), GetRoleIdsFromPermSet(permissionSet)));
         }
 
-        internal static bool RemoveObjectFromAll(int moduleId, string objectId, DotNetNuke.Modules.ActiveForums.ObjectType objectType, int permissionsId)
+        internal static HashSet<int> AddRoleIdToRoleIds(int roleId, HashSet<int> roleIds)
+        {
+            roleIds.Add(roleId);
+            return roleIds;
+        }
+
+        internal static bool RemoveObjectFromAll(int moduleId, string objectId, int permissionsId)
         {
             var pc = new DotNetNuke.Modules.ActiveForums.Controllers.PermissionController();
             var permissionInfo = pc.GetById(permissionsId);
             if (permissionInfo != null)
             {
-                permissionInfo = RemoveObjectFromAll(permissionInfo, objectId, objectType);
+                permissionInfo = RemoveObjectFromAll(permissionInfo, objectId);
                 pc.Update(permissionInfo);
             }
 
             return true;
         }
 
-        internal static DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo RemoveObjectFromAll(DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo permissionInfo, string objectId, DotNetNuke.Modules.ActiveForums.ObjectType objectType)
+        internal static DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo RemoveObjectFromAll(DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo permissionInfo, string objectId)
         {
             var enumType = typeof(SecureActions);
             Array values = Enum.GetValues(enumType);
@@ -794,62 +786,58 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             {
                 string requestedAccess = Convert.ToString(Enum.Parse(enumType, values.GetValue(i).ToString()));
                 string permSet = GetPermSetForRequestedAccess(permissionInfo, (DotNetNuke.Modules.ActiveForums.SecureActions)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.SecureActions), requestedAccess));
-                permSet = RemovePermFromSet(objectId, objectType, permSet);
+                permSet = RemovePermFromSet(objectId, permSet);
                 SetPermSetForRequestedAccess(permissionInfo, (DotNetNuke.Modules.ActiveForums.SecureActions)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.SecureActions), requestedAccess), permSet);
             }
 
             return permissionInfo;
         }
 
-        internal static string GetSecureObjectList(IPortalSettings portalSettings, DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo permissionInfo, DotNetNuke.Modules.ActiveForums.ObjectType objectType)
+        internal static string GetSecureObjectList(IPortalSettings portalSettings, DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo permissionInfo)
         {
             string roleObjects = string.Empty;
 
-            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Announce, objectType, roleObjects);
-            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Attach, objectType, roleObjects);
-            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Ban, objectType, roleObjects);
-            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Categorize, objectType, roleObjects);
-            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Create, objectType, roleObjects);
-            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Delete, objectType, roleObjects);
-            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Edit, objectType, roleObjects);
-            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Lock, objectType, roleObjects);
-            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Moderate, objectType, roleObjects);
-            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Move, objectType, roleObjects);
-            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Pin, objectType, roleObjects);
-            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Poll, objectType, roleObjects);
-            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Prioritize, objectType, roleObjects);
-            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Read, objectType, roleObjects);
-            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Reply, objectType, roleObjects);
-            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Split, objectType, roleObjects);
-            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Subscribe, objectType, roleObjects);
-            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Tag, objectType, roleObjects);
-            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Trust, objectType, roleObjects);
-            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.View, objectType, roleObjects);
+            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Announce, roleObjects);
+            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Attach, roleObjects);
+            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Ban, roleObjects);
+            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Categorize, roleObjects);
+            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Create, roleObjects);
+            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Delete, roleObjects);
+            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Edit, roleObjects);
+            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Lock, roleObjects);
+            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Moderate, roleObjects);
+            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Move, roleObjects);
+            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Pin, roleObjects);
+            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Poll, roleObjects);
+            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Prioritize, roleObjects);
+            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Read, roleObjects);
+            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Reply, roleObjects);
+            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Split, roleObjects);
+            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Subscribe, roleObjects);
+            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Tag, roleObjects);
+            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.Trust, roleObjects);
+            roleObjects = GetObjFromSecObj(portalSettings, permissionInfo.View, roleObjects);
 
             return roleObjects;
         }
 
-        private static string GetObjFromSecObj(IPortalSettings portalSettings, string permSet, DotNetNuke.Modules.ActiveForums.ObjectType objectType, string objects)
+        private static string GetObjFromSecObj(IPortalSettings portalSettings, string permSet, string objects)
         {
             if (string.IsNullOrEmpty(permSet))
             {
-                permSet = portalSettings.AdministratorRoleId + ";|||";
+                permSet = portalSettings.AdministratorRoleId.ToString();
             }
 
-            var index = (int)objectType;
-            string[] perms = permSet.Split('|');
-            if (perms[index] != null)
+            string perms = permSet;
+            if (!string.IsNullOrEmpty(perms))
             {
-                if (!string.IsNullOrEmpty(perms[index]))
+                foreach (string s in perms.Split(';'))
                 {
-                    foreach (string s in perms[index].Split(';'))
+                    if (!string.IsNullOrEmpty(s))
                     {
-                        if (!string.IsNullOrEmpty(s))
+                        if (Array.IndexOf(objects.Split(';'), s) == -1)
                         {
-                            if (Array.IndexOf(objects.Split(';'), s) == -1)
-                            {
-                                objects += s + ";";
-                            }
+                            objects += s + ";";
                         }
                     }
                 }

--- a/Dnn.CommunityForums/DnnCommunityForums.dnn
+++ b/Dnn.CommunityForums/DnnCommunityForums.dnn
@@ -75,7 +75,7 @@
             <attributes>
               <businessControllerClass>DotNetNuke.Modules.ActiveForums.TopicsController, DotNetNuke.Modules.ActiveForums</businessControllerClass>
               <desktopModuleID>[DESKTOPMODULEID]</desktopModuleID>
-              <upgradeVersionsList>07.00.07,07.00.11,07.00.12,08.00.00,08.01.00,08.02.00,08.02.02,08.02.03,08.02.04,08.02.08</upgradeVersionsList>
+              <upgradeVersionsList>07.00.07,07.00.11,07.00.12,08.00.00,08.01.00,08.02.00,08.02.02,08.02.03,08.02.04,08.02.08,09.00.00</upgradeVersionsList>
             </attributes>
           </eventMessage>
         </component>

--- a/Dnn.CommunityForums/Entities/PermissionInfo.cs
+++ b/Dnn.CommunityForums/Entities/PermissionInfo.cs
@@ -166,6 +166,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         [IgnoreColumn]
         public HashSet<int> BanRoleIds => DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(this.Ban);
 
+        [Obsolete("Deprecated in Community Forums. Scheduled for removal in 10.00.00. Not Used.")]
         [IgnoreColumn]
         public ObjectType Type { get; set; }
 
@@ -223,45 +224,10 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                 return true;
             }
 
-            var thisPermsRoles = new HashSet<string>();
-            var thisPermsUsers = new HashSet<string>();
-            var thisPermsGroups = new HashSet<string>();
-            var thisPerms = thisPermissions.Split("|".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
-            if (thisPerms.Length > 0 && !string.IsNullOrEmpty(thisPerms[0]))
-            {
-                thisPermsRoles = thisPerms[0].Split(";".ToCharArray(), StringSplitOptions.RemoveEmptyEntries).ToHashSet();
-            }
-
-            if (thisPerms.Length > 1 && !string.IsNullOrEmpty(thisPerms[1]))
-            {
-                thisPermsUsers = thisPerms[1].Split(";".ToCharArray(), StringSplitOptions.RemoveEmptyEntries).ToHashSet();
-            }
-
-            if (thisPerms.Length > 2 && !string.IsNullOrEmpty(thisPerms[2]))
-            {
-                thisPermsGroups = thisPerms[2].Split(";".ToCharArray(), StringSplitOptions.RemoveEmptyEntries).ToHashSet();
-            }
-
-            var otherPermsRoles = new HashSet<string>();
-            var otherPermsUsers = new HashSet<string>();
-            var otherPermsGroups = new HashSet<string>();
-            var otherPerms = otherPermissions.Split("|".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
-            if (otherPerms.Length > 0 && !string.IsNullOrEmpty(otherPerms[0]))
-            {
-                otherPermsRoles = otherPerms[0].Split(";".ToCharArray(), StringSplitOptions.RemoveEmptyEntries).ToHashSet();
-            }
-
-            if (otherPerms.Length > 1 && !string.IsNullOrEmpty(otherPerms[1]))
-            {
-                otherPermsUsers = otherPerms[1].Split(";".ToCharArray(), StringSplitOptions.RemoveEmptyEntries).ToHashSet();
-            }
-
-            if (otherPerms.Length > 2 && !string.IsNullOrEmpty(otherPerms[2]))
-            {
-                otherPermsGroups = otherPerms[2].Split(";".ToCharArray(), StringSplitOptions.RemoveEmptyEntries).ToHashSet();
-            }
-
-            return thisPermsRoles.SetEquals(otherPermsRoles) && thisPermsUsers.SetEquals(otherPermsUsers) && thisPermsGroups.SetEquals(otherPermsGroups);
+            var thisPermsRoles= thisPermissions.Split(";".ToCharArray(), StringSplitOptions.RemoveEmptyEntries).ToHashSet();
+            var otherPermsRoles = otherPermissions.Split(";".ToCharArray(), StringSplitOptions.RemoveEmptyEntries).ToHashSet();
+            
+            return thisPermsRoles.SetEquals(otherPermsRoles);
         }
 
         internal string GetCacheKey() => string.Format(this.cacheKeyTemplate, this.ModuleId, this.PermissionsId);

--- a/Dnn.CommunityForums/Services/AdminServiceController.cs
+++ b/Dnn.CommunityForums/Services/AdminServiceController.cs
@@ -163,8 +163,6 @@ namespace DotNetNuke.Modules.ActiveForums
 
             public string SecurityId { get; set; }
 
-            public int SecurityType { get; set; }
-
             public string SecurityAccessRequested { get; set; }
 
             public string ReturnId { get; set; }
@@ -177,28 +175,15 @@ namespace DotNetNuke.Modules.ActiveForums
             {
                 case "delete":
                     {
-                        DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.RemoveObjectFromAll(dto.ModuleId, dto.SecurityId, (DotNetNuke.Modules.ActiveForums.ObjectType)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.ObjectType), dto.SecurityType.ToString()), dto.PermissionsId);
+                        DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.RemoveObjectFromAll(dto.ModuleId, dto.SecurityId, dto.PermissionsId);
                         return this.Request.CreateResponse(HttpStatusCode.OK);
                     }
 
                 case "addobject":
                     {
-                        if (dto.SecurityType == 1)
-                        {
-                            var ui = new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ActiveModule.ModuleID).GetByUserId(this.ActiveModule.PortalID, Convert.ToInt32(dto.SecurityId));
-                            dto.SecurityId = ui != null ? ui.UserId.ToString() : string.Empty;
-                        }
-                        else
-                        {
-                            if (dto.SecurityId.Contains(":"))
-                            {
-                                dto.SecurityType = 2;
-                            }
-                        }
-
                         if (!string.IsNullOrEmpty(dto.SecurityId))
                         {
-                            DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermissions(dto.ModuleId, dto.PermissionsId, DotNetNuke.Modules.ActiveForums.SecureActions.View, dto.SecurityId, (DotNetNuke.Modules.ActiveForums.ObjectType)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.ObjectType), dto.SecurityType.ToString()));
+                            DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermissions(dto.ModuleId, dto.PermissionsId, DotNetNuke.Modules.ActiveForums.SecureActions.View, dto.SecurityId);
                         }
 
                         return this.Request.CreateResponse(HttpStatusCode.OK);
@@ -208,11 +193,11 @@ namespace DotNetNuke.Modules.ActiveForums
                     {
                         if (dto.Action == "remove")
                         {
-                            DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.RemoveObjectFromPermissions(dto.ModuleId, dto.PermissionsId, (DotNetNuke.Modules.ActiveForums.SecureActions)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.SecureActions), dto.SecurityAccessRequested), dto.SecurityId, (DotNetNuke.Modules.ActiveForums.ObjectType)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.ObjectType), dto.SecurityType.ToString()));
+                            DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.RemoveObjectFromPermissions(dto.ModuleId, dto.PermissionsId, (DotNetNuke.Modules.ActiveForums.SecureActions)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.SecureActions), dto.SecurityAccessRequested), dto.SecurityId);
                         }
                         else
                         {
-                            DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermissions(dto.ModuleId, dto.PermissionsId, (DotNetNuke.Modules.ActiveForums.SecureActions)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.SecureActions), dto.SecurityAccessRequested), dto.SecurityId, (DotNetNuke.Modules.ActiveForums.ObjectType)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.ObjectType), dto.SecurityType.ToString()));
+                            DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermissions(dto.ModuleId, dto.PermissionsId, (DotNetNuke.Modules.ActiveForums.SecureActions)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.SecureActions), dto.SecurityAccessRequested), dto.SecurityId);
                         }
 
                         return this.Request.CreateResponse(HttpStatusCode.OK, dto.Action + "|" + dto.ReturnId);

--- a/Dnn.CommunityForums/class/Data/AttachmentsDB.cs
+++ b/Dnn.CommunityForums/class/Data/AttachmentsDB.cs
@@ -107,7 +107,7 @@ namespace DotNetNuke.Modules.ActiveForums.Data
 
             if (dr.HasColumn("CanRead"))
             {
-                result.CanRead = Utilities.SafeConvertString(dr["CanRead"], "0;1;" + DotNetNuke.Common.Globals.glbRoleUnauthUser + ";" + DotNetNuke.Common.Globals.glbRoleAllUsers + ";|||"); // Default to public read permissions
+                result.CanRead = Utilities.SafeConvertString(dr["CanRead"], Globals.DefaultAnonRoles); // Default to public read permissions
             }
 
             return result;

--- a/Dnn.CommunityForums/class/ForumsConfig.cs
+++ b/Dnn.CommunityForums/class/ForumsConfig.cs
@@ -267,15 +267,16 @@ namespace DotNetNuke.Modules.ActiveForums
                     {
                         /* during upgrade, explicitly (re-)load template text from database rather than Template_List API since API loads template using fallback/default logic and doesn't yet have the upgraded template text */
                         /* if installing version 8.2 or greater, only convert specific templates */
-                        if ((Globals.ModuleVersion < new Version(8, 2)) ||
-                            ((templateInfo.TemplateType == Templates.TemplateTypes.ForumView) ||
-                             (templateInfo.TemplateType == Templates.TemplateTypes.TopicView) ||
-                             (templateInfo.TemplateType == Templates.TemplateTypes.TopicsView) ||
-                             (templateInfo.TemplateType == Templates.TemplateTypes.TopicForm) ||
-                             (templateInfo.TemplateType == Templates.TemplateTypes.ReplyForm) ||
-                             (templateInfo.TemplateType == Templates.TemplateTypes.Profile) ||
-                             (templateInfo.TemplateType == Templates.TemplateTypes.PostInfo) ||
-                             (templateInfo.TemplateType == Templates.TemplateTypes.QuickReplyForm)))
+                        if ((Globals.ModuleVersion < new Version(8, 2)) || 
+                            ((templateInfo.TemplateType == Templates.TemplateTypes.ForumView) || 
+                             (templateInfo.TemplateType == Templates.TemplateTypes.TopicView) || 
+                             (templateInfo.TemplateType == Templates.TemplateTypes.TopicsView) || 
+                             (templateInfo.TemplateType == Templates.TemplateTypes.TopicForm) || 
+                             (templateInfo.TemplateType == Templates.TemplateTypes.ReplyForm) || 
+                             (templateInfo.TemplateType == Templates.TemplateTypes.Profile) || 
+                             (templateInfo.TemplateType == Templates.TemplateTypes.PostInfo) || 
+                             (templateInfo.TemplateType == Templates.TemplateTypes.QuickReplyForm))
+                            )
                         {
                             IDataReader dr = DataProvider.Instance().Templates_Get(templateInfo.TemplateId, templateInfo.PortalId, templateInfo.ModuleId);
                             while (dr.Read())
@@ -739,35 +740,34 @@ namespace DotNetNuke.Modules.ActiveForums
             }
         }
 
-        // internal static void Sort_PermissionSets_080200()
-        // {
-        //    foreach (var perms in new DotNetNuke.Modules.ActiveForums.Controllers.PermissionController().Get())
-        //    {
-        //        perms.Announce = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.SortPermissionSetMembers(perms.Announce);
-        //        perms.Attach = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.SortPermissionSetMembers(perms.Attach);
-        //        perms.Ban = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.SortPermissionSetMembers(perms.Ban);
-        //        perms.Block = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.SortPermissionSetMembers(perms.Block);
-        //        perms.Categorize = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.SortPermissionSetMembers(perms.Categorize);
-        //        perms.Create = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.SortPermissionSetMembers(perms.Create);
-        //        perms.Delete = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.SortPermissionSetMembers(perms.Delete);
-        //        perms.Edit = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.SortPermissionSetMembers(perms.Edit);
-        //        perms.Lock = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.SortPermissionSetMembers(perms.Lock);
-        //        perms.Moderate = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.SortPermissionSetMembers(perms.Moderate);
-        //        perms.Move = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.SortPermissionSetMembers(perms.Move);
-        //        perms.Pin = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.SortPermissionSetMembers(perms.Pin);
-        //        perms.Poll = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.SortPermissionSetMembers(perms.Poll);
-        //        perms.Prioritize = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.SortPermissionSetMembers(perms.Prioritize);
-        //        perms.Read = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.SortPermissionSetMembers(perms.Read);
-        //        perms.Reply = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.SortPermissionSetMembers(perms.Reply);
-        //        perms.Split = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.SortPermissionSetMembers(perms.Split);
-        //        perms.Subscribe = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.SortPermissionSetMembers(perms.Subscribe);
-        //        perms.Tag = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.SortPermissionSetMembers(perms.Tag);
-        //        perms.Trust = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.SortPermissionSetMembers(perms.Trust);
-        //        perms.View = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.SortPermissionSetMembers(perms.View);
-        //        new DotNetNuke.Modules.ActiveForums.Controllers.PermissionController().Update(perms);
+        internal static void Upgrade_PermissionSets_090000()
+        {
+            foreach (var perms in new DotNetNuke.Modules.ActiveForums.Controllers.PermissionController().Get())
+            {
+                perms.Announce = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Announce).ToString();
+                perms.Attach = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Attach).ToString();
+                perms.Ban = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Ban).ToString();
+                perms.Block = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Block).ToString();
+                perms.Categorize = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Categorize).ToString();
+                perms.Create = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Create).ToString();
+                perms.Delete = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Delete).ToString();
+                perms.Edit = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Edit).ToString();
+                perms.Lock = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Lock).ToString();
+                perms.Moderate = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Moderate).ToString();
+                perms.Move = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Move).ToString();
+                perms.Pin = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Pin).ToString().ToString();
+                perms.Poll = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Poll).ToString();
+                perms.Prioritize = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Prioritize).ToString();
+                perms.Read = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Read).ToString();
+                perms.Reply = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Reply).ToString();
+                perms.Split = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Split).ToString();
+                perms.Subscribe = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Subscribe).ToString();
+                perms.Tag = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Tag).ToString();
+                perms.Trust = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Trust).ToString();
+                perms.View = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.View).ToString();
+                new DotNetNuke.Modules.ActiveForums.Controllers.PermissionController().Update(perms);
 
-        // }
-
-        // }
+            }
+        }
     }
 }

--- a/Dnn.CommunityForums/class/ForumsConfig.cs
+++ b/Dnn.CommunityForums/class/ForumsConfig.cs
@@ -744,27 +744,27 @@ namespace DotNetNuke.Modules.ActiveForums
         {
             foreach (var perms in new DotNetNuke.Modules.ActiveForums.Controllers.PermissionController().Get())
             {
-                perms.Announce = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Announce).ToString();
-                perms.Attach = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Attach).ToString();
-                perms.Ban = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Ban).ToString();
-                perms.Block = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Block).ToString();
-                perms.Categorize = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Categorize).ToString();
-                perms.Create = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Create).ToString();
-                perms.Delete = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Delete).ToString();
-                perms.Edit = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Edit).ToString();
-                perms.Lock = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Lock).ToString();
-                perms.Moderate = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Moderate).ToString();
-                perms.Move = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Move).ToString();
-                perms.Pin = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Pin).ToString().ToString();
-                perms.Poll = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Poll).ToString();
-                perms.Prioritize = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Prioritize).ToString();
-                perms.Read = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Read).ToString();
-                perms.Reply = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Reply).ToString();
-                perms.Split = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Split).ToString();
-                perms.Subscribe = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Subscribe).ToString();
-                perms.Tag = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Tag).ToString();
-                perms.Trust = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Trust).ToString();
-                perms.View = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.View).ToString();
+                perms.Announce = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Announce));
+                perms.Attach = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Attach));
+                perms.Ban = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Ban));
+                perms.Block = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Block));
+                perms.Categorize = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Categorize));
+                perms.Create = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Create));
+                perms.Delete = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Delete));
+                perms.Edit = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Edit));
+                perms.Lock = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Lock));
+                perms.Moderate = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Moderate));
+                perms.Move = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Move));
+                perms.Pin = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Pin));
+                perms.Poll = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Poll));
+                perms.Prioritize = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Prioritize));
+                perms.Read = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Read));
+                perms.Reply = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Reply));
+                perms.Split = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Split));
+                perms.Subscribe = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Subscribe));
+                perms.Tag = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Tag));
+                perms.Trust = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.Trust));
+                perms.View = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIds(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(perms.View));
                 new DotNetNuke.Modules.ActiveForums.Controllers.PermissionController().Update(perms);
 
             }

--- a/Dnn.CommunityForums/class/Permissions.cs
+++ b/Dnn.CommunityForums/class/Permissions.cs
@@ -49,6 +49,7 @@ namespace DotNetNuke.Modules.ActiveForums
         Ban,
     }
 
+    [Obsolete("Deprecated in Community Forums. Removed in 10.00.00. Not Used.")]
     public enum ObjectType : int
     {
         RoleId,

--- a/Dnn.CommunityForums/components/Topics/TopicsController.cs
+++ b/Dnn.CommunityForums/components/Topics/TopicsController.cs
@@ -289,8 +289,6 @@ namespace DotNetNuke.Modules.ActiveForums
                         DotNetNuke.Modules.ActiveForums.Helpers.UpgradeModuleSettings.AddUrlPrefixLikes_080200();
                         ForumsConfig.Install_LikeNotificationType_080200();
                         ForumsConfig.Install_PinNotificationType_080200();
-
-                        // ForumsConfig.Sort_PermissionSets_080200();
                     }
                     catch (Exception ex)
                     {
@@ -304,6 +302,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     try
                     {
                         DotNetNuke.Modules.ActiveForums.Helpers.UpgradeModuleSettings.DeleteObsoleteModuleSettings_090000();
+                        ForumsConfig.Upgrade_PermissionSets_090000();
                     }
                     catch (Exception ex)
                     {

--- a/Dnn.CommunityForums/controls/admin_securitygrid.ascx
+++ b/Dnn.CommunityForums/controls/admin_securitygrid.ascx
@@ -2,40 +2,31 @@
 <%@ Register TagPrefix="am" Namespace="DotNetNuke.Modules.ActiveForums.Controls" Assembly="DotNetNuke.Modules.ActiveForums" %>
 <script type="text/javascript">
     
-    function addObject(type){
+    function addObject(){
         currAction = 'addobject';
-        if (type == 0){
-            var ddlRole = document.getElementById("drpSecRoles");
-            var objectName = ddlRole.options[ddlRole.selectedIndex].text;
-            var objectId = ddlRole.options[ddlRole.selectedIndex].value;
-            if (objectId !=''){
-                ddlRole.selectedIndex = 0;
-                securityAddObject(<%=PermissionsId%>,objectId,objectName,0);
-            };
-
-        }else if (type == 1){
-            var objectName = document.getElementById("<%=txtUserName.ClientID%>").value;
-            if (objectName != ''){
-                securityAddObject(-1,objectName,objectName,1);
-
-            };
+        var ddlRole = document.getElementById("drpSecRoles");
+        var objectName = ddlRole.options[ddlRole.selectedIndex].text;
+        var objectId = ddlRole.options[ddlRole.selectedIndex].value;
+        if (objectId !=''){
+            ddlRole.selectedIndex = 0;
+            securityAddObject(<%=PermissionsId%>,objectId,objectName,0);
         };
-};
+    };
 
 var rebuild = false;
 
-function securityDelObject(obj,oid,otype,pid){
+function securityDelObject(obj,oid,pid){
     if(confirm('[RESX:Actions:DeleteConfirm]')){
         rebuild = true;
         af_showLoad();
-        securityCallback('delete', -1, pid, oid, '', otype, '', securityToggleComplete);
+        securityCallback('delete', -1, pid, oid, '', '', securityToggleComplete);
     };
 };
 
-function securityAddObject(pid,secId,secName,secType){
+function securityAddObject(pid,secId,secName){
     af_showLoad();
     selectedTab = 'divSecurity';
-    securityCallback('addobject', -1, pid, secId, secName, secType, '', securityToggleComplete);      
+    securityCallback('addobject', -1, pid, secId, secName, '', securityToggleComplete);      
     rebuild = true;
 };
 
@@ -64,13 +55,12 @@ function secGridComplete(){
     af_clearLoad();
 };
 
-function securityCallback(action, returnId, pid, secId,secName, secType, accessReq, callback) {
+function securityCallback(action, returnId, pid, secId,secName, accessReq, callback) {
     var data = {};
     data.ModuleId = <%=ModuleId%>;
     data.Action = action;
     data.PermissionsId = pid;
     data.SecurityId = secId;
-    data.SecurityType = secType;
     data.SecurityAccessRequested = accessReq;
     data.ReturnId = returnId;
     var sf = $.ServicesFramework(<%=ModuleId%>);
@@ -90,7 +80,7 @@ function securityCallback(action, returnId, pid, secId,secName, secType, accessR
     });
 };
 
-function securityToggle(obj,pid,secId,secName,secType,key) {
+function securityToggle(obj,pid,secId,secName,key) {
     var returnId = obj.id;
     var img = obj.firstChild;
     if (img.src == imgOn.src){
@@ -100,7 +90,7 @@ function securityToggle(obj,pid,secId,secName,secType,key) {
     };
     img.src = imgSpin.src;
     img.setAttribute('alt','Please Wait');
-    securityCallback(currAction, returnId, pid, secId, secName, secType, key, securityToggleComplete);           
+    securityCallback(currAction, returnId, pid, secId, secName, key, securityToggleComplete);           
 };
 
 </script>
@@ -123,27 +113,6 @@ function securityToggle(obj,pid,secId,secName,secType,key) {
                         </td>
                     </tr>
                 </table>
-            </td>
-            <!-- Note: this is an artifact from where there used to be user-specific security -- leaving this here for now  but setting display:none to remove ugly gap -->
-            <td style="display: none; width: 5%"></td>
-            <td style="display: none;" class="amroles" align="right">
-                <div style="display: none;">
-                    <table cellpadding="0" cellspacing="2">
-                        <tr>
-                            <td style="width: 12px;">
-                                <img id="Img44" src="~/DesktopModules/ActiveForums/images/tooltip.png" runat="server" onmouseover="amShowTip(this, '[RESX:Tips:AddUser]');" onmouseout="amHideTip(this);" /></td>
-                            <td>[RESX:UserName]:</td>
-                            <td style="width: 150px;">
-                                <asp:TextBox ID="txtUserName" runat="server" CssClass="amcptxtbx" Width="150" /></td>
-                            <td style="width: 16px;">
-                                <div class="amcplnkbtn" style="width: 16px;" onclick="addObject(1);">
-                                    <img id="Img42" src="~/DesktopModules/ActiveForums/images/add.png" runat="server" alt="[RESX:AddUserName]" />
-                                </div>
-                            </td>
-                        </tr>
-                    </table>
-                </div>
-
             </td>
         </tr>
     </table>

--- a/Dnn.CommunityForums/controls/admin_securitygrid.ascx.cs
+++ b/Dnn.CommunityForums/controls/admin_securitygrid.ascx.cs
@@ -81,7 +81,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
         private void BuildNewGrid(DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo security, int permissionsId)
         {
             // Roles
-            string[] roles = this.GetSecureObjectList(security, 0).Split(';');
+            string[] roles = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetSecureObjectList(this.PortalSettings, security).Split(';');
             int[] roleIds = new int[roles.Length - 2 + 1];
             int i = 0;
             for (i = 0; i <= roles.Length - 2; i++)
@@ -112,63 +112,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     pi.ObjectName = DotNetNuke.Security.Roles.RoleController.Instance.GetRoleById(portalId: this.PortalId, roleId: Convert.ToInt32(key)).RoleName;
                 }
 
-                pi.Type = ObjectType.RoleId;
                 pl.Add(pi);
-            }
-
-            // Users
-            string users = this.GetSecureObjectList(security, 1);
-            string userNames = string.Empty;
-            if (!string.IsNullOrEmpty(users))
-            {
-                foreach (string uid in users.Split(';'))
-                {
-                    if (!string.IsNullOrEmpty(uid))
-                    {
-                        DotNetNuke.Entities.Users.UserInfo u = DotNetNuke.Entities.Users.UserController.Instance.GetUser(this.PortalId, Convert.ToInt32(uid));
-                        if (u != null)
-                        {
-                            DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo pi = new DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo();
-                            pi.ObjectId = u.UserID.ToString();
-                            pi.ObjectName = u.DisplayName;
-                            pi.Type = ObjectType.UserId;
-                            pl.Add(pi);
-                        }
-                    }
-                }
-            }
-
-            // Groups
-            string groups = this.GetSecureObjectList(security, 2);
-            if (!string.IsNullOrEmpty(groups))
-            {
-                foreach (string g in groups.Split(';'))
-                {
-                    if (!string.IsNullOrEmpty(g))
-                    {
-                        string gType = g.Split(':')[1];
-                        int groupId = Convert.ToInt32(g.Split(':')[0]);
-                        RoleInfo role = DotNetNuke.Security.Roles.RoleController.Instance.GetRoleById(portalId: this.PortalId, roleId: groupId);
-                        string groupName = role.RoleName;
-                        if (!string.IsNullOrEmpty(groupName))
-                        {
-                            DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo pi = new DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo();
-                            pi.ObjectId = g;
-                            pi.ObjectName = groupName;
-                            pi.Type = ObjectType.GroupId;
-                            if (Convert.ToInt32(gType) == 0)
-                            {
-                                pi.ObjectName += " - Owner";
-                            }
-                            else
-                            {
-                                pi.ObjectName += " - Member";
-                            }
-
-                            pl.Add(pi);
-                        }
-                    }
-                }
             }
 
             var gridSecurityActions = new string[][,]
@@ -223,7 +167,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 }
 
                 i = 0;
-                string[,] grid = new string[pl.Count + 1, 3 + gridSecurityActions[gridIndex].GetUpperBound(0) + 1];
+                string[,] grid = new string[pl.Count + 1, 2 + gridSecurityActions[gridIndex].GetUpperBound(0) + 1];
 
                 sb.Append($"<h6>{gridHeader}</h6>");
                 sb.Append("<table class=\"dcf-sec-grid\"><tr><td class=\"dcf-sec-grid-roles\"><div class=\"afsecobjects\"><table>");
@@ -233,18 +177,17 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 {
                     grid[i, 0] = pi.ObjectId;
                     grid[i, 1] = pi.ObjectName;
-                    grid[i, 2] = Convert.ToInt16(pi.Type).ToString();
                     for (int j = gridSecurityActions[gridIndex].GetLowerBound(0); j <= gridSecurityActions[gridIndex].GetUpperBound(0); j++)
                     {
-                        grid[i, j + 3] = Convert.ToString(this.PermValue((int)pi.Type, pi.ObjectId, gridSecurityActions[gridIndex][j, 1]));
+                        grid[i, j + 2] = Convert.ToString(this.PermValue(pi.ObjectId, gridSecurityActions[gridIndex][j, 1]));
                     }
 
                     sb.Append("<tr><td style=\"width:16px;\"></td><td class=\"afsecobject\" style=\"white-space:nowrap;\"><div class=\"afsecobjecttxt\" title=\"" + grid[i, 1] + "\" onmouseover=\"this.firstChild.style.display='';\" onmouseout=\"this.firstChild.style.display='none';\"><span style=\"width:16px;height:16px;float:right;display:none;\">");
-                    if ((Convert.ToInt32(grid[i, 2]) == 0 && Convert.ToInt32(grid[i, 0]) > 0) | Convert.ToInt32(grid[i, 2]) > 0)
+                    if (Convert.ToInt32(grid[i, 0]) > 0)
                     {
                         if (!this.ReadOnly)
                         {
-                            sb.Append("<img src=\"" + this.Page.ResolveUrl(Globals.ModulePath + "images/mini_del.gif") + "\" alt=\"Remove Object\" style=\"cursor:pointer;z-index:10;\" class=\"afminidel\" onclick=\"securityDelObject(this,'" + grid[i, 0] + "'," + grid[i, 2] + "," + permissionsId + ");\" />");
+                            sb.Append("<img src=\"" + this.Page.ResolveUrl(Globals.ModulePath + "images/mini_del.gif") + "\" alt=\"Remove Object\" style=\"cursor:pointer;z-index:10;\" class=\"afminidel\" onclick=\"securityDelObject(this,'" + grid[i, 0] + "'," + permissionsId + ");\" />");
                         }
                     }
 
@@ -282,14 +225,14 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 for (int x = 0; x < pl.Count; x++)
                 {
                     sb.Append("<tr onmouseover=\"this.className='afgridrowover'\" onmouseout=\"this.className='afgridrow'\">");
-                    for (int r = gridSecurityActions[gridIndex].GetLowerBound(0) + 3; r <= gridSecurityActions[gridIndex].GetUpperBound(0) + 3; r++)
+                    for (int r = gridSecurityActions[gridIndex].GetLowerBound(0) + 2; r <= gridSecurityActions[gridIndex].GetUpperBound(0) + 2; r++)
                     {
-                        keyText = gridSecurityActions[gridIndex][r - 3, 0];
+                        keyText = gridSecurityActions[gridIndex][r - 2, 0];
                         sb.Append("<td class=\"afsecactionelem\" style=\"text-align:center;\">");
-                        sb.Append($"<div class=\"afsectoggle\" id=\"{grid[x, 0]}{grid[x, 2]}{keyText}\"");
+                        sb.Append($"<div class=\"afsectoggle\" id=\"{grid[x, 0]}{keyText}\"");
                         if (!this.ReadOnly)
                         {
-                            sb.Append($"onclick=\"securityToggle(this,{permissionsId},'{grid[x, 0]}','{grid[x, 1]}', {grid[x, 2]},'{keyText}');\"");
+                            sb.Append($"onclick=\"securityToggle(this,{permissionsId},'{grid[x, 0]}','{grid[x, 1]}','{keyText}');\"");
                         }
 
                         sb.Append(">" + (Convert.ToBoolean(grid[x, r]) ? $"<img src=\"{this.imgOn}\" alt=\"Enabled\" />" : $"<img src=\"{this.imgOff}\" alt=\"Disabled\" />") + "</div></td>");
@@ -305,21 +248,13 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             this.litSecGrid.Text = sb.ToString();
         }
 
-        private bool PermValue(int objectType, string objectId, string permSet)
+        private bool PermValue(string objectId, string permSet)
         {
             if (string.IsNullOrEmpty(permSet))
             {
                 return false;
             }
-            else
-            {
-                return DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasAccess(permSet.Split('|')[objectType], objectId + ";");
-            }
-        }
-
-        private string GetSecureObjectList(DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo s, int objectType)
-        {
-            return DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetSecureObjectList(this.PortalSettings, s, (DotNetNuke.Modules.ActiveForums.ObjectType)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.ObjectType), objectType.ToString()));
+            return DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasAccess(permSet, objectId + ";");
         }
 
         private void cbSecurityToggle_Callback(object sender, CallBackEventArgs e)
@@ -327,50 +262,29 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             string action = e.Parameters[0].ToString();
             int pId = this.PermissionsId;
             string secId = e.Parameters[2].ToString();
-            int secType = Convert.ToInt32(e.Parameters[3].ToString());
-            string key = e.Parameters[4].ToString();
-            string returnId = e.Parameters[5].ToString();
+            string key = e.Parameters[3].ToString();
+            string returnId = e.Parameters[4].ToString();
             string sOut = string.Empty;
             if (action == "delete")
             {
-                DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.RemoveObjectFromAll(this.ModuleId, secId, (DotNetNuke.Modules.ActiveForums.ObjectType)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.ObjectType), secType.ToString()), pId);
+                DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.RemoveObjectFromAll(this.ModuleId, secId, pId);
             }
             else if (action == "addobject")
             {
-                if (secType == 1)
-                {
-                    var ui = new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ModuleId).GetByUserId(this.PortalId, Convert.ToInt32(secId));
-                    if (ui != null)
-                    {
-                        secId = ui.UserId.ToString();
-                    }
-                    else
-                    {
-                        secId = string.Empty;
-                    }
-                }
-                else
-                {
-                    if (secId.Contains(":"))
-                    {
-                        secType = 2;
-                    }
-                }
-
                 if (!string.IsNullOrEmpty(secId))
                 {
-                    DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermissions(this.ModuleId, pId, DotNetNuke.Modules.ActiveForums.SecureActions.View, secId, (DotNetNuke.Modules.ActiveForums.ObjectType)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.ObjectType), secType.ToString()));
+                    DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermissions(this.ModuleId, pId, DotNetNuke.Modules.ActiveForums.SecureActions.View, secId);
                 }
             }
             else
             {
                 if (action == "remove")
                 {
-                    DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.RemoveObjectFromPermissions(this.ModuleId, pId, (DotNetNuke.Modules.ActiveForums.SecureActions)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.SecureActions), key), secId, (DotNetNuke.Modules.ActiveForums.ObjectType)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.ObjectType), secType.ToString()));
+                    DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.RemoveObjectFromPermissions(this.ModuleId, pId, (DotNetNuke.Modules.ActiveForums.SecureActions)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.SecureActions), key), secId);
                 }
                 else
                 {
-                    DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermissions(this.ModuleId, pId, (DotNetNuke.Modules.ActiveForums.SecureActions)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.SecureActions), key), secId, (DotNetNuke.Modules.ActiveForums.ObjectType)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.ObjectType), secType.ToString()));
+                    DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermissions(this.ModuleId, pId, (DotNetNuke.Modules.ActiveForums.SecureActions)Enum.Parse(typeof(DotNetNuke.Modules.ActiveForums.SecureActions), key), secId);
                 }
 
                 sOut = action + "|" + returnId;

--- a/Dnn.CommunityForumsTests/Controllers/PermissionControllerTests.cs
+++ b/Dnn.CommunityForumsTests/Controllers/PermissionControllerTests.cs
@@ -1,4 +1,20 @@
-﻿// Copyright (c) by DNN Community
+﻿using NUnit.Framework;
+using DotNetNuke.Modules.ActiveForums.Controllers;
+
+namespace DotNetNuke.Modules.ActiveForums.Controllers.Tests
+{
+    [TestFixture()]
+    public class PermissionControllerTests
+    {
+        [Test()]
+        public void GetRoleIdsTest()
+        {
+            Assert.Fail();
+        }
+    }
+}
+
+// Copyright (c) by DNN Community
 //
 // DNN Community licenses this file to you under the MIT license.
 //
@@ -202,7 +218,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Controllers
         public void GetRoleIdsFromPermSetTest()
         {
             // Arrange
-            var permSet = "-1;3;4|;|";
+            var permSet = "-1;3;4";
             var expectedResult = new HashSet<int> { -1, 3, 4 };
 
             // Act
@@ -289,8 +305,8 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Controllers
 
         // Permission set manipulation tests
         [Test]
-        [TestCase(arg1: "0;1;-3;-1;38;||", arg2: "0;1;-1;-3;38;||", ExpectedResult = true)]
-        [TestCase(arg1: "0;1;-1;-3;38;|||", arg2: "0;1;-1;-3;38;||", ExpectedResult = true)]
+        [TestCase(arg1: "0;1;-3;-1;38", arg2: "0;1;-1;-3;38;", ExpectedResult = true)]
+        [TestCase(arg1: "0;1;-1;-3;38;", arg2: "0;1;-1;-3;38;", ExpectedResult = true)]
         public bool SortPermissionSetMembersTest(string permSet, string expectedResults)
         {
             // Arrange
@@ -303,7 +319,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Controllers
         public void AddPermToSetTest()
         {
             // Arrange
-            const string emptyPermissions = ";|||";
+            const string emptyPermissions = "";
             var mockPermissions = new Mock<DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo>
             {
                 Object =
@@ -331,13 +347,12 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Controllers
             };
 
             var permSet = mockPermissions.Object.View;
-            var objType = DotNetNuke.Modules.ActiveForums.ObjectType.RoleId;
             var objId = DotNetNuke.Tests.Utilities.Constants.RoleID_Administrators;
 
-            var expectedResult = $"{DotNetNuke.Tests.Utilities.Constants.RoleID_RegisteredUsers};{DotNetNuke.Tests.Utilities.Constants.RoleID_Administrators}{emptyPermissions}";
+            var expectedResult = $"{DotNetNuke.Tests.Utilities.Constants.RoleID_Administrators};{DotNetNuke.Tests.Utilities.Constants.RoleID_RegisteredUsers}";
 
             // Act
-            var actualResult = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddPermToSet(objId.ToString(), objType, permSet);
+            var actualResult = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddPermToSet(objId.ToString(), permSet);
 
             // Assert
             Assert.That(actualResult, Is.EqualTo(expectedResult));
@@ -347,7 +362,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Controllers
         public void RemovePermFromSetTest()
         {
             // Arrange
-            const string emptyPermissions = ";|||";
+            const string emptyPermissions = "";
             var mockPermissions = new Mock<DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo>
             {
                 Object =
@@ -375,13 +390,12 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Controllers
             };
 
             var permSet = mockPermissions.Object.View;
-            var objType = DotNetNuke.Modules.ActiveForums.ObjectType.RoleId;
             var objId = DotNetNuke.Tests.Utilities.Constants.RoleID_Administrators;
 
             var expectedResult = $"{DotNetNuke.Tests.Utilities.Constants.RoleID_RegisteredUsers}{emptyPermissions}";
 
             // Act
-            var actualResult = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.RemovePermFromSet(objId.ToString(), objType, permSet);
+            var actualResult = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.RemovePermFromSet(objId.ToString(), permSet);
 
             // Assert
             Assert.That(actualResult, Is.EqualTo(expectedResult));
@@ -391,7 +405,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Controllers
         public void GetPermSetForRequestedAccessTest()
         {
             // Arrange
-            const string emptyPermissions = ";|||";
+            const string emptyPermissions = "";
             var mockPermissions = new Mock<DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo>
             {
                 Object =
@@ -441,7 +455,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Controllers
         public void AddObjectToPermSetTest()
         {
             // Arrange
-            const string emptyPermissions = ";|||";
+            const string emptyPermissions = "";
             var mockPermissions = new Mock<DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo>
             {
                 Object =
@@ -468,7 +482,6 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Controllers
                 },
             };
             var requestedAction = mockPermissions.Object.View;
-            var objType = DotNetNuke.Modules.ActiveForums.ObjectType.RoleId;
             var objId = DotNetNuke.Tests.Utilities.Constants.RoleID_Administrators;
 
             var expectedResult = new Mock<DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo>
@@ -498,7 +511,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Controllers
                 };
 
             // Act
-            var actualResult = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermSet(mockPermissions.Object, SecureActions.View, objId.ToString(), objType);
+            var actualResult = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.AddObjectToPermSet(mockPermissions.Object, SecureActions.View, objId.ToString());
 
             // Assert
             Assert.That(actualResult.EqualPermissions(expectedResult.Object), Is.True);
@@ -508,7 +521,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Controllers
         public void RemoveObjectFromAllTest()
         {
             // Arrange
-            const string emptyPermissions = ";|||";
+            const string emptyPermissions = "";
             var registeredUsersRoleId = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRegisteredUsersRoleId(portalSettings: DotNetNuke.Entities.Portals.PortalController.Instance.GetCurrentPortalSettings()).ToString();
             var mockPermissions = new Mock<DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo>
             {
@@ -537,7 +550,6 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Controllers
                 },
             };
 
-            var objType = DotNetNuke.Modules.ActiveForums.ObjectType.RoleId;
             var objId = DotNetNuke.Tests.Utilities.Constants.RoleID_Administrators;
 
             var expectedResult = new Mock<DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo>
@@ -568,7 +580,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Controllers
                 };
 
             // Act
-            var actualResult = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.RemoveObjectFromAll(mockPermissions.Object, objId.ToString(), objType);
+            var actualResult = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.RemoveObjectFromAll(mockPermissions.Object, objId.ToString());
 
             // Assert
             Assert.That(actualResult.EqualPermissions(expectedResult.Object), Is.True);
@@ -579,7 +591,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Controllers
         public void GetDefaultPermissionsTest()
         {
             // Arrange
-            const string emptyPermissions = ";|||";
+            const string emptyPermissions = "";
             var registeredUsersRoleId = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRegisteredUsersRoleId(portalSettings: DotNetNuke.Entities.Portals.PortalController.Instance.GetCurrentPortalSettings()).ToString();
             var expectedResult = new Mock<DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo>
             {
@@ -620,7 +632,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Controllers
         public void GetAdminPermissionsTest()
         {
             // Arrange
-            const string emptyPermissions = ";|||";
+            const string emptyPermissions = "";
             var expectedResult = new Mock<DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo>
             {
                 Object =
@@ -660,7 +672,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Controllers
         public void GetEmptyPermissionsTest()
         {
             // Arrange
-            const string emptyPermissions = ";|||";
+            const string emptyPermissions = "";
             var expectedResult = new Mock<DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo>
             {
                 Object =
@@ -758,7 +770,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Controllers
         public void GetSecureObjectListTest()
         {
             // Arrange
-            const string emptyPermissions = ";|||";
+            const string emptyPermissions = "";
             var mockPermissions = new Mock<DotNetNuke.Modules.ActiveForums.Entities.PermissionInfo>
             {
                 Object =
@@ -789,7 +801,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Controllers
             var expectedResult = $"{DotNetNuke.Tests.Utilities.Constants.RoleID_Administrators};";
 
             // Act
-            var actualResult = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetSecureObjectList(DotNetNuke.Entities.Portals.PortalController.Instance.GetCurrentPortalSettings(), mockPermissions.Object, DotNetNuke.Modules.ActiveForums.ObjectType.RoleId);
+            var actualResult = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetSecureObjectList(DotNetNuke.Entities.Portals.PortalController.Instance.GetCurrentPortalSettings(), mockPermissions.Object);
 
             // Assert
             Assert.That(actualResult, Is.EqualTo(expectedResult));
@@ -848,6 +860,60 @@ namespace DotNetNuke.Modules.ActiveForumsTests.Controllers
 
             // Act
             var actualResult = PermissionController.GetPortalRoleIds(DotNetNuke.Entities.Portals.PortalController.Instance.GetCurrentPortalSettings().PortalId, roles);
+
+            // Assert
+            Assert.That(actualResult, Is.EqualTo(expectedResult));
+        }
+
+        [Test]
+        public void GetRoleIdsTest()
+        {
+            // Arrange
+            var roles = new HashSet<int>
+            {
+                DotNetNuke.Tests.Utilities.Constants.RoleID_RegisteredUsers,
+                DotNetNuke.Tests.Utilities.Constants.RoleID_Administrators,
+                Convert.ToInt32(DotNetNuke.Common.Globals.glbRoleUnauthUser),
+                Convert.ToInt32(DotNetNuke.Common.Globals.glbRoleAllUsers),
+            };
+
+            var expectedResult = string.Join(";", new List<int>
+            {
+                DotNetNuke.Tests.Utilities.Constants.RoleID_RegisteredUsers,
+                DotNetNuke.Tests.Utilities.Constants.RoleID_Administrators,
+                Convert.ToInt32(DotNetNuke.Common.Globals.glbRoleUnauthUser),
+                Convert.ToInt32(DotNetNuke.Common.Globals.glbRoleAllUsers),
+
+            }.OrderBy(r => r));
+
+            // Act
+            var actualResult = PermissionController.GetRoleIds(roles);
+
+            // Assert
+            Assert.That(actualResult, Is.EqualTo(expectedResult));
+        }
+        
+        [Test]
+        public void RemoveRoleIdFromRoleIdsTest()
+        {
+            // Arrange
+            var roles = new HashSet<int>
+            {
+                DotNetNuke.Tests.Utilities.Constants.RoleID_RegisteredUsers,
+                DotNetNuke.Tests.Utilities.Constants.RoleID_Administrators,
+                Convert.ToInt32(DotNetNuke.Common.Globals.glbRoleUnauthUser),
+                Convert.ToInt32(DotNetNuke.Common.Globals.glbRoleAllUsers),
+            };
+
+            var expectedResult = new HashSet<int>
+            {
+                DotNetNuke.Tests.Utilities.Constants.RoleID_RegisteredUsers,
+                Convert.ToInt32(DotNetNuke.Common.Globals.glbRoleUnauthUser),
+                Convert.ToInt32(DotNetNuke.Common.Globals.glbRoleAllUsers),
+            };
+
+            // Act
+            var actualResult = PermissionController.RemoveRoleIdFromRoleIds(DotNetNuke.Tests.Utilities.Constants.RoleID_Administrators, roles);
 
             // Assert
             Assert.That(actualResult, Is.EqualTo(expectedResult));


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Upgrade permissions to just contain role ids

## Changes made
- Deprecated `ObjectType` and `Type` property from the `PermissionInfo` class (only 'Type' is now DNN roles).
- `DnnCommunityForums.dnn`: Added new upgrade version `09.00.00` to the `upgradeVersionsList`.
- Added upgrade code to transform existing `activeforums_Permissions` data
- `PermissionController.cs`: Removed `objectType` parameter from multiple methods and added new methods for handling role IDs.
- `ForumController.cs`: Modified `AddObjectToPermissions` calls to eliminate the `objectType` parameter.
- `admin_securitygrid.ascx`: Updated JavaScript functions to streamline security object management.
- Updated test cases in `PermissionControllerTests.cs` to reflect the removal of the `objectType` parameter.

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [ ] Fixes Bug
- [ ] Feature solution
- [X] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1393