### PR TITLE
FIX: Misspelled resource key for "italics" button in TipTap editor

### DIFF
--- a/Dnn.CommunityForums/Resources/tiptap-editor3/tiptap-editor.js
+++ b/Dnn.CommunityForums/Resources/tiptap-editor3/tiptap-editor.js
@@ -35,7 +35,7 @@ export default class TipTapEditorController {
         this.editorElement = document.querySelector('#' + editorID)
         this.actions = [
             { name: "bold", title: amaf.resx.BoldDesc, fontTag: "fa-bold", command: 'toggleBold', disable: true },
-            { name: "italic", title: amaf.resx.ItalicDesc, fontTag: "fa-italic", command: 'toggleItalic', disable: true },
+            { name: "italic", title: amaf.resx.ItalicsDesc, fontTag: "fa-italic", command: 'toggleItalic', disable: true },
             { name: "underline", title: amaf.resx.UnderlineDesc, fontTag: "fa-underline", command: 'toggleUnderline', disable: true },
             { name: "strike", title: amaf.resx.StrikeDesc, fontTag: "fa-strikethrough", command: 'toggleStrike', disable: true },
             { name: "undo", title: amaf.resx.UndoDesc, fontTag: "fa-undo", command: 'undo', disable: true },

--- a/Dnn.CommunityForums/scripts/resx.js
+++ b/Dnn.CommunityForums/scripts/resx.js
@@ -23,7 +23,7 @@ amaf.resx = {
     Subscribe: '[RESX:Subscribe]',
     Unsubscribe: '[RESX:Unsubscribe]',
     BoldDesc: '[RESX:BoldDesc]',
-    ItalicDesc: '[RESX:ItalicDesc]',
+    ItalicsDesc: '[RESX:ItalicsDesc]',
     UnderlineDesc: '[RESX:UnderlineDesc]',
     StrikeDesc: '[RESX:StrikeDesc]',
     UndoDesc: '[RESX:UndoDesc]',


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Fix misspelled resource key

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1900