### PR TITLE
FIX: Refresh page when emptying recycle bin

### DIFF
--- a/Dnn.CommunityForums/Extensions/WebForms/GridViewExtensions.cs
+++ b/Dnn.CommunityForums/Extensions/WebForms/GridViewExtensions.cs
@@ -31,7 +31,7 @@ namespace DotNetNuke.Modules.ActiveForums.Extensions.WebForms
     {
         public static void WrapGridViewInDataTableNet(this GridView gridView, Abstractions.Portals.IPortalSettings portalSettings, DotNetNuke.Entities.Users.UserInfo userInfo)
         {
-            if (gridView.Rows.Count > 0)
+            if (gridView?.Rows?.Count > 0)
             {
                 ClientResourceManager.RegisterScript(gridView.Page, Globals.ModulePath + "Resources/datatables.net-2.3.3/Scripts/dataTables.min.js", FileOrder.Js.DefaultPriority + 2, "DnnPageHeaderProvider");
                 ClientResourceManager.RegisterScript(gridView.Page, Globals.ModulePath + "Resources/datatables.net-dt-2.3.3/Scripts/dataTables.dataTables.min.js", FileOrder.Js.DefaultPriority + 3, "DnnPageHeaderProvider");

--- a/Dnn.CommunityForums/controls/af_recycle_bin.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_recycle_bin.ascx.cs
@@ -90,7 +90,8 @@ namespace DotNetNuke.Modules.ActiveForums
             {
                 topicController.DeleteById(content.TopicId, DeleteBehavior.Remove);
             });
-            this.BindRecycleData();
+
+            this.Response.Redirect(this.Request.RawUrl, true);
         }
 
         protected void btnRestoreAll_Click(object sender, System.EventArgs e)


### PR DESCRIPTION

<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Refresh page when emptying recycle bin to avoid datatables browser warning


## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install 

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1858