### PR TITLE
ENH: Tweak visibility of users showing in mention list

### DIFF
--- a/Dnn.CommunityForums/ReleaseNotes.txt
+++ b/Dnn.CommunityForums/ReleaseNotes.txt
@@ -75,7 +75,7 @@
         <h4>New Features &amp; Enhancements</h4>
         <ul>
             
-            <li>None at this time.</li>
+            <li>UPDATE: When selecting users for mentions and visibility is "Registered Users", admins can also select other admins, and superusers can select anyone (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1819">Issue 1819</a>)</li>
 <!--
             <li>None at this time.</li>
             <li>NEW: Web API endpoints for forums search functionality (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/pull/1758">PR 1758</a>)</li>
@@ -99,6 +99,7 @@
 
         <ul>
              <li>FIX: Prevent blank tags from being created (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1825">Issue 1825</a>)</li>
+             <li>FIX: Correct location of Control Panel forums feature popup (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1820">Issue 1820</a>)</li>
 <!--
           <li>None at this time.</li> 
              

--- a/Dnn.CommunityForums/Services/Controllers/UserController.cs
+++ b/Dnn.CommunityForums/Services/Controllers/UserController.cs
@@ -185,9 +185,13 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Controllers
 
                         if (forum.FeatureSettings.UserMentionVisibility.Equals(DotNetNuke.Modules.ActiveForums.Enums.UserMentionVisibility.RegisteredUsers))
                         {
-                            users.RemoveAll(user => user.IsAdmin);
+                            if (!this.UserInfo.IsAdmin && !this.UserInfo.IsSuperUser)
+                            {
+                                users.RemoveAll(user => user.IsAdmin);
+                            }
                         }
-                        else if (forum.FeatureSettings.UserMentionVisibility.Equals(DotNetNuke.Modules.ActiveForums.Enums.UserMentionVisibility.Everyone))
+
+                        if (forum.FeatureSettings.UserMentionVisibility.Equals(DotNetNuke.Modules.ActiveForums.Enums.UserMentionVisibility.Everyone) || this.UserInfo.IsSuperUser)
                         {
                             users.AddRange(
                                 DotNetNuke.Entities.Users.UserController.GetUsersByDisplayName(


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Tweaks list of users shown for user mentions to include admins if user is an administrator or superuser, and superusers to other superusers.

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [ ] Fixes Bug
- [X] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1819