### PR TITLE
FIX: Forum groups losing sort order 

### DIFF
--- a/Dnn.CommunityForums/Controllers/ForumGroupController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumGroupController.cs
@@ -131,6 +131,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
 
             // TODO: When these methods are updated to use DAL2 for update, uncomment Cacheable attribute on forumGroupInfo
             forumGroupInfo.ForumGroupId = DotNetNuke.Modules.ActiveForums.DataProvider.Instance().Groups_Save(portalId, forumGroupInfo.ModuleId, forumGroupInfo.ForumGroupId, forumGroupInfo.GroupName, forumGroupInfo.SortOrder, forumGroupInfo.Active, forumGroupInfo.Hidden, forumGroupInfo.PermissionsId, forumGroupInfo.PrefixURL, forumGroupInfo.GroupSettingsKey);
+            /* refresh to get computed values such as SortOrder */
+            forumGroupInfo = this.GetById(forumGroupInfo.ForumGroupId, forumGroupInfo.ModuleId);
             if (string.IsNullOrEmpty(forumGroupInfo.GroupSettingsKey))
             {
                 forumGroupInfo.GroupSettingsKey = $"G:{forumGroupInfo.ForumGroupId}";

--- a/Dnn.CommunityForums/CustomControls/UserControls/ForumView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/ForumView.cs
@@ -218,11 +218,11 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
                     if (this.Request.QueryString[ParamKeys.GroupId] != null)
                     {
-                        this.Forums = this.Forums.Where(f => f.ForumGroupId == Convert.ToInt32(this.Request.QueryString[ParamKeys.GroupId])).OrderBy(f => f.ForumGroup?.SortOrder).ThenBy(f => f.SortOrder).ToList();
+                        this.Forums = this.Forums.Where(f => f.ForumGroupId == Convert.ToInt32(this.Request.QueryString[ParamKeys.GroupId])).OrderBy(f => f.ForumGroup?.SortOrder).ThenBy(f => f.ForumGroupId).ThenBy(f => f.SortOrder).ToList();
                     }
                     else
                     {
-                        this.Forums = this.Forums.OrderBy(f => f.ForumGroup?.SortOrder).ThenBy(f => f.SortOrder).ToList();
+                        this.Forums = this.Forums.OrderBy(f => f.ForumGroup?.SortOrder).ThenBy(f => f.ForumGroupId).ThenBy(f => f.SortOrder).ToList();
                     }
 
                     string sGroupName = (this.ForumGroupId != -1 && this.Forums?.Count > 0) ? this.Forums?.FirstOrDefault().GroupName : string.Empty;
@@ -250,7 +250,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     int tmpGroupCount = 0;
                     if (this.Forums != null)
                     {
-                        foreach (var fi in this.Forums.Where(f => !this.SubsOnly || f.ParentForumId > 0).OrderBy(f => f.ForumGroup?.SortOrder).ThenBy(f => f.SortOrder).Take(Globals.ForumCount))
+                        foreach (var fi in this.Forums.Where(f => !this.SubsOnly || f.ParentForumId > 0).OrderBy(f => f.ForumGroup?.SortOrder).ThenBy(f => f.ForumGroupId).ThenBy(f => f.SortOrder).Take(Globals.ForumCount))
                         {
                             fi.PortalSettings = this.PortalSettings;
                             fi.MainSettings = this.MainSettings;


### PR DESCRIPTION

### Description of PR...
This pull request enhances the functionality of forum group management by ensuring that saved forum group information is refreshed correctly and improves the sorting logic for displaying forums. 

## Changes made
- `ForumGroupController.cs`: Updated `Groups_Save` to refresh `forumGroupInfo` after saving to get SortOrder calculated by stored procedure
- `ForumView.cs`: Modified `BuildForumView` to include `ForumGroupId` in the sorting criteria for forums to prevent forums from groups without a sort order from being orphaned

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1433 