### PR TITLE
FIX: "Autolink" feature now ignores invalid URLs

### DIFF
--- a/Dnn.CommunityForums/class/Utilities.cs
+++ b/Dnn.CommunityForums/class/Utilities.cs
@@ -383,7 +383,13 @@ namespace DotNetNuke.Modules.ActiveForums
                 urlText = string.Concat(url.Substring(0, maxLengthAutoLinkLabel - 22), "...", url.Substring(url.Length - 20));
             }
 
-            return url.ToLowerInvariant().Contains(currentSite.ToLowerInvariant()) ? string.Format(inSite, new Uri(url).AbsoluteUri, urlText) : string.Format(outSite, new Uri(url).AbsoluteUri, urlText);
+            var validUri = Uri.IsWellFormedUriString(url, UriKind.Absolute);
+            if (validUri)
+            {
+                return url.ToLowerInvariant().Contains(currentSite.ToLowerInvariant()) ? string.Format(inSite, new Uri(url).AbsoluteUri, urlText) : string.Format(outSite, new Uri(url).AbsoluteUri, urlText);
+            }
+
+            return match.Value;
         }
 
         public static string AutoLinks(string text, string currentSite)

--- a/Dnn.CommunityForumsTests/class/UtilitiesTests.cs
+++ b/Dnn.CommunityForumsTests/class/UtilitiesTests.cs
@@ -942,6 +942,17 @@ namespace DotNetNuke.Modules.ActiveForumsTests
         }
 
         [Test]
+        [TestCase("Visit https://.../en-us/internal and https://external.com", ExpectedResult = "Visit https://.../en-us/internal and <a href=\"https://external.com/\" target=\"_blank\" rel=\"nofollow\">https://external.com</a>")]
+        public string AutoLinks_WithInvalidUrl_ShouldSkipInvalidUrl(string text)
+        {
+            // Arrange & Act
+            var result = Utilities.AutoLinks(text, this.DefaultSite);
+
+            // Assert
+            return result;
+        }
+
+        [Test]
         [TestCase("&lt;a href=\"https://example.com\"&gt;Link&lt;/a&gt;", ExpectedResult = true)]
         public bool AutoLinks_WithEncodedHref_ShouldDecodeAndProcess(string text)
         {
@@ -1165,6 +1176,26 @@ namespace DotNetNuke.Modules.ActiveForumsTests
 
             // Assert
             return result == expected;
+        }
+
+        [Test]
+        public void ReplaceLink_WithInvalidUrl_ShouldSkipInvalidUrl()
+        {
+            // Arrange
+            string url = "https://.../en-us/internal";
+            string expected = url;
+
+            // Act
+            var match = System.Text.RegularExpressions.Regex.Match(url, UrlPattern, RegexOptions.IgnoreCase);
+            if (!match.Success)
+            {
+                Assert.Fail();
+            }
+
+            string result = Utilities.ReplaceLink(match, this.DefaultSite, url);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(expected));
         }
     }
 }

--- a/Dnn.CommunityForumsTests/class/UtilitiesTests.cs
+++ b/Dnn.CommunityForumsTests/class/UtilitiesTests.cs
@@ -942,6 +942,17 @@ namespace DotNetNuke.Modules.ActiveForumsTests
         }
 
         [Test]
+        [TestCase("Visit https://.../en-us/internal and https://external.com", ExpectedResult = "Visit https://.../en-us/internal and <a href=\"https://external.com/\" target=\"_blank\" rel=\"nofollow\">https://external.com</a>")]
+        public string AutoLinks_WithInvalidUrl_ShouldSkipInvalidUrl(string text)
+        {
+            // Arrange & Act
+            var result = Utilities.AutoLinks(text, this.DefaultSite);
+
+            // Assert
+            return result;
+        }
+
+        [Test]
         [TestCase("&lt;a href=\"https://example.com\"&gt;Link&lt;/a&gt;", ExpectedResult = true)]
         public bool AutoLinks_WithEncodedHref_ShouldDecodeAndProcess(string text)
         {
@@ -971,7 +982,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests
             var result = Utilities.AutoLinks(text, this.DefaultSite);
 
             // Assert
-            return result == string.Empty;
+            return  result == string.Empty;
         }
 
         [Test]
@@ -1165,6 +1176,26 @@ namespace DotNetNuke.Modules.ActiveForumsTests
 
             // Assert
             return result == expected;
+        }
+
+        [Test]
+        public void ReplaceLink_WithInvalidUrl_ShouldSkipInvalidUrl()
+        {
+            // Arrange
+            string url = "https://.../en-us/internal";
+            string expected = url;
+
+            // Act
+            var match = System.Text.RegularExpressions.Regex.Match(url, UrlPattern, RegexOptions.IgnoreCase);
+            if (!match.Success)
+            {
+                Assert.Fail();
+            }
+
+            string result = Utilities.ReplaceLink(match, this.DefaultSite, url);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(expected));
         }
     }
 }


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
AutoLink feature should ignore and not try to process malformed URLs

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

Before: 
<img width="1131" height="375" alt="image" src="https://github.com/user-attachments/assets/4810ed44-af7f-47cd-9645-13634ac7a2bb" />

After:
<img width="1193" height="520" alt="image" src="https://github.com/user-attachments/assets/825652c0-ce77-4fbe-94a6-4709e648cb2b" />

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1902