### PR TITLE
FIX: Create badges image folder if not exist

### DIFF
--- a/Dnn.CommunityForums/controls/admin_badges.ascx.cs
+++ b/Dnn.CommunityForums/controls/admin_badges.ascx.cs
@@ -87,7 +87,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
         private void BindBadgeImages()
         {
-            var folderInfo = DotNetNuke.Services.FileSystem.FolderManager.Instance.GetFolder(this.PortalId, Globals.DefaultBadgesFolderName);
+            var folderInfo = DotNetNuke.Services.FileSystem.FolderManager.Instance.GetFolder(this.PortalId, Globals.DefaultBadgesFolderName) ?? DotNetNuke.Services.FileSystem.FolderManager.Instance.AddFolder(this.PortalId, Globals.DefaultBadgesFolderName);
             foreach (var fileInfo in DotNetNuke.Services.FileSystem.FolderManager.Instance.GetFiles(folderInfo, recursive: true))
             {
                 if (fileInfo.ContentType.ToLowerInvariant().Contains("image/"))


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Control panel can't load badges list if images folder does not exist.

## Changes made
- Create folder if needed

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1795