### PR TITLE
FIX: HTML Decode Email notification subject

### DIFF
--- a/Dnn.CommunityForums/Controllers/EmailController.cs
+++ b/Dnn.CommunityForums/Controllers/EmailController.cs
@@ -105,7 +105,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                             {
                                 topicSubscriber.Email,
                             },
-                            Subject = Utilities.StripHTMLTag(TemplateUtils.ParseEmailTemplate(subjectTemplate, portalID: fi.PortalId, moduleID: moduleId, tabID: tabId, forumID: fi.ForumID, topicId: topicId, replyId: replyId, author: author, accessingUser: topicSubscriber.User, topicSubscriber: true, navigationManager: navigationManager, requestUrl: requestUrl, rawUrl: rawUrl)),
+                            Subject = Utilities.StripHTMLTag(System.Net.WebUtility.HtmlDecode(TemplateUtils.ParseEmailTemplate(subjectTemplate, portalID: fi.PortalId, moduleID: moduleId, tabID: tabId, forumID: fi.ForumID, topicId: topicId, replyId: replyId, author: author, accessingUser: topicSubscriber.User, topicSubscriber: true, navigationManager: navigationManager, requestUrl: requestUrl, rawUrl: rawUrl))),
                             Body = TemplateUtils.ParseEmailTemplate(bodyTemplate, portalID: fi.PortalId, moduleID: moduleId, tabID: tabId, forumID: fi.ForumID, topicId: topicId, replyId: replyId, author: author, accessingUser: topicSubscriber.User, topicSubscriber: true, navigationManager: navigationManager, requestUrl: requestUrl, rawUrl: rawUrl),
                         });
                     }
@@ -122,7 +122,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                             {
                                 forumSubscriber.Email,
                             },
-                            Subject = Utilities.StripHTMLTag(TemplateUtils.ParseEmailTemplate(subjectTemplate, portalID: fi.PortalId, moduleID: moduleId, tabID: tabId, forumID: fi.ForumID, topicId: topicId, replyId: replyId, author: author, accessingUser: forumSubscriber.User, topicSubscriber: false, navigationManager: navigationManager, requestUrl: requestUrl, rawUrl: rawUrl)),
+                            Subject = Utilities.StripHTMLTag(System.Net.WebUtility.HtmlDecode(TemplateUtils.ParseEmailTemplate(subjectTemplate, portalID: fi.PortalId, moduleID: moduleId, tabID: tabId, forumID: fi.ForumID, topicId: topicId, replyId: replyId, author: author, accessingUser: forumSubscriber.User, topicSubscriber: false, navigationManager: navigationManager, requestUrl: requestUrl, rawUrl: rawUrl))),
                             Body = TemplateUtils.ParseEmailTemplate(bodyTemplate, portalID: fi.PortalId, moduleID: moduleId, tabID: tabId, forumID: fi.ForumID, topicId: topicId, replyId: replyId, author: author, accessingUser: forumSubscriber.User, topicSubscriber: false, navigationManager: navigationManager, requestUrl: requestUrl, rawUrl: rawUrl),
                         });
                     }


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Decode HTML in email subjects


## How did you test these updates?  
<!-- Please be as descriptive as possible. -->

Local install.
Before:
<img width="1270" height="903" alt="image" src="https://github.com/user-attachments/assets/732ac26f-1690-45cf-961b-5364296c4fc2" />
After:
<img width="1472" height="848" alt="image" src="https://github.com/user-attachments/assets/8c407a78-5f77-4415-a620-db4dadb6c8ed" />

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1607