### PR TITLE
FIX: Correct resource key for Control Panel tag display

### DIFF
--- a/Dnn.CommunityForums/controls/admin_tags.ascx
+++ b/Dnn.CommunityForums/controls/admin_tags.ascx
@@ -56,7 +56,7 @@ function amaf_deleteTag(row){
 						<div class="amheadingcelltext">[RESX:TagName]</div>
 					</td>
 					<td class="amcptblhdr" ColumnName="Items" style="height:16px;white-space:nowrap;width:50px;">
-						<div class="amheadingcelltext">[RESX:TagItems]</div>
+						<div class="amheadingcelltext">[RESX:Items]</div>
 					</td>
 					<td class="amcptblhdr" style="height:16px;white-space:nowrap;width:30px;">
 						<div class="amheadingcelltext">&nbsp;</div>


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...

Corrected resource key

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

Before:

<img width="1423" height="237" alt="image" src="https://github.com/user-attachments/assets/fb21f964-7200-43f9-979f-76602a5d9675" />


After:
<img width="1473" height="231" alt="image" src="https://github.com/user-attachments/assets/dee4e776-4bc7-4b30-90bf-9de6a93c572a" />


## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1593