### PR TITLE
ENH: Require URL prefix for forum/forum groups when URL rewriter enabled

### DIFF
--- a/Dnn.CommunityForums/controls/admin_manageforums_forumeditor.ascx
+++ b/Dnn.CommunityForums/controls/admin_manageforums_forumeditor.ascx
@@ -16,7 +16,7 @@
     function forumSave() {
         closeAllProp();
         var fgp = document.getElementById("<%=drpGroups.ClientID%>");
-        if(fgp && !AMPage.IsGroupValid('afforum')){return false};
+        if(!AMPage.IsGroupValid('afforum')){return false};
         af_showLoad();
         var fname = document.getElementById("<%=txtForumName.ClientID%>");
         if (fname) {
@@ -958,6 +958,9 @@ function afadmin_getProperties() {
                         <td class="amcpbold" valign="top">[RESX:VanityName]:</td>
                         <td width="100%">
                             <asp:textbox id="txtPrefixURL" runat="server" width="100%" cssclass="amcptxtbx" maxlength="50" onkeypress="return filterVanity(this,event);" />
+                        </td>
+                        <td>
+                            <am:requiredfieldvalidator id="reqPrefix" runat="server" text="*" controltovalidate="txtPrefixURL" validationgroup="afforum" />
                         </td>
                         <td>
                             <img src="<%=Page.ResolveUrl("~/DesktopModules/activeforums/images/spacer.gif")%>" width="20" height="" /></td>

--- a/Dnn.CommunityForums/controls/admin_manageforums_forumeditor.ascx.cs
+++ b/Dnn.CommunityForums/controls/admin_manageforums_forumeditor.ascx.cs
@@ -51,6 +51,7 @@ namespace DotNetNuke.Modules.ActiveForums
         protected System.Web.UI.HtmlControls.HtmlTableRow trDesc;
         protected System.Web.UI.WebControls.TextBox txtForumDesc;
         protected System.Web.UI.HtmlControls.HtmlTableRow trPrefix;
+        protected DotNetNuke.Modules.ActiveForums.Controls.RequiredFieldValidator reqPrefix;
         protected System.Web.UI.WebControls.TextBox txtPrefixURL;
         protected System.Web.UI.HtmlControls.HtmlTable trActive;
         protected System.Web.UI.WebControls.CheckBox chkActive;
@@ -188,6 +189,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 this.trActive.Visible = false;
                 this.trHidden.Visible = false;
                 this.reqGroups.Enabled = false;
+                this.reqPrefix.Enabled = false;
                 this.trDesc.Visible = false;
                 this.trInheritModuleFeatures.Visible = false;
                 this.trInheritModuleSecurity.Visible = false;
@@ -201,6 +203,7 @@ namespace DotNetNuke.Modules.ActiveForums
             {
                 this.trGroups.Visible = false;
                 this.reqGroups.Enabled = false;
+                this.reqPrefix.Enabled = this.MainSettings.URLRewriteEnabled;
                 this.trDesc.Visible = false;
                 this.trInheritModuleFeatures.Visible = true;
                 this.trInheritModuleSecurity.Visible = true;
@@ -213,6 +216,7 @@ namespace DotNetNuke.Modules.ActiveForums
             }
             else if (this.editorType == "F")
             {
+                this.reqPrefix.Enabled = this.MainSettings.URLRewriteEnabled;
                 this.lblForumGroupName.Text = this.GetSharedResource("[RESX:ForumName]");
                 this.trInheritModuleFeatures.Visible = false;
                 this.trInheritModuleSecurity.Visible = false;
@@ -246,8 +250,10 @@ namespace DotNetNuke.Modules.ActiveForums
 
             this.imgOn = this.Page.ResolveUrl(DotNetNuke.Modules.ActiveForums.Globals.ModuleImagesPath + "admin_check.png");
             this.imgOff = this.Page.ResolveUrl(DotNetNuke.Modules.ActiveForums.Globals.ModuleImagesPath + "admin_stop.png");
+
             this.reqForumName.Text = "<img src=\"" + this.Page.ResolveUrl(RequiredImage) + "\" />";
             this.reqGroups.Text = "<img src=\"" + this.Page.ResolveUrl(RequiredImage) + "\" />";
+            this.reqPrefix.Text = "<img src=\"" + this.Page.ResolveUrl(RequiredImage) + "\" />";
             var propImage = "<img src=\"" + this.Page.ResolveUrl(DotNetNuke.Modules.ActiveForums.Globals.ModuleImagesPath + "properties16.png") + "\" alt=\"[RESX:ConfigureProperties]\" />";
 
             this.rdAttachOn.Attributes.Add("onclick", "toggleAttach(this);");


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Require URL prefix (vanity name) for forum and forum groups in Control panel when URL rewriter is enabled in module settings.


## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

<img width="1409" height="1028" alt="image" src="https://github.com/user-attachments/assets/18c8dedf-9873-423d-b235-846fe4460659" />

<img width="1397" height="822" alt="image" src="https://github.com/user-attachments/assets/f01fc60e-bb35-4f01-96ae-85b8deef79f6" />


## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1546 