### PR TITLE
FIX: Isolate group in friendly URL rewriter

### DIFF
--- a/Dnn.CommunityForums/components/Extensions/ReWriter.cs
+++ b/Dnn.CommunityForums/components/Extensions/ReWriter.cs
@@ -441,6 +441,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
                 // avoid redirect, e.g. "/Support/Forums" == "support/forums/" ... starts or ends with /, same number of /, same text when ignoring /
                 if (this.urlType.Equals(0) &&
+                    this.forumgroupId <= 0 &&
                     this.forumId <= 0 &&
                     this.topicId <= 0 &&
                     ((searchURL2.StartsWith("/") || searchURL2.EndsWith("/")) &&


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Friendly URL for a forum group should show just that group.

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

<img width="1575" height="688" alt="image" src="https://github.com/user-attachments/assets/b00442ad-d5d0-4d86-af68-ee60e32d8746" />


## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1775