### PR TITLE
ENH: Ignore unauthorized users when retrieving "active users" 

### DIFF
--- a/Dnn.CommunityForums/Controllers/ForumUserController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumUserController.cs
@@ -75,7 +75,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                         forumUser.UserInfo = user;
                         return forumUser;
                     }
-                );
+                ).Where(forumUser => forumUser.IsAdmin || forumUser.IsSuperUser || forumUser.UserInfo.Membership.Approved);
         }
 
         public DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo GetByUserId(int portalId, int userId)


### PR DESCRIPTION


<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Updates ForumUserController.GetActiveUsers() method to exclude unauthorized users; this will prevent badge assignments and avatar lookups, etc. for unauthorized users.

## PR Template Checklist

- [ ] Fixes Bug
- [ ] Feature solution
- [X] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1622