### PR TITLE
FIX: Performance on gravatar queue on large sites

### DIFF
--- a/Dnn.CommunityForums/DnnCommunityForums.csproj
+++ b/Dnn.CommunityForums/DnnCommunityForums.csproj
@@ -12,8 +12,8 @@
         <Description>Discussion Forum Module for DNN</Description>
         <Company>dnncommunity.org</Company>
         <Authors>dnncommunity.org</Authors>
-        <FileVersion>09.01.00.00</FileVersion>
-        <AssemblyVersion>09.01.00.00</AssemblyVersion>
+        <FileVersion>09.01.01.00</FileVersion>
+        <AssemblyVersion>09.01.01.00</AssemblyVersion>
 
         <IncludeSymbols>False</IncludeSymbols>
         <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>

--- a/Dnn.CommunityForums/DnnCommunityForums.dnn
+++ b/Dnn.CommunityForums/DnnCommunityForums.dnn
@@ -1,6 +1,6 @@
 ﻿<dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="Active Forums" type="Module" version="09.01.00">
+    <package name="Active Forums" type="Module" version="09.01.01">
       <friendlyName>DNN Community Forums</friendlyName>
       <description>DNN Community Forums: The official online forums module for the DNN Community.</description>
       <iconFile>DesktopModules/ActiveForums/images/branding/logo/DNN-Community-Forums-Icon-64px.png</iconFile>
@@ -86,7 +86,7 @@
             <assembly>
               <name>DotNetNuke.Modules.ActiveForums.dll</name>
               <sourceFileName>bin\DotNetNuke.Modules.ActiveForums.dll</sourceFileName>
-              <version>09.01.00</version>
+              <version>09.01.01</version>
             </assembly>
           </assemblies>
         </component>
@@ -486,7 +486,7 @@
       </components>
     </package>
       
-    <package name="Active Forums What's New" type="Module" version="09.01.00">
+    <package name="Active Forums What's New" type="Module" version="09.01.01">
       <friendlyName>DNN Community Forums What's New</friendlyName>
       <foldername>ActiveForumsWhatsNew</foldername>
       <description>DNN Community Forums: Display the most recent topics or replies from selected forums on any page within your site.</description>
@@ -555,7 +555,7 @@
       </components>
     </package>
 
-    <package name="Active Forums Viewer" type="Module" version="09.01.00">
+    <package name="Active Forums Viewer" type="Module" version="09.01.01">
       <friendlyName>DNN Community Forums Forums Viewer</friendlyName>
       <foldername>ActiveForumsViewer</foldername>
       <description>DNN Community Forums: Display any forum topic view on any page within your site.</description>

--- a/Dnn.CommunityForums/DnnCommunityForums_Symbols.dnn
+++ b/Dnn.CommunityForums/DnnCommunityForums_Symbols.dnn
@@ -1,6 +1,6 @@
 ﻿<dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="Active Forums_Symbols" type="Library" version="09.01.00">
+    <package name="Active Forums_Symbols" type="Library" version="09.01.01">
       <friendlyName>DNN Community Forums Symbols</friendlyName>
       <description>DNN Community Forums: The official online forums module for the DNN Community.</description>
       <iconFile>DesktopModules/ActiveForums/images/branding/logo/DNN-Community-Forums-Icon-64px.png</iconFile>
@@ -14,7 +14,7 @@
       <releaseNotes src="ReleaseNotes.txt" />
       <azureCompatible>True</azureCompatible>
       <dependencies>
-        <dependency type="managedPackage" version="9.1.0">Active Forums</dependency>
+        <dependency type="managedPackage" version="9.1.1">Active Forums</dependency>
       </dependencies>
       <components>
         <component type="ResourceFile">

--- a/Dnn.CommunityForums/ReleaseNotes.txt
+++ b/Dnn.CommunityForums/ReleaseNotes.txt
@@ -46,8 +46,9 @@
             DNN Community Forums Release Notes
         </h2>
         <h3>
-            09.01.00
+            09.01.01
         </h3>
+<!--
 
         <p>
             <b>THANK YOU</b> for all of the valuable contributions by 
@@ -55,7 +56,6 @@
             and 
             <a href="https://github.com/johnhenley" target="_blank">@johnhenley</a>. 
         </p>
-<!--
                , and
             <a href="https://github.com/nvsai" target="_blank">@nvsai</a>, 
             <a href="https://github.com/ernieblues" target="_blank">@nvsai</a>, and 
@@ -69,28 +69,23 @@
 
         <h4>New Features &amp; Enhancements</h4>
         <ul>
+<!-- 
             <li>NEW: Adds Recycle Bin to be able to restore (soft-)deleted topics and replies (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/pull/1531">PR# 1531</a>)</li>
             <li>NEW: Adds an avatar injection service to populate avatars (currently using Gravatar) for forums users who haven't set up their own DNN profile picture/avatar. (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/pull/1446">PR# 1446</a>)</li>
             <li>NEW: Grid controls (Recycle Bin and Subscriptions page) now using DataTables.net JavaScript library for enhanced UI (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/pull/1553">PR# 1553</a>)</li>
-<!-- 
+
             <li>NEW: (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/pull/TBD">PR# TBD</a>)</li>
             <li>UPDATE:  (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/">Issue </a>)</li>
---> 
             <li>UPDATE: Improved handling of XML & HTML in posts (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1385">Issue 1385</a>)</li>
             <li>UPDATE: Changed "subscribe" to tokenized controls in topic and topics views to allow checkboxes or buttons (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1556">Issue 1556</a> & <a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1568">Issue 1568</a>)</li>
 
-<!--
+--> 
             <li>None at this time.</li>
--->
         </ul>
 
         <h4>Bug Fixes</h4>
         <ul>
-            <li>FIX: Update indexes on forum/topic tracking tables for uniqueness; upgrade script to detect and remove duplicates, keeping the latest entries (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1434">Issue 1434</a>)</li>
-            <li>FIX: Friendly URLs updated to working correctly with Forum Viewer and/or localized sites (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1557">Issue 1557</a>)</li>
-            <li>FIX: Incorrect logic in permissions checking for attachments (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1559">Issue 1559</a>)</li>
-            <li>FIX: Non-Admin/Non-Moderator is unable to edit their own post when edit interval/spam control feature used (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1562">Issue 1562</a>)</li>
-            <li>FIX: Subscribe controls not working from viewer module (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1572">Issue 1572</a>)</li>
+            <li>FIX: Poor performance for avatar refresh queue on large sites (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1584">Issue 1584</a>)</li>
             
 <!--
              <li>None at this time.</li>
@@ -99,16 +94,16 @@
 
         <h4>Tasks / Development Updates (and Technical Debt)</h4>
         <ul>
+<!--
             <li>Remove unused columns from forums table (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/792">Issue 792</a>)</li>
             <li>Categories and topic categories were previously handled as tags with an 'isCategory' flag; they are now first-class entities (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1441">Issue 1441</a>)</li>
             <li>Update Web API method security to not require ForumId for certain methods (e.g. user Ban) (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1507">Issue 1507</a>)</li>
             <li>Refactor Web API methods security checking to use Role Ids rather than string array of Role names; refactor Topic view model and Topic update panel (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1526">Issue 1526</a>)</li>
             <li>Remove old "Core Forums" to "Active Forums" SQL migration script (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1569">Issue 1569</a>)</li>
             <li>09.01.00 Release Prep (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1543">Issue 1543</a>)</li>
-<!--
             <li>TASK:  (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/">Issue </a>)</li>
-            <li>None at this time.</li>
 -->
+            <li>None at this time.</li>
         </ul>
         <hr />
     </div>

--- a/Dnn.CommunityForums/Services/Avatars/AvatarRefreshQueue.cs
+++ b/Dnn.CommunityForums/Services/Avatars/AvatarRefreshQueue.cs
@@ -25,9 +25,12 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Avatars
     using System;
     using System.Collections.Generic;
     using System.Linq;
+
+    using DotNetNuke.Data;
     using DotNetNuke.Entities.Modules;
     using DotNetNuke.Services.Log.EventLog;
     using DotNetNuke.Services.Scheduling;
+    using DotNetNuke.UI.UserControls;
 
     public class AvatarRefreshQueue : DotNetNuke.Services.Scheduling.SchedulerClient
     {
@@ -96,10 +99,28 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Avatars
         {
             try
             {
-                return new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(moduleId: moduleId).Get().Where(u => (u.PortalId == portalId && !u.UserInfo.IsDeleted && !u.AvatarDisabled && !u.PrefBlockAvatars) &&
-                                                                                                                                ((string.IsNullOrEmpty(u.UserInfo.Profile.GetPropertyValue("Photo")) && !u.AvatarLastRefresh.HasValue) || /* anyone without an avatar who has never had their avatar refreshed */
-                                                                                                                                 (u.AvatarLastRefresh.HasValue && DateTime.UtcNow.Subtract(u.AvatarLastRefresh.Value).TotalDays > 90))) /* or anyone whose avatar was last refreshed more than 90 days ago */
-                                                                                                                                .OrderByDescending(u => u.AvatarLastRefresh).Take(50).ToList();
+                var forumUserController = new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(moduleId: moduleId);
+                string sSql = "SELECT TOP 50 fup.UserId FROM {databaseOwner}{objectQualifier}activeforums_UserProfiles fup ";
+                sSql += "INNER JOIN {databaseOwner}{objectQualifier}UserPortals as up ON up.PortalId = fup.PortalId AND up.UserId = fup.UserId AND up.IsDeleted = 0 ";
+                sSql += "INNER JOIN {databaseOwner}{objectQualifier}ProfilePropertyDefinition ppd ON ppd.PortalID = @0 AND ppd.PropertyName = 'Photo' ";
+                sSql += "LEFT OUTER JOIN {databaseOwner}{objectQualifier}UserProfile as upr ON upr.UserId = fup.UserId AND upr.PropertyDefinitionID = ppd.PropertyDefinitionID ";
+                sSql += "WHERE fup.PortalId = @0 AND fup.AvatarDisabled = 0 AND fup.PrefBlockAvatars = 0 ";
+                sSql += "AND (   (fup.AvatarLastRefresh IS NULL AND upr.PropertyValue IS NULL) ";
+                sSql += "     OR (fup.AvatarLastRefresh IS NOT NULL AND DATEDIFF(dd,GETUTCDATE(),fup.AvatarLastRefresh) > 90) ) ";
+                sSql += "ORDER BY fup.AvatarLastRefresh DESC";
+                var userIds = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<int>(System.Data.CommandType.Text, sSql, portalId);
+
+                var users = new List<DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo>();
+                foreach (var userId in userIds)
+                {
+                    var forumUser = forumUserController.GetByUserId(portalId: portalId, userId: userId);
+                    if (forumUser != null)
+                    {
+                        users.Add(forumUser);
+                    }
+                }
+
+                return users;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Corrects performance of user retrieval for gravatar refresh queue. Scheduler retrieves 50 users at a time to look for new avatars. However, the way the logic was written, the combination of the DAL2/PetaPoco/LINQ was retrieving all users and THEN filtering down to 50 users. This reworks to use direct SQL to get the 50 users for each retrieval.
## How did you test these updates?  

<!-- Please be as descriptive as possible. -->
Local install
<img width="932" height="935" alt="image" src="https://github.com/user-attachments/assets/adbb2180-a608-4ca1-bf6d-71a1aaa386c5" />

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1584