### PR TITLE
ENH: Specify avatar size using token 

### DIFF
--- a/Dnn.CommunityForums/Entities/ForumUserInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumUserInfo.cs
@@ -522,11 +522,32 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                 format = tokenReplacer.ReplaceEmbeddedTokens(format);
             }
 
+            var length = DotNetNuke.Common.Utilities.Null.NullInteger;
+            if (propertyName.Contains(":"))
+            {
+                var splitPropertyName = propertyName.Split(':');
+                propertyName = splitPropertyName[0];
+                length = Utilities.SafeConvertInt(splitPropertyName[1], DotNetNuke.Common.Utilities.Null.NullInteger);
+            }
+
             propertyName = propertyName.ToLowerInvariant();
             switch (propertyName)
             {
                 case "avatar":
-                    return PropertyAccess.FormatString(!this.PrefBlockAvatars && !this.AvatarDisabled ? DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetAvatar(this.UserId, this.MainSettings.AvatarWidth, this.MainSettings.AvatarHeight) : string.Empty, format);
+                    if (this.PrefBlockAvatars || this.AvatarDisabled)
+                    {
+                        return PropertyAccess.FormatString(string.Empty, format);
+                    }
+
+                    var height = this.MainSettings.AvatarHeight;
+                    var width = this.MainSettings.AvatarWidth;
+                    if (length > 0)
+                    {
+                        height = length;
+                        width = length;
+                    }
+
+                    return PropertyAccess.FormatString(DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.GetAvatar(this.UserId, width, height), format);
                 case "usercaption":
                     return PropertyAccess.FormatString(this.UserCaption, format);
                 case "displayname":


### PR DESCRIPTION

<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Handle optional size (same ## for height/width) on avatar token.

For example:
[FORUMAUTHOR:AVATAR:50]


## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install
Before, using module settings:
![image](https://github.com/user-attachments/assets/c6473cec-d1de-4a51-acf3-5f88ded8a783)
![image](https://github.com/user-attachments/assets/b1c3c7c4-a3b9-4616-ad5a-b0ee16010cc1)

After, changed template:
![image](https://github.com/user-attachments/assets/7cde23bd-92e3-4037-9576-67e18b10d03a)
![image](https://github.com/user-attachments/assets/c7c06ac3-59c0-4289-a10c-eec30e373ab6)

## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #421