### PR TITLE
ENH: ensure friendly URL/vanity names during upgrade

### DIFF
--- a/Dnn.CommunityForums/components/Topics/TopicsController.cs
+++ b/Dnn.CommunityForums/components/Topics/TopicsController.cs
@@ -379,6 +379,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     try
                     {
                         DotNetNuke.Modules.ActiveForums.Helpers.UpgradeModuleSettings.DeleteObsoleteModuleSettings_090600();
+                        ForumsConfig.Upgrade_EnsureVanityNames_090600();
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
During upgrade, ensure forums and forum groups all have non-empty vanity names if using friendly URLs.


## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1546