### PR TITLE
FIX: Primary portal alias ignored when generating URLs

### DIFF
--- a/Dnn.CommunityForums/ReleaseNotes.txt
+++ b/Dnn.CommunityForums/ReleaseNotes.txt
@@ -84,11 +84,11 @@
 
         <h4>Bug Fixes</h4>
         <ul>
-              <li>None at this time.</li>
+              <li>FIX: Primary portal alias ignored when generating some links (was just using first available alias) (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1651">Issue 1651</a>)</li>
             
 <!--
-<li>FIX: Incorrect SQL scripts delivered with 09.02.01 (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1644">Issue 1644</a>)</li>
-           
+
+          <li>None at this time.</li> 
 
 -->
         </ul>

--- a/Dnn.CommunityForums/class/Utilities.cs
+++ b/Dnn.CommunityForums/class/Utilities.cs
@@ -34,6 +34,7 @@ namespace DotNetNuke.Modules.ActiveForums
     using System.Web;
     using System.Web.UI.WebControls;
 
+    using DotNetNuke.Abstractions.Portals;
     using DotNetNuke.Common.Utilities;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Entities.Tabs;
@@ -272,7 +273,8 @@ namespace DotNetNuke.Modules.ActiveForums
                     psc.LoadPortalSettings(portalSettings);
                 }
 
-                portalSettings.PortalAlias = DotNetNuke.Entities.Portals.PortalAliasController.Instance.GetPortalAliasesByPortalId(portalId).FirstOrDefault();
+                var portalAliases = DotNetNuke.Entities.Portals.PortalAliasController.Instance.GetPortalAliasesByPortalId(portalId);
+                portalSettings.PortalAlias = portalAliases.FirstOrDefault(pa => pa.IsPrimary) ?? portalAliases.FirstOrDefault();
                 return portalSettings;
             }
             catch (Exception ex)


### PR DESCRIPTION


<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...

FIX: Primary portal alias ignored when generating URLs (was just using first portal alias for portal)

## Changes made
- Use primary portal alias if set; otherwise use first available portal alias for portal

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install.

Defined Portal Aliases:
<img width="997" height="805" alt="image" src="https://github.com/user-attachments/assets/22f095f8-e4b8-477c-bfcd-a15ce8fd5024" />

Before fix; using wrong alias:
<img width="1084" height="596" alt="image" src="https://github.com/user-attachments/assets/86fc5089-2801-46f9-97ab-8e615f731972" />

After fix; using primary alias:
<img width="1872" height="1231" alt="image" src="https://github.com/user-attachments/assets/67549cd9-6ee8-4d78-9714-1e0951795d74" />


## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1651