### PR TITLE
BUG: Portal logo not showing in email notifications on multi-language sites

### DIFF
--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
@@ -1027,10 +1027,9 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
             bool isReply = !dr.GetInt("ReplyId").Equals(0);
 
-
             // Replace Tags Control
             var tags = dr.GetString("Tags");
-            if (string.IsNullOrWhiteSpace(tags))
+            if (tags.Equals(",") || string.IsNullOrWhiteSpace(tags))
             {
                 sOutput = TemplateUtils.ReplaceSubSection(sOutput, string.Empty, "[AF:CONTROL:TAGS]", "[/AF:CONTROL:TAGS]");
             }

--- a/Dnn.CommunityForums/Services/Tokens/ForumsModuleTokenReplacer.cs
+++ b/Dnn.CommunityForums/Services/Tokens/ForumsModuleTokenReplacer.cs
@@ -21,10 +21,12 @@
 namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
 {
     using System;
+    using System.IO;
 
     using DotNetNuke.Entities.Host;
     using DotNetNuke.Entities.Portals;
     using DotNetNuke.Services.Authentication;
+    using DotNetNuke.Services.FileSystem;
     using DotNetNuke.Services.Tokens;
 
     internal class ForumsModuleTokenReplacer : DotNetNuke.Services.Tokens.BaseCustomTokenReplace, DotNetNuke.Services.Tokens.IPropertyAccess
@@ -117,6 +119,21 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
             {
                 switch (propertyName)
                 {
+                    case "portallogourl":
+                        {
+                            var logoUrl = FileManager.Instance.GetUrl(FileManager.Instance.GetFile(this.PortalSettings.PortalId, this.PortalSettings.LogoFile));
+                            logoUrl = $"https://{this.PortalSettings.DefaultPortalAlias}{logoUrl}";
+                            logoUrl = Utilities.RemoveCultureFromUrl(this.PortalSettings, logoUrl);
+                            return PropertyAccess.FormatString(Utilities.ResolveUrl(this.PortalSettings, logoUrl), format);
+                        }
+
+                    case "portalurlwithoutculture":
+                        {
+                            var portalUrl = $"https://{this.PortalSettings.DefaultPortalAlias}";
+                            portalUrl = Utilities.RemoveCultureFromUrl(this.PortalSettings, portalUrl);
+                            return PropertyAccess.FormatString(Utilities.ResolveUrl(this.PortalSettings, portalUrl), format);
+                        }
+
                     case "loginlink":
                         {
                             // [DCF:LOGINLINK|Please <a href="{0}">login</a> to join the conversation.]
@@ -206,5 +223,6 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
                 return this.PortalSettings.LoginTabId > 0 ? Utilities.NavigateURL(this.PortalSettings.LoginTabId, string.Empty, $"returnUrl={this.RawUrl}") : Utilities.NavigateURL(this.TabId, string.Empty, $"ctl=login&returnUrl={this.RawUrl}");
             }
         }
+
     }
 }

--- a/Dnn.CommunityForums/class/Utilities.cs
+++ b/Dnn.CommunityForums/class/Utilities.cs
@@ -1922,5 +1922,15 @@ namespace DotNetNuke.Modules.ActiveForums
 
             return false;
         }
+
+        internal static string RemoveCultureFromUrl(DotNetNuke.Entities.Portals.PortalSettings portalSettings, string url)
+        {
+            if (!string.IsNullOrEmpty(portalSettings.PortalAlias?.CultureCode) && url.ToLowerInvariant().Contains($"/{portalSettings.PortalAlias?.CultureCode?.ToLowerInvariant()}/"))
+            {
+                url = url.ToLowerInvariant().Replace($"/{portalSettings.PortalAlias.CultureCode.ToLowerInvariant()}/", "/");
+            }
+
+            return url;
+        }
     }
 }

--- a/Dnn.CommunityForums/config/templates/SubscribedEmail.ascx
+++ b/Dnn.CommunityForums/config/templates/SubscribedEmail.ascx
@@ -125,7 +125,7 @@
                                 <tr>
                                     <td class="headerContent">
                                         <a href="[PORTAL:SCHEME]://[PORTAL:URL]">
-                                            <img src="[PORTAL:SCHEME]://[PORTAL:URL][PORTAL:HOMEDIRECTORY][PORTAL:LOGOFILE]" style="max-width: 600px;" id="headerImage campaign-icon" width="200" />
+                                            <img src="[DCF:PORTALLOGOURL]" style="max-width: 600px;" id="headerImage campaign-icon" width="200" />
                                         </a>
 
                                     </td>
@@ -176,8 +176,7 @@
                                                 <td valign="top">
                                                     <table width="80" border="0" cellspacing="0" cellpadding="8" align="left">
                                                         <tr>
-                                                            <td>[FORUMAUTHOR:USERPROFILELINK|<a href="{0}" class="af-profile-link" rel="nofollow">[FORUMAUTHOR:AVATAR:60]<br />
-                                                                [FORUMAUTHOR:DISPLAYNAME]</a>|[FORUMAUTHOR:DISPLAYNAME]]
+                                                            <td>[FORUMAUTHOR:USERPROFILELINK|<a href="{0}" class="af-profile-link" rel="nofollow">[FORUMAUTHOR:AVATAR:60]<br />[FORUMAUTHOR:DISPLAYNAME]</a>|[FORUMAUTHOR:AVATAR:60]<br />[FORUMAUTHOR:DISPLAYNAME]]
                                                             </td>
                                                         </tr>
                                                     </table>

--- a/Dnn.CommunityForumsTests/TestBase.cs
+++ b/Dnn.CommunityForumsTests/TestBase.cs
@@ -330,6 +330,8 @@ namespace DotNetNuke.Modules.ActiveForumsTests
                 AdministratorRoleName = DotNetNuke.Tests.Utilities.Constants.RoleName_Administrators,
                 RegisteredRoleId = DotNetNuke.Tests.Utilities.Constants.RoleID_RegisteredUsers,
                 RegisteredRoleName = DotNetNuke.Tests.Utilities.Constants.RoleName_RegisteredUsers,
+                PortalAlias = new PortalAliasInfo { HTTPAlias = "localhost", CultureCode = "en-US", IsPrimary = true, },
+                CultureCode = "en-US",
             };
 
             this.portalController.Setup(pc => pc.GetCurrentPortalSettings()).Returns(portalSettings);

--- a/Dnn.CommunityForumsTests/class/UtilitiesTests.cs
+++ b/Dnn.CommunityForumsTests/class/UtilitiesTests.cs
@@ -649,5 +649,18 @@ namespace DotNetNuke.Modules.ActiveForumsTests
             // Assert
             Assert.That(result, Is.EqualTo(expected));
         }
+
+        [Test]
+        [TestCase("https://localhost/en-us/portals/0/images/logo.png", ExpectedResult = "https://localhost/portals/0/images/logo.png")]
+        [TestCase("https://localhost/portals/0/images/logo.png", ExpectedResult = "https://localhost/portals/0/images/logo.png")]
+        public string RemoveCultureFromUrl(string url)
+        {
+            // Arrange
+
+            // Act
+            return Utilities.RemoveCultureFromUrl(DotNetNuke.Entities.Portals.PortalController.Instance.GetCurrentPortalSettings(), url);
+
+            // Assert
+        }
     }
 }


### PR DESCRIPTION

<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Portal logo not showing in email notifications when running a multi-language sites

## Changes made
- Add a new token [DCF:PORTALLOGOURL] that removes culture portion of the URL if it exists 
- Change email notification logo from `[PORTAL:SCHEME]://[PORTAL:URL][PORTAL:HOMEDIRECTORY][PORTAL:LOGOFILE]` to `[DCF:PORTALLOGOURL]` 
- Also added new token [DCF:PORTALURLWITHOUTCULTURE] that removes culture portion of the portal URL if it exists 

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install
<img width="595" height="533" alt="image" src="https://github.com/user-attachments/assets/1f6eebae-2148-418f-a0cf-c07563a7dd88" />

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [X] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1731