### PR TITLE
FIX: Missing body in email notifications

### DIFF
--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.de-DE.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.de-DE.resx
@@ -1841,4 +1841,13 @@ Von
   <data name="[RESX:TokenReplacementException].Text" xml:space="preserve">
     <value>Ausnahme: Ersetzen des Tokens für Entität: {0}-ID: {1} Tokeneigenschaft: {2} Format: {3}</value>
   </data>
+  <data name="[RESX:EmailNotificationGreeting].Text" xml:space="preserve">
+    <value>In einem Forum, das Sie verfolgen, wurde eine Nachricht gepostet.</value>
+  </data>
+  <data name="[RESX:EmailNotificationVisitLinkMessage].Text" xml:space="preserve">
+    <value>Um den vollständigen Thread und die Antwort zu sehen, besuchen Sie bitte:</value>
+  </data>
+  <data name="[RESX:ThankYou].Text" xml:space="preserve">
+    <value>Vielen Dank</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.es-ES.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.es-ES.resx
@@ -1840,4 +1840,13 @@ De
   <data name="[RESX:TokenReplacementException].Text" xml:space="preserve">
     <value>Excepción que reemplaza el token en la entidad: {0} id: {1} propiedad del token: {2} formato: {3}</value>
   </data>
+  <data name="[RESX:EmailNotificationGreeting].Text" xml:space="preserve">
+    <value>Se ha publicado un mensaje en un foro que está siguiendo.</value>
+  </data>
+  <data name="[RESX:EmailNotificationVisitLinkMessage].Text" xml:space="preserve">
+    <value>Para ver el hilo completo y la respuesta, visite:</value>
+  </data>
+  <data name="[RESX:ThankYou].Text" xml:space="preserve">
+    <value>Gracias</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.fr-FR.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.fr-FR.resx
@@ -1837,4 +1837,13 @@ De,
   <data name="[RESX:TokenReplacementException].Text" xml:space="preserve">
     <value>Exception remplaçant le jeton sur l’entité : {0} id : {1} propriété du jeton : {2} format : {3}</value>
   </data>
+  <data name="[RESX:EmailNotificationGreeting].Text" xml:space="preserve">
+    <value>Un message a été posté sur un forum que vous suivez.</value>
+  </data>
+  <data name="[RESX:EmailNotificationVisitLinkMessage].Text" xml:space="preserve">
+    <value>Pour consulter le fil de discussion complet et y répondre, veuillez visiter :</value>
+  </data>
+  <data name="[RESX:ThankYou].Text" xml:space="preserve">
+    <value>Merci</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.it-IT.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.it-IT.resx
@@ -1840,4 +1840,13 @@ Da
   <data name="[RESX:TokenReplacementException].Text" xml:space="preserve">
     <value>Eccezione che sostituisce il token sull'entità: {0} id: {1} proprietà token: {2} formato: {3}</value>
   </data>
+  <data name="[RESX:EmailNotificationGreeting].Text" xml:space="preserve">
+    <value>È stato pubblicato un messaggio su un forum che stai monitorando.</value>
+  </data>
+  <data name="[RESX:EmailNotificationVisitLinkMessage].Text" xml:space="preserve">
+    <value>Per visualizzare il thread completo e la risposta, visitare:</value>
+  </data>
+  <data name="[RESX:ThankYou].Text" xml:space="preserve">
+    <value>Grazie</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.nl-NL.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.nl-NL.resx
@@ -1876,4 +1876,13 @@ Van,
   <data name="[RESX:TokenReplacementException].Text" xml:space="preserve">
     <value>Uitzondering ter vervanging van token op entiteit: {0} id: {1} eigenschap token: {2} indeling: {3}</value>
   </data>
+  <data name="[RESX:EmailNotificationGreeting].Text" xml:space="preserve">
+    <value>Er is een bericht geplaatst op een forum dat u volgt.</value>
+  </data>
+  <data name="[RESX:EmailNotificationVisitLinkMessage].Text" xml:space="preserve">
+    <value>Om de volledige thread te bekijken en te antwoorden, ga naar:</value>
+  </data>
+  <data name="[RESX:ThankYou].Text" xml:space="preserve">
+    <value>Bedankt</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.resx
@@ -1837,4 +1837,13 @@ From,
   <data name="[RESX:TokenReplacementException].Text" xml:space="preserve">
     <value>Exception replacing token on entity: {0} id: {1} token property: {2} format: {3}</value>
   </data>
+  <data name="[RESX:EmailNotificationGreeting].Text" xml:space="preserve">
+    <value>A message was posted to a forum you are tracking.</value>
+  </data>
+  <data name="[RESX:EmailNotificationVisitLinkMessage].Text" xml:space="preserve">
+    <value>To view the complete thread and reply, please visit:</value>
+  </data>
+  <data name="[RESX:ThankYou].Text" xml:space="preserve">
+    <value>Thank you,</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/Controllers/EmailController.cs
+++ b/Dnn.CommunityForums/Controllers/EmailController.cs
@@ -77,7 +77,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             var navigationManager = (INavigationManager)new Services.URLNavigator().NavigationManager();
             DotNetNuke.Abstractions.Portals.IPortalSettings portalSettings = Utilities.GetPortalSettings(fi.PortalId);
             var lstSubscriptionInfo = subs;
-            var bodyTemplate = DotNetNuke.Modules.ActiveForums.Controllers.TemplateController.Template_Get(moduleId, TemplateType.Email, fi.FeatureSettings.TemplateFileNameSuffix);
+            var bodyTemplate = DotNetNuke.Modules.ActiveForums.Controllers.TemplateController.Template_Get(moduleId, TemplateType.SubscribedEmail, fi.FeatureSettings.TemplateFileNameSuffix);
             var subjectTemplate = !string.IsNullOrEmpty(fi.FeatureSettings.EmailNotificationSubjectTemplate) ?
                 fi.FeatureSettings.EmailNotificationSubjectTemplate :
                 (!string.IsNullOrEmpty(fi.ForumGroup.FeatureSettings.EmailNotificationSubjectTemplate) ?

--- a/Dnn.CommunityForums/Enums/TemplateType.cs
+++ b/Dnn.CommunityForums/Enums/TemplateType.cs
@@ -30,7 +30,7 @@ namespace DotNetNuke.Modules.ActiveForums.Enums
         TopicEditor,
         ReplyEditor,
         QuickReply,
-        Email,
+        SubscribedEmail,
         ProfileInfo,
         ModEmail,
         PostInfo,

--- a/Dnn.CommunityForums/config/templates/SubscribedEmail.ascx
+++ b/Dnn.CommunityForums/config/templates/SubscribedEmail.ascx
@@ -1,8 +1,8 @@
-<font face="tahoma" size="2">A message was posted to a forum you are tracking.<br /><br />
+<font face="tahoma" size="2">[RESX:EmailNotificationGreeting]<br /><br />
 <table width="90%" bordercolor="#666666" border="1" cellpadding="2" cellspacing="0"><tr><td valign="top" bgcolor="#dcdcdc" width="100">
 <font face="arial" size="2"><b>[FORUMPOST:AUTHORDISPLAYNAMELINK|<a href="{0}" class="af-profile-link" rel="nofollow">[FORUMPOST:AUTHORDISPLAYNAME]</a>|[FORUMPOST:AUTHORDISPLAYNAME]]</b></font>
 <font size="1" face="arial">Posted:[FORUMPOST:DATECREATED] </font></td><td valgin="top"><font face="arial" size="2"><b>Subject:</b> [FORUMPOST:SUBJECT] <br />
-<br />[FORUMPOST:BODY]</font></td></tr></table><hr noshade size="1" />To view the complete thread and reply, please visit:
-[FORUMPOST:LINK]<br /><br /> Thank you,
+<br />[FORUMPOST:BODY]</font></td></tr></table><hr noshade size="1" />[RESX:EmailNotificationVisitLinkMessage]
+[FORUMPOST:LINK]<br /><br /> [RESX:ThankYou]
 [PORTAL:PORTALNAME]
 </font>


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Email notifications were missing content.

## Changes made
- Fix incorrect template name in enum (Email -> SubscribedEmail)
- Moves text from template to use resources to enable translation

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

Before:
![image](https://github.com/user-attachments/assets/ced8487e-a578-4530-bd38-b1409fc2c01b)

After:
![image](https://github.com/user-attachments/assets/b2d67f15-b250-4ba0-a5ff-1c0fac30d40d)

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1452