### PR TITLE
TASK: Remove legacy calendar.css reference

### DIFF
--- a/Dnn.CommunityForums/controls/af_post.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_post.ascx.cs
@@ -71,17 +71,6 @@ namespace DotNetNuke.Modules.ActiveForums
 
             ServicesFramework.Instance.RequestAjaxAntiForgerySupport();
 
-            var oLink = new System.Web.UI.HtmlControls.HtmlGenericControl("link");
-            oLink.Attributes["rel"] = "stylesheet";
-            oLink.Attributes["type"] = "text/css";
-            oLink.Attributes["href"] = this.Page.ResolveUrl(Globals.ModulePath + "scripts/calendar.css");
-
-            var oCSS = this.Page.FindControl("CSS");
-            if (oCSS != null)
-            {
-                oCSS.Controls.Add(oLink);
-            }
-
             this.authorId = this.UserId;
             this.canModApprove = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasRequiredPerm(this.ForumInfo.Security.ModerateRoleIds, this.ForumUser.UserRoleIds);
             this.canEdit = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasRequiredPerm(this.ForumInfo.Security.EditRoleIds, this.ForumUser.UserRoleIds);


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Task #1723 removed legacy datepicker but left a reference behind.

Link to already-removed and now-unused `calendar.css` generates 404.

## Changes made
- Remove loading of calendar.css

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1723