### PR TITLE
ENH: Move email notification text to resource files

### DIFF
--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.de-DE.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.de-DE.resx
@@ -1850,4 +1850,7 @@ Von
   <data name="[RESX:ThankYou].Text" xml:space="preserve">
     <value>Vielen Dank</value>
   </data>
+  <data name="[RESX:Posted].Text" xml:space="preserve">
+    <value>Verschickt:</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.es-ES.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.es-ES.resx
@@ -1849,4 +1849,7 @@ De
   <data name="[RESX:ThankYou].Text" xml:space="preserve">
     <value>Gracias</value>
   </data>
+  <data name="[RESX:Posted].Text" xml:space="preserve">
+    <value>Publicada:</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.fr-FR.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.fr-FR.resx
@@ -1846,4 +1846,7 @@ De,
   <data name="[RESX:ThankYou].Text" xml:space="preserve">
     <value>Merci</value>
   </data>
+  <data name="[RESX:Posted].Text" xml:space="preserve">
+    <value>Publié:</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.it-IT.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.it-IT.resx
@@ -1849,4 +1849,7 @@ Da
   <data name="[RESX:ThankYou].Text" xml:space="preserve">
     <value>Grazie</value>
   </data>
+  <data name="[RESX:Posted].Text" xml:space="preserve">
+    <value>Pubblicato:</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.nl-NL.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.nl-NL.resx
@@ -1885,4 +1885,7 @@ Van,
   <data name="[RESX:ThankYou].Text" xml:space="preserve">
     <value>Bedankt</value>
   </data>
+  <data name="[RESX:Posted].Text" xml:space="preserve">
+    <value>Verzonden:</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/App_LocalResources/SharedResources.resx
+++ b/Dnn.CommunityForums/App_LocalResources/SharedResources.resx
@@ -1846,4 +1846,7 @@ From,
   <data name="[RESX:ThankYou].Text" xml:space="preserve">
     <value>Thank you,</value>
   </data>
+  <data name="[RESX:Posted].Text" xml:space="preserve">
+    <value>Posted:</value>
+  </data>
 </root>

--- a/Dnn.CommunityForums/config/templates/SubscribedEmail.ascx
+++ b/Dnn.CommunityForums/config/templates/SubscribedEmail.ascx
@@ -1,7 +1,7 @@
 <font face="tahoma" size="2">[RESX:EmailNotificationGreeting]<br /><br />
 <table width="90%" bordercolor="#666666" border="1" cellpadding="2" cellspacing="0"><tr><td valign="top" bgcolor="#dcdcdc" width="100">
 <font face="arial" size="2"><b>[FORUMPOST:AUTHORDISPLAYNAMELINK|<a href="{0}" class="af-profile-link" rel="nofollow">[FORUMPOST:AUTHORDISPLAYNAME]</a>|[FORUMPOST:AUTHORDISPLAYNAME]]</b></font>
-<font size="1" face="arial">Posted:[FORUMPOST:DATECREATED] </font></td><td valgin="top"><font face="arial" size="2"><b>Subject:</b> [FORUMPOST:SUBJECT] <br />
+<font size="1" face="arial">[RESX:Posted]:[FORUMPOST:DATECREATED] </font></td><td valgin="top"><font face="arial" size="2"><b>[RESX:Subject]:</b> [FORUMPOST:SUBJECT] <br />
 <br />[FORUMPOST:BODY]</font></td></tr></table><hr noshade size="1" />[RESX:EmailNotificationVisitLinkMessage]
 [FORUMPOST:LINK]<br /><br /> [RESX:ThankYou]
 [PORTAL:PORTALNAME]


### PR DESCRIPTION

<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Moves hard-coded text from email notification template to resource files to facilitate localization.


## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1454