### PR TITLE
TASK: Use ClientResourceManager for loading module.css for Viewer module

### DIFF
--- a/Dnn.CommunityForums/ActiveForumViewer.ascx.cs
+++ b/Dnn.CommunityForums/ActiveForumViewer.ascx.cs
@@ -22,7 +22,11 @@ namespace DotNetNuke.Modules.ActiveForums
 {
     using System;
     using System.Linq;
+    using System.Web.UI;
     using System.Web.UI.WebControls;
+
+    using DotNetNuke.Web.Client;
+    using DotNetNuke.Web.Client.ClientResourceManagement;
 
     public partial class ActiveForumViewer : ForumBase
     {
@@ -57,17 +61,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     if (tmpForumTabId <= 0) { tmpForumTabId = this.TabId; }
                     this.ctlForumLoader.ForumTabId = tmpForumTabId;
                     this.ctlForumLoader.ModuleConfiguration = this.ModuleConfiguration;
-                    System.Web.UI.HtmlControls.HtmlGenericControl oLink = new System.Web.UI.HtmlControls.HtmlGenericControl("link");
-                    oLink.Attributes["rel"] = "stylesheet";
-                    oLink.Attributes["type"] = "text/css";
-                    oLink.Attributes["href"] = this.Page.ResolveUrl(Globals.ModulePath + "module.css");
-                    System.Web.UI.Control oCSS = this.Page.FindControl("CSS");
-                    if (oCSS != null)
-                    {
-                        int iControlIndex = 0;
-                        iControlIndex = oCSS.Controls.Count;
-                        oCSS.Controls.AddAt(0, oLink);
-                    }
+                    ClientResourceManager.RegisterStyleSheet(this.Page, this.Page.ResolveUrl(Globals.ModulePath + "module.css"), FileOrder.Css.ModuleCss);
                 }
                 else
                 {


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Forums Viewer module needs to load `module.css` from Forums module and should use ClientResourceManager.


## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [ ] Fixes Bug
- [ ] Feature solution
- [X] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1792