### PR TITLE
FIX: Last reply name tokens showing original topic author's name

### DIFF
--- a/Dnn.CommunityForums/Entities/TopicInfo.cs
+++ b/Dnn.CommunityForums/Entities/TopicInfo.cs
@@ -1032,7 +1032,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
 
                     case "lastpostauthordisplaynamelink":
                         return PropertyAccess.FormatString(
-                            this.LastReplyId > 0 && this.Author.AuthorId > 0
+                            this.LastReplyId > 0 && this.LastReply.Author.AuthorId > 0
                                 ? Controllers.ForumUserController.CanLinkToProfile(
                                     this.Forum.PortalSettings,
                                     this.Forum.MainSettings,
@@ -1040,7 +1040,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                                     new Controllers.ForumUserController(this.ModuleId).GetByUserId(
                                         accessingUser.PortalID,
                                         accessingUser.UserID),
-                                    this.Author.ForumUser)
+                                    this.LastReply.Author.ForumUser)
                                     ? Utilities.NavigateURL(
                                         this.Forum.PortalSettings.UserTabId,
                                         string.Empty,
@@ -1067,19 +1067,19 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                             var forumUser = forumUserController.GetByUserId(accessingUser.PortalID, accessingUser.UserID);
                             return PropertyAccess.FormatString(
                                 this.LastReplyId > 0
-                                    ? this.Author.AuthorId > 0
+                                    ? this.LastReply.Author.AuthorId > 0
                                         ? Controllers.ForumUserController.GetDisplayName(
                                                 this.Forum.PortalSettings,
                                                 this.Forum.MainSettings,
                                                 bModerate,
                                                 forumUser.IsAdmin || forumUser.IsSuperUser,
-                                                this.Author.AuthorId,
-                                                this.Author.Username,
-                                                this.Author.FirstName,
-                                                this.Author.LastName,
-                                                this.Author.DisplayName).Replace("&amp;#", "&#")
-                                            .Replace("Anonymous", this.Content.AuthorName)
-                                        : this.Content.AuthorName
+                                                this.LastReply.Author.AuthorId,
+                                                this.LastReply.Author.Username,
+                                                this.LastReply.Author.FirstName,
+                                                this.LastReply.Author.LastName,
+                                                this.LastReply.Author.DisplayName).Replace("&amp;#", "&#")
+                                            .Replace("Anonymous", this.LastReply.Content.AuthorName)
+                                        : this.LastReply.Content.AuthorName
                                     : this.Author.AuthorId > 0
                                         ? Controllers.ForumUserController.GetDisplayName(
                                                 this.Forum.PortalSettings,


### PR DESCRIPTION
…

<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...

`[FORUMTOPIC:LASTPOSTAUTHORDISPLAYNAMELINK]` and `[FORUMTOPIC:LASTPOSTSTAUTHORDISPLAYNAME]` showing original topic author not latest reply author


## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install
<img width="1800" height="589" alt="image" src="https://github.com/user-attachments/assets/efa783f9-7ddf-4c8e-a8b4-a6e0254e649d" />

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1905