### PR TITLE
FIX: Forum permissions changing under certain rare conditions when updating module settings

### DIFF
--- a/Dnn.CommunityForums/ForumSettings.ascx.cs
+++ b/Dnn.CommunityForums/ForumSettings.ascx.cs
@@ -22,11 +22,13 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 {
     using System;
     using System.Linq;
+    using System.Reflection;
     using System.Text;
     using System.Web;
     using System.Web.UI.WebControls;
     using System.Xml;
 
+    using DotNetNuke.Collections;
     using DotNetNuke.Entities.Tabs;
     using DotNetNuke.Entities.Urls;
     using DotNetNuke.Framework;
@@ -254,17 +256,30 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 this.TimeFormatString = !string.IsNullOrWhiteSpace(this.txtTimeFormat.Text) ? this.txtTimeFormat.Text : "h:mm tt";
                 this.DateFormatString = !string.IsNullOrWhiteSpace(this.txtDateFormat.Text) ? this.txtDateFormat.Text : "M/d/yyyy";
 
-                this.ForumGroupTemplate = Utilities.SafeConvertInt(this.drpForumGroupTemplate.SelectedValue);
-                var adminSec = this.txtGroupModSec.Value.Split(',');
-                this.SaveForumSecurity("groupadmin", adminSec);
-                var memSec = this.txtGroupMemSec.Value.Split(',');
-                this.SaveForumSecurity("groupmember", memSec);
-                var regSec = this.txtGroupRegSec.Value.Split(',');
-                this.SaveForumSecurity("registereduser", regSec);
-                var anonSec = this.txtGroupAnonSec.Value.Split(',');
-                this.SaveForumSecurity("anon", anonSec);
-
-                DotNetNuke.Modules.ActiveForums.Controllers.ForumController.UpdatePermissionsForSocialGroupForums(this.ModuleId);
+                if (this.Mode.Equals("SocialGroup"))
+                {
+                    this.ForumGroupTemplate = Utilities.SafeConvertInt(this.drpForumGroupTemplate.SelectedValue);
+                    var adminSec = this.txtGroupModSec.Value.Split(',');
+                    this.SaveForumSecurity("groupadmin", adminSec);
+                    var memSec = this.txtGroupMemSec.Value.Split(',');
+                    this.SaveForumSecurity("groupmember", memSec);
+                    var regSec = this.txtGroupRegSec.Value.Split(',');
+                    this.SaveForumSecurity("registereduser", regSec);
+                    var anonSec = this.txtGroupAnonSec.Value.Split(',');
+                    this.SaveForumSecurity("anon", anonSec);
+                    DotNetNuke.Modules.ActiveForums.Controllers.ForumController.UpdatePermissionsForSocialGroupForums(this.ModuleId);
+                }
+                else
+                {
+                    DotNetNuke.Entities.Modules.ModuleController.Instance.DeleteModuleSetting(this.ModuleId, "ForumConfig");
+                    DotNetNuke.Entities.Modules.ModuleController.Instance.DeleteModuleSetting(this.ModuleId, "ForumGroupTemplate");
+                    var fc = new DotNetNuke.Modules.ActiveForums.Controllers.ForumController();
+                    fc.Get(this.ModuleId).Where(f => f.SocialGroupId != 0).ForEach(forum =>
+                    {
+                        forum.SocialGroupId = 0;
+                        fc.Update(forum);
+                    });
+                }
 
                 try
                 {


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Changing module settings is resetting forum security for social groups even when the module is running in "Standard" mode. 
Forum configuration data associated with issue reported had SocialGroupId set to non-zero values, which triggered resetting the security for those forums. This change will reset all module forums to SocialGroupId = 0 when running in "Standard" mode when you save the module settings.

## Changes made
- Only update forum security for social group forums when running module in "Social Groups" mode
- When running in "Standard" mode, remove social group settings

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install using provide data associated with reported issue.

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1606