### PR TITLE
FIX: In filtered topic views, blank lines showing for topics that user doesn't have permissions to read

### DIFF
--- a/Dnn.CommunityForums/Controllers/ForumController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumController.cs
@@ -144,28 +144,25 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             return forumId <= 0 ? null : new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().GetById(forumId, moduleId);
         }
 
-        public static string GetForumsForUser(int portalId, int moduleId, ForumUserInfo forumUser, string permissionType = "CanView", bool strict = false)
+        public static string GetForumsForUser(int portalId, int moduleId, ForumUserInfo forumUser, DotNetNuke.Modules.ActiveForums.SecureActions action = DotNetNuke.Modules.ActiveForums.SecureActions.View, string permissionType = "CanView")
         {
-            // Setting strict to true enforces the actual permission
-            // If strict is false, forums will show up in the list if they are not hidden for users
-            // that don't otherwise have access
             var forumIds = string.Empty;
             DotNetNuke.Modules.ActiveForums.Entities.ForumCollection fc = new DotNetNuke.Modules.ActiveForums.Controllers.ForumController().GetForums(moduleId);
             foreach (DotNetNuke.Modules.ActiveForums.Entities.ForumInfo f in fc)
             {
                 var roles = new HashSet<int>();
-                switch (permissionType)
+                switch (action)
                 {
-                    case "CanView":
+                    case DotNetNuke.Modules.ActiveForums.SecureActions.View:
                         roles = f.Security?.ViewRoleIds;
                         break;
-                    case "CanRead":
+                    case DotNetNuke.Modules.ActiveForums.SecureActions.Read:
                         roles = f.Security?.ReadRoleIds;
                         break;
-                    case "CanApprove":
+                    case DotNetNuke.Modules.ActiveForums.SecureActions.Moderate:
                         roles = f.Security?.ModerateRoleIds;
                         break;
-                    case "CanEdit":
+                    case DotNetNuke.Modules.ActiveForums.SecureActions.Edit:
                         roles = f.Security?.EditRoleIds;
                         break;
                     default:
@@ -175,7 +172,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
 
                 var hasPermissions = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasRequiredPerm(roles, forumUser.UserRoleIds);
 
-                if ((hasPermissions || (!strict && !f.Hidden && (permissionType == "CanView" || permissionType == "CanRead"))) && f.Active)
+                if (hasPermissions)
                 {
                     forumIds += string.Concat(f.ForumID, ";");
                 }

--- a/Dnn.CommunityForums/CustomControls/HTML/TopicBrowser.cs
+++ b/Dnn.CommunityForums/CustomControls/HTML/TopicBrowser.cs
@@ -72,7 +72,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
         public string Render()
         {
-            string fs = DotNetNuke.Modules.ActiveForums.Controllers.ForumController.GetForumsForUser(this.PortalId, this.ModuleId, this.ForumUser, "CanEdit");
+            string fs = DotNetNuke.Modules.ActiveForums.Controllers.ForumController.GetForumsForUser(this.PortalId, this.ModuleId, this.ForumUser, DotNetNuke.Modules.ActiveForums.SecureActions.Edit);
             if (!string.IsNullOrEmpty(fs))
             {
                 this._canEdit = true;

--- a/Dnn.CommunityForums/CustomControls/UserControls/UserProfile.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/UserProfile.cs
@@ -126,7 +126,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             Literal lit = new Literal();
 
             var user = new DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController(this.ForumModuleId).GetByUserId(this.PortalId, this.UID);
-            user.UserForums = DotNetNuke.Modules.ActiveForums.Controllers.ForumController.GetForumsForUser(this.PortalId, this.ForumModuleId, this.ForumUser, "CanRead");
+            user.UserForums = DotNetNuke.Modules.ActiveForums.Controllers.ForumController.GetForumsForUser(this.PortalId, this.ForumModuleId, this.ForumUser, DotNetNuke.Modules.ActiveForums.SecureActions.Read);
             var author = new DotNetNuke.Modules.ActiveForums.Entities.AuthorInfo(this.PortalId, this.ForumModuleId, this.UID);
             sTemplate = TemplateUtils.ParseProfileTemplate(this.ForumModuleId, sTemplate, author, this.ImagePath, this.ForumUser.CurrentUserType, false, false, string.Empty, this.UserInfo.UserID, this.TimeZoneOffset);
             sTemplate = this.RenderModals(sTemplate);

--- a/Dnn.CommunityForums/Entities/ForumInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumInfo.cs
@@ -467,7 +467,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         [IgnoreColumn]
         public bool GetIsMod(DotNetNuke.Modules.ActiveForums.Entities.ForumUserInfo forumUser)
         {
-            return (!(string.IsNullOrEmpty(DotNetNuke.Modules.ActiveForums.Controllers.ForumController.GetForumsForUser(this.PortalId, this.ModuleId, forumUser, "CanApprove"))));
+            return !string.IsNullOrEmpty(DotNetNuke.Modules.ActiveForums.Controllers.ForumController.GetForumsForUser(this.PortalId, this.ModuleId, forumUser, DotNetNuke.Modules.ActiveForums.SecureActions.Moderate));
         }
 
         [IgnoreColumn]

--- a/Dnn.CommunityForums/Entities/ForumUserInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumUserInfo.cs
@@ -208,7 +208,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         [IgnoreColumn]
         public bool GetIsMod(int ModuleId)
         {
-            return !this.IsAnonymous && !string.IsNullOrEmpty(DotNetNuke.Modules.ActiveForums.Controllers.ForumController.GetForumsForUser(this.PortalId, ModuleId, this, "CanApprove"));
+            return !this.IsAnonymous && !string.IsNullOrEmpty(DotNetNuke.Modules.ActiveForums.Controllers.ForumController.GetForumsForUser(this.PortalId, ModuleId, this, DotNetNuke.Modules.ActiveForums.SecureActions.Moderate));
         }
 
         [IgnoreColumn]

--- a/Dnn.CommunityForums/ReleaseNotes.txt
+++ b/Dnn.CommunityForums/ReleaseNotes.txt
@@ -85,6 +85,7 @@
         <h4>Bug Fixes</h4>
         <ul>
               <li>FIX: Primary portal alias ignored when generating some links (was just using first available alias) (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1651">Issue 1651</a>)</li>
+              <li>FIX: In filtered topic views, blank lines showing for topics that user doesn't have permissions to read (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1676">Issue 1676</a>)</li>
             
 <!--
 

--- a/Dnn.CommunityForums/controls/af_grid.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_grid.ascx.cs
@@ -157,7 +157,7 @@ namespace DotNetNuke.Modules.ActiveForums
             this.rowIndex = (this.PageId - 1) * this.pageSize;
 
             var db = new Data.Common();
-            var forumIds = DotNetNuke.Modules.ActiveForums.Controllers.ForumController.GetForumsForUser(this.PortalId, this.ForumModuleId, this.ForumUser, "CanRead");
+            var forumIds = DotNetNuke.Modules.ActiveForums.Controllers.ForumController.GetForumsForUser(this.PortalId, this.ForumModuleId, this.ForumUser, DotNetNuke.Modules.ActiveForums.SecureActions.Read);
 
             if (this.Request.Params[ParamKeys.GridType] != null)
             {

--- a/Dnn.CommunityForums/controls/af_search.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_search.ascx.cs
@@ -547,7 +547,7 @@ namespace DotNetNuke.Modules.ActiveForums
             // An intersection of the forums allows vs forums requested.
             var parseId = 0;
 
-            var sForumsAllowed = DotNetNuke.Modules.ActiveForums.Controllers.ForumController.GetForumsForUser(this.PortalId, this.ModuleId, this.ForumUser, "CanRead", true); // Make sure and pass strict = true here
+            var sForumsAllowed = DotNetNuke.Modules.ActiveForums.Controllers.ForumController.GetForumsForUser(this.PortalId, this.ModuleId, this.ForumUser, DotNetNuke.Modules.ActiveForums.SecureActions.Read);
             var forumsAllowed = sForumsAllowed.Split(new[] { ':', ';' }).Where(f => int.TryParse(f, out parseId)).Select(f => parseId).ToList();
             var forumsRequested = this.Forums.Split(new[] { ':', ';' }).Where(f => int.TryParse(f, out parseId)).Select(f => parseId).ToList();
 


### PR DESCRIPTION

<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...

Relaxed ("non-strict") permissions were being used to populate list of forums to retrieve topics for filtered views.
However, rendering token replacement (IPropertyAccess / GetProperty() always uses strict permissions. This resulted in unpopulated/blank values being shown for topics in forums to which the user doesn't have access. 

## Changes made
- Remove "non-strict" permissions checking and just use actual permissions.
- Refactor forum permissions checking to use enums not strings

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install.

Before (blanks):
<img width="1828" height="1437" alt="image" src="https://github.com/user-attachments/assets/fc9c859c-0b96-420b-880e-95223fc72be3" />

After (correctly showing no unread topics)
<img width="1841" height="1103" alt="image" src="https://github.com/user-attachments/assets/d107db71-8971-47b6-b1b6-c6148095a112" />


## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1676