### PR TITLE
FIX: Empty link in moderation notifications

### DIFF
--- a/Dnn.CommunityForums/Entities/ForumInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumInfo.cs
@@ -888,7 +888,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                         return this.FeatureSettings.AllowRSS && Controllers.PermissionController.HasRequiredPerm(this.Security.ReadRoleIds, DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromRoleNameArray(this.PortalId, accessingUser.Roles)) ? PropertyAccess.FormatString(this.RssLink, format) : string.Empty;
                     case "modlink":
                         var modLink = Utilities.NavigateURL(this.GetTabId(), this.portalSettings, string.Empty, new[] { $"{ParamKeys.ViewType}={Views.ModerateTopics}", $"{ParamKeys.ForumId}={this.ForumID}" });
-                        return Controllers.PermissionController.HasRequiredPerm(this.Security.ModerateRoleIds, DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromRoleNameArray(this.PortalId, accessingUser.Roles)) ? PropertyAccess.FormatString(modLink, format) : string.Empty;
+                        return PropertyAccess.FormatString(modLink, format);
                 }
             }
             catch (Exception ex)

--- a/Dnn.CommunityForums/sql/09.00.01.SqlDataProvider
+++ b/Dnn.CommunityForums/sql/09.00.01.SqlDataProvider
@@ -111,22 +111,22 @@ IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwn
 EXECUTE sp_refreshsqlmodule N'{databaseOwner}[{objectQualifier}vw_activeforums_TopicsView]';
 GO
 IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_Topics_Save]') AND type in (N'P', N'PC'))
-EXECUTE sp_refreshsqlmodule N'{databaseOwner}[{objectQualifier}activeforums_Topics_Save]
+EXECUTE sp_refreshsqlmodule N'{databaseOwner}[{objectQualifier}activeforums_Topics_Save]';
 GO
 IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_Reply_Save]') AND type in (N'P', N'PC'))
-EXECUTE sp_refreshsqlmodule N'{databaseOwner}[{objectQualifier}activeforums_Reply_Save]
+EXECUTE sp_refreshsqlmodule N'{databaseOwner}[{objectQualifier}activeforums_Reply_Save]';
 GO
 IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_Templates_Save]') AND type in (N'P', N'PC'))
-EXECUTE sp_refreshsqlmodule N'{databaseOwner}[{objectQualifier}activeforums_Templates_Save]
+EXECUTE sp_refreshsqlmodule N'{databaseOwner}[{objectQualifier}activeforums_Templates_Save]';
 GO
 IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_Mod_Pending]') AND type in (N'P', N'PC'))
-EXECUTE sp_refreshsqlmodule N'{databaseOwner}[{objectQualifier}activeforums_Mod_Pending]
+EXECUTE sp_refreshsqlmodule N'{databaseOwner}[{objectQualifier}activeforums_Mod_Pending]';
 GO
 IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_Search_GetSearchItemsFromBegDate]') AND type in (N'P', N'PC'))
-EXECUTE sp_refreshsqlmodule N'{databaseOwner}[{objectQualifier}activeforums_Search_GetSearchItemsFromBegDate]
+EXECUTE sp_refreshsqlmodule N'{databaseOwner}[{objectQualifier}activeforums_Search_GetSearchItemsFromBegDate]';
 GO
 IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_Search_Standard]') AND type in (N'P', N'PC'))
-EXECUTE sp_refreshsqlmodule N'{databaseOwner}[{objectQualifier}activeforums_Search_Standard]
+EXECUTE sp_refreshsqlmodule N'{databaseOwner}[{objectQualifier}activeforums_Search_Standard]';
 GO
 
 


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Link for moderation page is missing in moderation notifications.
Unable to duplicate in local testing, but removing security checks when generating the link to determine if it is the security checks or the link creation that is at fault.
## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1468