### PR TITLE
FIX: GridView paging needs to be disabled for DataTables.Net

### DIFF
--- a/Dnn.CommunityForums/controls/af_recycle_bin.ascx
+++ b/Dnn.CommunityForums/controls/af_recycle_bin.ascx
@@ -6,7 +6,7 @@
 <div>
     <asp:UpdatePanel ID="upOptions1" UpdateMode="Conditional" runat="server" ChildrenAsTriggers="True" >
         <contenttemplate>
-            <asp:GridView ID="dgrdRestoreView" AutoGenerateColumns="false" AllowPaging="true" PageSize="25"
+            <asp:GridView ID="dgrdRestoreView" AutoGenerateColumns="false" AllowPaging="false"
                 Width="100%" CellPadding="4" GridLines="None" CssClass="dnnGrid" runat="server">
                
                 <HeaderStyle CssClass="dnnGridHeader" VerticalAlign="Top" HorizontalAlign="Left" />

--- a/Dnn.CommunityForums/controls/af_recycle_bin.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_recycle_bin.ascx.cs
@@ -69,7 +69,7 @@ namespace DotNetNuke.Modules.ActiveForums
             this.dgrdRestoreView.Columns[6].HeaderText = DotNetNuke.Modules.ActiveForums.Utilities.GetSharedResource("[RESX:Author]");
             this.dgrdRestoreView.Columns[7].HeaderText = DotNetNuke.Modules.ActiveForums.Utilities.GetSharedResource("[RESX:DateCreated]");
 
-            this.dgrdRestoreView.PageIndexChanging += this.RestoreViewGridRowPageIndexChanging;
+            //this.dgrdRestoreView.PageIndexChanging += this.RestoreViewGridRowPageIndexChanging;
             this.dgrdRestoreView.RowCommand += this.RestoreViewGrid_OnRowCommand;
             this.dgrdRestoreView.RowDataBound += this.OnRestoreViewGridRowDataBound;
             this.btnEmptyRecycleBin.Click += this.btnEmptyRecycleBin_Click;
@@ -136,7 +136,6 @@ namespace DotNetNuke.Modules.ActiveForums
                     _pageSize = 10;
                 }
 
-                this.dgrdRestoreView.PageSize = _pageSize;
 
                 if (this.UserId > 0 && this.ForumUser.GetIsMod(this.ForumModuleId))
                 {
@@ -154,6 +153,7 @@ namespace DotNetNuke.Modules.ActiveForums
             var recycleData = this.GetData().ToList();
             this.dgrdRestoreView.DataSource = recycleData;
             this.dgrdRestoreView.DataBind();
+            this.dgrdRestoreView.PageSize = this.dgrdRestoreView.Rows.Count;
             this.btnEmptyRecycleBin.Enabled = recycleData.Any();
             this.btnRestoreAll.Enabled = recycleData.Any();
             this.dgrdRestoreView.WrapGridViewInDataTableNet(this.PortalSettings, this.UserInfo);
@@ -211,10 +211,10 @@ namespace DotNetNuke.Modules.ActiveForums
             }
         }
 
-        protected void RestoreViewGridRowPageIndexChanging(object sender, GridViewPageEventArgs e)
-        {
-            this.dgrdRestoreView.PageIndex = e.NewPageIndex;
-            this.dgrdRestoreView.DataBind();
-        }
+        //protected void RestoreViewGridRowPageIndexChanging(object sender, GridViewPageEventArgs e)
+        //{
+        //    this.dgrdRestoreView.PageIndex = e.NewPageIndex;
+        //    this.dgrdRestoreView.DataBind();
+        //}
     }
 }

--- a/Dnn.CommunityForums/controls/profile_mysubscriptions.ascx
+++ b/Dnn.CommunityForums/controls/profile_mysubscriptions.ascx
@@ -7,7 +7,7 @@
     <span>[RESX:Topic] [RESX:Subscriptions]:</span>
     <asp:updatepanel id="updatePanel1" updatemode="Conditional" runat="server" childrenastriggers="True">
         <contenttemplate>
-            <asp:GridView ID="dgrdTopicSubs" AutoGenerateColumns="false" AllowPaging="true" PageSize="25"
+            <asp:GridView ID="dgrdTopicSubs" AutoGenerateColumns="false" 
                 Width="100%" CellPadding="4" GridLines="None" CssClass="dnnGrid" runat="server">
                 <HeaderStyle CssClass="dnnGridHeader" VerticalAlign="Top" HorizontalAlign="Left" />
                 <RowStyle CssClass="dnnGridItem" HorizontalAlign="Left" />

--- a/Dnn.CommunityForums/controls/profile_mysubscriptions.ascx.cs
+++ b/Dnn.CommunityForums/controls/profile_mysubscriptions.ascx.cs
@@ -49,9 +49,9 @@ namespace DotNetNuke.Modules.ActiveForums
             this.dgrdForumSubs.Columns[4].HeaderText = DotNetNuke.Modules.ActiveForums.Utilities.GetSharedResource("[RESX:Forum].Text");
             this.dgrdForumSubs.Columns[5].HeaderText = DotNetNuke.Modules.ActiveForums.Utilities.GetSharedResource("[RESX:LastPost].Text");
 
-            this.dgrdTopicSubs.PageIndexChanging += this.TopicSubsGridRow_PageIndexChanging;
+            //this.dgrdTopicSubs.PageIndexChanging += this.TopicSubsGridRow_PageIndexChanging;
             this.dgrdTopicSubs.RowDataBound += this.OnTopicSubsGridRowDataBound;
-            this.dgrdForumSubs.PageIndexChanging += this.ForumSubsGridRow_PageIndexChanging;
+            //this.dgrdForumSubs.PageIndexChanging += this.ForumSubsGridRow_PageIndexChanging;
             this.dgrdForumSubs.RowDataBound += this.OnForumSubsGridRowDataBound;
             this.btnSubscribeAll.Click += this.btnSubscribeAll_Click;
         }
@@ -61,19 +61,19 @@ namespace DotNetNuke.Modules.ActiveForums
             base.OnLoad(e);
             try
             {
-                int _pageSize = this.MainSettings.PageSize;
-                if (this.UserInfo.UserID > 0)
-                {
-                    _pageSize = this.UserDefaultPageSize;
-                }
+                //int _pageSize = this.MainSettings.PageSize;
+                //if (this.UserInfo.UserID > 0)
+                //{
+                //    _pageSize = this.UserDefaultPageSize;
+                //}
 
-                if (_pageSize < 5)
-                {
-                    _pageSize = 10;
-                }
+                //if (_pageSize < 5)
+                //{
+                //    _pageSize = 10;
+                //}
 
-                this.dgrdForumSubs.PageSize = _pageSize;
-                this.dgrdTopicSubs.PageSize = _pageSize;
+                //this.dgrdForumSubs.PageSize = _pageSize;
+                //this.dgrdTopicSubs.PageSize = _pageSize;
 
                 // TODO: Add moderator functionality to edit a user's subscriptions; this currently is just for a user to edit own subscriptions
                 this.UID = this.Request.QueryString[Literals.UserId] != null ? Convert.ToInt32(this.Request.QueryString[Literals.UserId]) : this.UserInfo.UserID;
@@ -98,14 +98,15 @@ namespace DotNetNuke.Modules.ActiveForums
             });
             this.dgrdTopicSubs.DataSource = subscribedTopics.ToList();
             this.dgrdTopicSubs.DataBind();
+            this.dgrdTopicSubs.PageSize = this.dgrdTopicSubs.Rows.Count;
             this.dgrdTopicSubs.WrapGridViewInDataTableNet(this.PortalSettings, this.UserInfo);
-
         }
 
         private void BindForumSubs()
         {
             this.dgrdForumSubs.DataSource = this.GetSubscriptions().ToList();
             this.dgrdForumSubs.DataBind();
+            this.dgrdForumSubs.PageSize = this.dgrdForumSubs.Rows.Count;
             this.dgrdForumSubs.WrapGridViewInDataTableNet(this.PortalSettings, this.UserInfo);
         }
 
@@ -188,16 +189,16 @@ namespace DotNetNuke.Modules.ActiveForums
             }
         }
 
-        protected void ForumSubsGridRow_PageIndexChanging(object sender, GridViewPageEventArgs e)
-        {
-            this.dgrdForumSubs.PageIndex = e.NewPageIndex;
-            this.dgrdForumSubs.DataBind();
-        }
+        //protected void ForumSubsGridRow_PageIndexChanging(object sender, GridViewPageEventArgs e)
+        //{
+        //    this.dgrdForumSubs.PageIndex = e.NewPageIndex;
+        //    this.dgrdForumSubs.DataBind();
+        //}
 
-        protected void TopicSubsGridRow_PageIndexChanging(object sender, GridViewPageEventArgs e)
-        {
-            this.dgrdTopicSubs.PageIndex = e.NewPageIndex;
-            this.dgrdTopicSubs.DataBind();
-        }
+        //protected void TopicSubsGridRow_PageIndexChanging(object sender, GridViewPageEventArgs e)
+        //{
+        //    this.dgrdTopicSubs.PageIndex = e.NewPageIndex;
+        //    this.dgrdTopicSubs.DataBind();
+        //}
     }
 }


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
DataTables.net has its own paging, so disable paging in GridView controls and just let DataTables.net handle paging.


## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1549 
Close #1550