### PR TITLE
FIX: remove leading comma in list of topic tags in TopicView

### DIFF
--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
@@ -1040,12 +1040,15 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 var tagList = string.Empty;
                 foreach (var tag in tags.Split(','))
                 {
-                    if (tagList != string.Empty)
+                    if (!string.IsNullOrEmpty(tag))
                     {
-                        tagList += ", ";
-                    }
+                        if (tagList != string.Empty)
+                        {
+                            tagList += ", ";
+                        }
 
-                    tagList += "<a href=\"" + Utilities.NavigateURL(this.TabId, string.Empty, new[] { ParamKeys.ViewType + "=search", ParamKeys.Tags + "=" + System.Net.WebUtility.UrlEncode(tag) }) + "\">" + tag + "</a>";
+                        tagList += "<a href=\"" + Utilities.NavigateURL(this.TabId, string.Empty, new[] { ParamKeys.ViewType + "=search", ParamKeys.Tags + "=" + System.Net.WebUtility.UrlEncode(tag) }) + "\">" + tag + "</a>";
+                    }
                 }
 
                 sOutput = sOutput.Replace("[AF:LABEL:TAGS]", tagList);


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Fix leading comma in list of tags in Topic View

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

<img width="1181" height="851" alt="image" src="https://github.com/user-attachments/assets/f0db0453-07ce-4093-b3d7-8082dbb41126" />


## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1771