### PR TITLE
TASK: During uninstall, remove activeforums_UserMentions before activeforums_UserProfiles

### DIFF
--- a/Dnn.CommunityForums/sql/Uninstall.SqlDataProvider
+++ b/Dnn.CommunityForums/sql/Uninstall.SqlDataProvider
@@ -775,14 +775,14 @@ GO
 IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_UserBadges]') AND type in (N'U'))
 DROP TABLE {databaseOwner}[{objectQualifier}activeforums_UserBadges]
 GO
+IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_UserMentions]') AND type in (N'U'))
+DROP TABLE {databaseOwner}[{objectQualifier}activeforums_UserMentions]
+GO
 IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_UserProfiles]') AND type in (N'U'))
 DROP TABLE {databaseOwner}[{objectQualifier}activeforums_UserProfiles]
 GO
 IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_Badges]') AND type in (N'U'))
 DROP TABLE {databaseOwner}[{objectQualifier}activeforums_Badges]
-GO
-IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_UserMentions]') AND type in (N'U'))
-DROP TABLE {databaseOwner}[{objectQualifier}activeforums_UserMentions]
 GO
 IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}activeforums_Queue]') AND type in (N'U'))
 DROP TABLE {databaseOwner}[{objectQualifier}activeforums_Queue]


### PR DESCRIPTION


<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
in SQL uninstall, remove `activeforums_UserMentions` before `activeforums_UserProfiles`

## Changes made
- Update Uninstall.SqlDataProvider

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [ ] Fixes Bug
- [ ] Feature solution
- [X] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1663