### PR TITLE
FIX: Don't remove hashtag # character when processing tags and tagging is disabled

### DIFF
--- a/Dnn.CommunityForums/Controllers/TagController.cs
+++ b/Dnn.CommunityForums/Controllers/TagController.cs
@@ -62,7 +62,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             if (!DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasRequiredPerm(forum.Security.TagRoleIds, post.Author.ForumUser.UserRoleIds))
             {
                 // if the user does not have permission to add tags, remove any tags from the post content but leave tag text
-                post.Content.Body = RegexUtils.GetCachedRegex(tagsPattern, RegexOptions.Compiled & RegexOptions.IgnoreCase, 2).Replace(post.Content.Body, "$#{tag}");
+                post.Content.Body = RegexUtils.GetCachedRegex(tagsPattern, RegexOptions.Compiled & RegexOptions.IgnoreCase, 2).Replace(post.Content.Body, "#${tag}");
             }
             else
             {

--- a/Dnn.CommunityForums/ReleaseNotes.txt
+++ b/Dnn.CommunityForums/ReleaseNotes.txt
@@ -74,8 +74,10 @@
 -->
         <h4>New Features &amp; Enhancements</h4>
         <ul>
-            <li>None at this time.</li>
+            <li>NEW: New token [FORUMTOPIC:LASTPOSTURL] (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/pull/1811">PR 1811</a>)</li>
+            <li>UPDATE: Tweaks to topics view: show status text not status ID, reply count should show if not logged in, show last post author/date from topic if no replies (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/pull/1811">PR 1811</a>)</li>
 <!--
+            <li>None at this time.</li>
             <li>NEW: Web API endpoints for forums search functionality (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/pull/1758">PR 1758</a>)</li>
             <li>NEW: Require URL prefix for forum/forum groups in Control Panel when friendly URLs are enabled (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/pull/1765">PR 1765</a>)</li>
             <li>NEW: During upgrade, ensure friendly URL/vanity names are properly populated when friendly URLs are enabled (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/pull/1767">PR 1767</a>)</li>
@@ -97,6 +99,7 @@
 
         <ul>
              <li>FIX: Friendly URL for forum group only not showing forums (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1807">Issue 1807</a>)</li>
+             <li>FIX: Hashtag character # inadvertantly removed if tagging is disabled by security (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1812">Issue 1812</a>)</li>
 <!--
           <li>None at this time.</li> 
              


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Don't remove the # character from content when parsing #hashtags and tagging is disabled.
 

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

### Entering post 
<img width="596" height="790" alt="image" src="https://github.com/user-attachments/assets/8a1674ac-aebb-4cb4-b84c-98bbca92eeea" />

### Posted content
<img width="714" height="536" alt="image" src="https://github.com/user-attachments/assets/d6999073-41f6-44af-bcf5-b461a2c96f2a" />

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1812