### PR TITLE
FIX: Don't parse roles out of PermissionSet when retrieving subscribers

### DIFF
--- a/Dnn.CommunityForums/ReleaseNotes.txt
+++ b/Dnn.CommunityForums/ReleaseNotes.txt
@@ -90,10 +90,12 @@
             <li>FIXED: 'Edit' link in topics view loading latest reply rather than the originating topic (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1396">Issue 1396</a>)</li>
             <li>FIXED: Scheduler item not correctly removed in 8.1 (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1397">Issue 1397</a>)</li>
             <li>FIXED: Submit button disabled after click to prevent duplicated posts (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1031">Issue 1031</a>)</li>
-            <li>FIXED: Improved token replacement causing page to not load if topic contains curly braces (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1435">Issue 1435</a>)</li>
+            <li>FIXED: Token replacement causing page to not load if topic contains curly braces (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1435">Issue 1435</a>)</li>
             <li>FIXED: Forum Groups not inheriting from default settings are losing their sort order (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1433">Issue 1433</a>)</li>
-            <li>FIXED: During upgrade, fix any permissions (role Id's) separated by colon rather than semi-colon (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1443">Issue 1443</a>)</li>
+            <li>FIXED: Keep Unicode quotes and accents out of friendly URLs (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1456">Issue 1456</a>)</li>
+            <li>FIXED: During 09.00.00 upgrade, fix any permissions (role Id's) separated by colon rather than semi-colon (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1443">Issue 1443</a>)</li>
             <li>FIXED: After upgrade to 09.00.00, email notifications are missing the email body (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1452">Issue 1452</a>)</li>
+            <li>FIXED: After upgrade to 09.00.00, exception when retrieving notification subscriptions (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1463">Issue 1463</a>)</li>
             <!--
             <li>FIXED:  (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/">Issue </a>!)</li>
             <li>None at this time.</li>

--- a/Dnn.CommunityForums/sql/09.00.00.SqlDataProvider
+++ b/Dnn.CommunityForums/sql/09.00.00.SqlDataProvider
@@ -1115,3 +1115,180 @@ GO
 /* issue 1386 end - retrieve attachments on unapproved posts */
 
 /* ---------------- */
+
+
+/* issue 1463 - begin - update procedure to remove parsing from CanSubscribe for activeforums_Permissions */
+
+/* updated subscribers procedure */
+IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_Subscriptions_Subscribers]') AND type in (N'P', N'PC'))
+DROP PROCEDURE {databaseOwner}[{objectQualifier}activeforums_Subscriptions_Subscribers]
+GO
+
+CREATE PROCEDURE  {databaseOwner}[{objectQualifier}activeforums_Subscriptions_Subscribers](@PortalId int, @ForumId int, @TopicId int, @SubType int)
+AS
+
+DECLARE @CanSubscribe nvarchar(256)
+SET @CanSubscribe = (
+					SELECT p.CanSubscribe
+					FROM {databaseOwner}{objectQualifier}activeforums_Forums as f 
+					INNER JOIN {databaseOwner}{objectQualifier}activeforums_Permissions as p 
+					ON p.PermissionsId = f.PermissionsId
+					WHERE f.ForumId = @ForumId
+					)
+					
+DECLARE @subs TABLE (userid int, email nvarchar(255), topicsubscriber bit)
+
+/* get topic subscribers who are not superusers so need to check against roles allowed to be subscribers */
+INSERT INTO @subs 
+	(userid, email, topicsubscriber)
+	(SELECT s.UserId, u.Email, 1 AS topicsubscriber  
+		FROM {databaseOwner}{objectQualifier}activeforums_Subscriptions AS s 		
+		INNER JOIN {databaseOwner}{objectQualifier}activeforums_Forums AS f 
+		ON f.ForumId = s.ForumId
+		INNER JOIN {databaseOwner}{objectQualifier}Users AS u 
+		ON  u.UserID = s.UserId 
+		AND u.IsSuperUser = 0 
+		AND u.IsDeleted = 0
+		INNER JOIN {databaseOwner}{objectQualifier}UserPortals AS up 
+		ON  up.UserId = u.UserID
+		AND up.PortalId = @PortalId
+		AND up.IsDeleted = 0
+		AND up.Authorised = 1
+		INNER JOIN {databaseOwner}{objectQualifier}UserRoles AS ur 
+		ON ur.UserID = u.UserID 
+		AND (
+					(ur.EffectiveDate IS NULL AND ur.ExpiryDate >= GETDATE()) /* DNN platform user roles still use native GETDATE() not GETUTCDATE() */
+				OR (ur.EffectiveDate IS NULL AND ur.ExpiryDate IS NULL)
+				OR (ur.EffectiveDate <= GETDATE() AND ur.ExpiryDate IS NULL)
+				OR (ur.EffectiveDate <= GETDATE() AND ur.ExpiryDate >= GETDATE())
+			)
+		INNER JOIN {databaseOwner}{objectQualifier}activeforums_Functions_Split(@CanSubscribe,';') AS r 
+		ON r.ID = ur.RoleId
+		WHERE 	(s.Mode = @SubType)
+		AND 	(s.TopicId = @TopicId)
+		AND (NOT EXISTS (SELECT * FROM @subs WHERE userid = s.UserId))
+	)
+
+/* get forum subscribers who are not superusers so need to check against roles allowed to be subscribers */
+INSERT INTO @subs 
+	(userid, email, topicsubscriber)
+	(SELECT s.UserId, u.Email, 0 AS topicsubscriber  
+		FROM {databaseOwner}{objectQualifier}activeforums_Subscriptions AS s 		
+		INNER JOIN {databaseOwner}{objectQualifier}activeforums_Forums AS f 
+		ON f.ForumId = s.ForumId
+		INNER JOIN {databaseOwner}{objectQualifier}Users AS u 
+		ON  u.UserID = s.UserId 
+		AND u.IsSuperUser = 0
+		AND u.IsDeleted = 0
+		INNER JOIN {databaseOwner}{objectQualifier}UserPortals AS up 
+		ON  up.UserId = u.UserID
+		AND up.PortalId = @PortalId
+		AND up.IsDeleted = 0
+		AND up.Authorised = 1
+		INNER JOIN {databaseOwner}{objectQualifier}UserRoles AS ur 
+		ON ur.UserID = u.UserID 
+		AND (
+					(ur.EffectiveDate IS NULL AND ur.ExpiryDate >= GETDATE()) /* DNN platform user roles still use native GETDATE() not GETUTCDATE() */
+				OR (ur.EffectiveDate IS NULL AND ur.ExpiryDate IS NULL)
+				OR (ur.EffectiveDate <= GETDATE() AND ur.ExpiryDate IS NULL)
+				OR (ur.EffectiveDate <= GETDATE() AND ur.ExpiryDate >= GETDATE())
+			)
+		INNER JOIN {databaseOwner}{objectQualifier}activeforums_Functions_Split(@CanSubscribe,';') AS r 
+		ON r.ID = ur.RoleId
+		WHERE (s.Mode = @SubType)
+		AND (S.ForumId = @ForumId AND S.TopicId = 0)
+		AND (NOT EXISTS (SELECT * FROM @subs WHERE userid = s.UserId))
+	)
+
+
+/* get topic subscribers who are superusers  */
+INSERT INTO @subs 
+	(userid, email, topicsubscriber)
+	(SELECT s.UserId, u.Email, 1 AS topicsubscriber  
+		FROM {databaseOwner}{objectQualifier}activeforums_Subscriptions AS s 		
+		INNER JOIN {databaseOwner}{objectQualifier}activeforums_Forums AS f 
+		ON f.ForumId = s.ForumId
+		INNER JOIN {databaseOwner}{objectQualifier}Users AS u 
+		ON  u.UserID = s.UserId 
+		AND u.IsSuperUser = 1 
+		AND u.IsDeleted = 0
+		INNER JOIN {databaseOwner}{objectQualifier}UserPortals AS up 
+		ON  up.UserId = u.UserID
+		AND up.PortalId = @PortalId
+		AND up.IsDeleted = 0
+		AND up.Authorised = 1
+		WHERE 	(s.Mode = @SubType)
+		AND 	(s.TopicId = @TopicId)
+		AND (NOT EXISTS (SELECT * FROM @subs WHERE userid = s.UserId))
+	)
+
+/* get forum subscribers who are superusers  */
+INSERT INTO @subs 
+	(userid, email, topicsubscriber)
+	(SELECT s.UserId, u.Email, 0 AS topicsubscriber  
+		FROM {databaseOwner}{objectQualifier}activeforums_Subscriptions AS s 		
+		INNER JOIN {databaseOwner}{objectQualifier}activeforums_Forums AS f 
+		ON f.ForumId = s.ForumId
+		INNER JOIN {databaseOwner}{objectQualifier}Users AS u 
+		ON  u.UserID = s.UserId 
+		AND u.IsSuperUser = 1 
+		AND u.IsDeleted = 0
+		INNER JOIN {databaseOwner}{objectQualifier}UserPortals AS up 
+		ON  up.UserId = u.UserID
+		AND up.PortalId = @PortalId
+		AND up.IsDeleted = 0
+		AND up.Authorised = 1
+		WHERE (s.Mode = @SubType)
+		AND (S.ForumId = @ForumId AND S.TopicId = 0)
+		AND (NOT EXISTS (SELECT * FROM @subs WHERE userid = s.UserId))
+	)
+
+/* get auto subscriptions based on roles */
+DECLARE @AutoSubscribe bit
+DECLARE @AutoSubscribeRoles nvarchar(255)
+DECLARE @TopicsOnly bit
+DECLARE @IsNewTopic bit
+SET @AutoSubscribe = IsNull((SELECT SettingValue FROM {databaseOwner}{objectQualifier}activeforums_Settings as S INNER JOIN {databaseOwner}{objectQualifier}activeforums_Forums as F ON F.ForumSettingsKey = S.GroupKey  WHERE S.SettingName = 'AUTOSUBSCRIBEENABLED' AND F.ForumId  = @ForumId),0)
+SET @AutoSubscribeRoles = IsNull((SELECT SettingValue FROM {databaseOwner}{objectQualifier}activeforums_Settings as S INNER JOIN {databaseOwner}{objectQualifier}activeforums_Forums as F ON F.ForumSettingsKey = S.GroupKey  WHERE S.SettingName = 'AUTOSUBSCRIBEROLES' AND F.ForumId  = @ForumId),'')
+SET @TopicsOnly = IsNull((SELECT SettingValue FROM {databaseOwner}{objectQualifier}activeforums_Settings as S INNER JOIN {databaseOwner}{objectQualifier}activeforums_Forums as F ON F.ForumSettingsKey = S.GroupKey  WHERE S.SettingName = 'AUTOSUBSCRIBENEWTOPICSONLY' AND F.ForumId  = @ForumId),0)
+SET @IsNewTopic = 0
+IF (SELECT ReplyCount FROM {databaseOwner}{objectQualifier}activeforums_Topics WHERE TopicId = @TopicId) > 0
+	SET @IsNewTopic = 1
+
+If (@TopicsOnly = 1 AND @IsNewTopic = 0) OR (@TopicsOnly = 0)
+	BEGIN
+	IF @AutoSubscribe = 1 AND @AutoSubscribeRoles <> ''
+		BEGIN
+		
+			INSERT INTO @subs 
+			(userid, email, topicsubscriber)
+			(SELECT u.UserID, u.Email, 0 AS topicsubscriber  /*auto subscribers are never topic-specific subscribers */
+				FROM {databaseOwner}{objectQualifier}Users AS u 
+				INNER JOIN {databaseOwner}{objectQualifier}UserPortals AS up 
+				ON  up.UserId = u.UserID
+				AND up.PortalId = @PortalId
+				AND up.IsDeleted = 0
+				AND up.Authorised = 1
+				INNER JOIN {databaseOwner}{objectQualifier}UserRoles AS ur 
+				ON ur.UserID = u.UserID 
+				AND (
+							(ur.EffectiveDate IS NULL AND ur.ExpiryDate >= GETDATE()) /* DNN platform user roles still use native GETDATE() not GETUTCDATE() */
+						OR (ur.EffectiveDate IS NULL AND ur.ExpiryDate IS NULL)
+						OR (ur.EffectiveDate <= GETDATE() AND ur.ExpiryDate IS NULL)
+						OR (ur.EffectiveDate <= GETDATE() AND ur.ExpiryDate >= GETDATE())
+					)
+				INNER JOIN {databaseOwner}{objectQualifier}activeforums_Functions_Split(@AutoSubscribeRoles,';') AS r 
+				ON r.ID = ur.RoleId
+				WHERE (u.IsDeleted = 0)
+				AND (NOT EXISTS (SELECT * FROM @subs WHERE userid = u.UserID))
+			)
+
+		END
+	END
+	
+/* return the results */	
+SELECT DISTINCT userid, email, topicsubscriber FROM @subs
+GO
+
+
+/* issue 1463 - end - update procedure to remove parsing from CanSubscribe for activeforums_Permissions */


### PR DESCRIPTION

<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Don't parse roles out of PermissionSet when retrieving subscribers

## Changes made
- Update stored procedure `activeforums_Subscriptions_Subscribers` to not parse role Id's portion from Permissions.
 (used to be "-1;3;6||" but is now just "-1;3;6" so don't substring out based on '|').

## How did you test these updates?  
Local install

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1463