### PR TITLE
ENH: Remove URLBASE friendly URL module setting

### DIFF
--- a/Dnn.CommunityForums/Classic.ascx.cs
+++ b/Dnn.CommunityForums/Classic.ascx.cs
@@ -112,9 +112,9 @@ namespace DotNetNuke.Modules.ActiveForums
                     {
                         ctl = Views.RecycleBin;
                     }
-                    else if (this.Request.Params[ParamKeys.ViewType] != null && this.Request.Params[ParamKeys.ViewType] == Views.Grid && this.Request.Params[ParamKeys.GridType] != null && this.Request.Params[ParamKeys.GridType] == Views.Likes)
+                    else if (this.Request.Params[ParamKeys.ViewType] != null && this.Request.Params[ParamKeys.ViewType] == Views.Grid && this.Request.Params[ParamKeys.GridType] != null && this.Request.Params[ParamKeys.GridType] == Views.likes)
                     {
-                        ctl = Views.Likes;
+                        ctl = Views.likes;
                         if (this.Request.QueryString[ParamKeys.ContentId] != null)
                         {
                             opts = $"{ParamKeys.ContentId}={this.Request.QueryString[ParamKeys.ContentId]}";

--- a/Dnn.CommunityForums/Controllers/ForumUserController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumUserController.cs
@@ -612,7 +612,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                 imgUrl = $"https://{portalSettings.DefaultPortalAlias}/DnnImageHandler.ashx?mode=profilepic&userId={userId}&h={avatarWidth}&w={avatarHeight}";
             }
 
-            return Utilities.RemoveCultureFromUrl(Utilities.ResolveUrl(imgUrl, portalSettings), portalSettings.PrimaryAlias);
+            return Utilities.RemoveCultureFromUrl(Utilities.ResolveUrl(imgUrl, portalSettings), portalSettings);
         }
 
         internal static void UpdateUserTopicCount(int portalId, int userId)

--- a/Dnn.CommunityForums/DnnCommunityForums.dnn
+++ b/Dnn.CommunityForums/DnnCommunityForums.dnn
@@ -75,7 +75,7 @@
             <attributes>
               <businessControllerClass>DotNetNuke.Modules.ActiveForums.TopicsController, DotNetNuke.Modules.ActiveForums</businessControllerClass>
               <desktopModuleID>[DESKTOPMODULEID]</desktopModuleID>
-              <upgradeVersionsList>07.00.07,07.00.11,07.00.12,08.00.00,08.01.00,08.02.00,08.02.02,08.02.03,08.02.04,08.02.08,09.00.00,09.01.00,09.02.00,09.02.01,09.03.00,09.05.00,09.06.00,09.07.00</upgradeVersionsList>
+              <upgradeVersionsList>07.00.07,07.00.11,07.00.12,08.00.00,08.01.00,08.02.00,08.02.02,08.02.03,08.02.04,08.02.08,09.00.00,09.01.00,09.02.00,09.02.01,09.03.00,09.05.00,09.06.00,09.07.00,10.00.00</upgradeVersionsList>
             </attributes>
           </eventMessage>
         </component>

--- a/Dnn.CommunityForums/Entities/ContentInfo.cs
+++ b/Dnn.CommunityForums/Entities/ContentInfo.cs
@@ -179,7 +179,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                             }
 
                             var imgUrl = $"https://{this.Post.Forum.PortalSettings.DefaultPortalAlias}{DotNetNuke.Services.FileSystem.FileManager.Instance.GetUrl(file)}";
-                            imgUrl = Utilities.RemoveCultureFromUrl(Utilities.ResolveUrl(imgUrl, this.Post.Forum.PortalSettings), this.Post.Forum.PortalSettings.PrimaryAlias);
+                            imgUrl = Utilities.RemoveCultureFromUrl(Utilities.ResolveUrl(imgUrl, this.Post.Forum.PortalSettings), this.Post.Forum.PortalSettings);
                             var tag = $"<img src=\"{imgUrl}\" width=\"{width}\" height=\"{height}\" loading=\"lazy\" />";
                             this.Body = this.Body.Replace(match.Groups["tag"].Value, tag);
                             DotNetNuke.Modules.ActiveForums.Controllers.ContentController.Instance.Save(this, this.ContentId);

--- a/Dnn.CommunityForums/Entities/ReplyInfo.cs
+++ b/Dnn.CommunityForums/Entities/ReplyInfo.cs
@@ -431,11 +431,11 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                         {
                             if (this.Forum.FeatureSettings.AllowLikes)
                             {
-                                string linkUrl = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, tabId: this.GetTabId(), moduleId: this.Forum.ModuleId, groupPrefix: this.Forum.ForumGroup.PrefixURL, forumPrefix: this.Forum.PrefixURL, forumGroupId: this.Forum.ForumGroupId, forumID: this.Forum.ForumID, topicId: this.TopicId, topicURL: this.Topic.TopicUrl, tagId: -1, categoryId: -1, otherPrefix: Views.Likes, pageId: 1, contentId: this.ContentId, socialGroupId: this.Forum.SocialGroupId);
+                                string linkUrl = new ControlUtils().BuildUrl(this.Forum.PortalSettings.PortalId, tabId: this.GetTabId(), moduleId: this.Forum.ModuleId, groupPrefix: this.Forum.ForumGroup.PrefixURL, forumPrefix: this.Forum.PrefixURL, forumGroupId: this.Forum.ForumGroupId, forumID: this.Forum.ForumID, topicId: this.TopicId, topicURL: this.Topic.TopicUrl, tagId: -1, categoryId: -1, otherPrefix: Views.likes, pageId: 1, contentId: this.ContentId, socialGroupId: this.Forum.SocialGroupId);
 
                                 if (string.IsNullOrEmpty(linkUrl))
                                 {
-                                    var @params = new List<string> { $"{ParamKeys.ViewType}={Views.Grid}", $"{ParamKeys.GridType}={Views.Likes}", $"{ParamKeys.ContentId}={this.ContentId}", };
+                                    var @params = new List<string> { $"{ParamKeys.ViewType}={Views.Grid}", $"{ParamKeys.GridType}={Views.likes}", $"{ParamKeys.ContentId}={this.ContentId}", };
 
                                     if (this.Forum.SocialGroupId > 0)
                                     {

--- a/Dnn.CommunityForums/Entities/TopicInfo.cs
+++ b/Dnn.CommunityForums/Entities/TopicInfo.cs
@@ -834,7 +834,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                                     topicURL: this.TopicUrl,
                                     tagId: -1,
                                     categoryId: -1,
-                                    otherPrefix: Views.Likes,
+                                    otherPrefix: Views.likes,
                                     pageId: 1,
                                     contentId: this.ContentId,
                                     socialGroupId: this.Forum.SocialGroupId);
@@ -843,7 +843,7 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
                                 {
                                     var @params = new List<string>
                                     {
-                                        $"{ParamKeys.ViewType}={Views.Grid}", $"{ParamKeys.GridType}={Views.Likes}", $"{ParamKeys.ContentId}={this.ContentId}",
+                                        $"{ParamKeys.ViewType}={Views.Grid}", $"{ParamKeys.GridType}={Views.likes}", $"{ParamKeys.ContentId}={this.ContentId}",
                                     };
 
                                     if (this.Forum.SocialGroupId > 0)

--- a/Dnn.CommunityForums/ForumSettings.ascx
+++ b/Dnn.CommunityForums/ForumSettings.ascx
@@ -187,10 +187,6 @@
 			</asp:RadioButtonList>
 			  <span class="urlToggle"><asp:Literal ID="litToggleConfig" runat="server" /></span>
 			  <div class="urlOptions">
-					<div class="dnnFormItem">
-						 <dnn:label ID="lblUrlPrefix" runat="server" resourcekey="URLPrefixBase" Suffix=":" />
-						 <asp:TextBox ID="txtURLPrefixBase" runat="server" MaxLength="50" />
-					</div>
 					 <div class="dnnFormItem">
 						 <dnn:label runat="server" resourcekey="URLPrefixCategory" Suffix=":" />
 						 <asp:TextBox ID="txtURLPrefixCategory" runat="server" MaxLength="50" />

--- a/Dnn.CommunityForums/ForumSettings.ascx.cs
+++ b/Dnn.CommunityForums/ForumSettings.ascx.cs
@@ -115,7 +115,6 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 this.txtMarkAnswerPointValue.Text = this.MarkAsAnswerPointValue.ToString();
                 this.txtModPointValue.Text = this.ModPointValue.ToString();
 
-                this.txtURLPrefixBase.Text = this.PrefixURLBase;
                 this.txtURLPrefixCategory.Text = this.PrefixURLCategory;
                 this.txtURLPrefixOther.Text = this.PrefixURLOther;
                 this.txtURLPrefixLikes.Text = this.PrefixURLLikes;
@@ -194,7 +193,6 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     this.MessagingTabId = Utilities.SafeConvertInt(this.drpMessagingTab.SelectedValue);
                 }
 
-                this.PrefixURLBase = this.txtURLPrefixBase.Text;
                 this.PrefixURLCategory = this.txtURLPrefixCategory.Text;
                 this.PrefixURLOther = this.txtURLPrefixOther.Text;
                 this.PrefixURLLikes = this.txtURLPrefixLikes.Text;

--- a/Dnn.CommunityForums/ForumSettings.ascx.designer.cs
+++ b/Dnn.CommunityForums/ForumSettings.ascx.designer.cs
@@ -401,22 +401,6 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
         /// Auto-generated field.
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
-        protected global::System.Web.UI.UserControl lblUrlPrefix;
-        /// <summary>
-        /// txtURLPrefixBase control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.WebControls.TextBox txtURLPrefixBase;
-        /// <summary>
-        /// txtURLPrefixCategory control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtURLPrefixCategory;
         /// <summary>
         /// txtURLPrefixTags control.

--- a/Dnn.CommunityForums/Services/Tokens/ForumsModuleTokenReplacer.cs
+++ b/Dnn.CommunityForums/Services/Tokens/ForumsModuleTokenReplacer.cs
@@ -129,13 +129,13 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Tokens
                     case "portallogourl":
                         {
                             var logoUrl = FileManager.Instance.GetUrl(FileManager.Instance.GetFile(this.PortalSettings.PortalId, this.PortalSettings.LogoFile));
-                            return PropertyAccess.FormatString(Utilities.RemoveCultureFromUrl(url: Utilities.ResolveUrl(url: $"https://{this.PortalSettings.DefaultPortalAlias}{logoUrl}", portalSettings: this.PortalSettings), portalAlias: this.portalSettings.PortalAlias), format);
+                            return PropertyAccess.FormatString(Utilities.RemoveCultureFromUrl(url: Utilities.ResolveUrl(url: $"https://{this.PortalSettings.DefaultPortalAlias}{logoUrl}", portalSettings: this.PortalSettings), portalSettings: this.portalSettings), format);
                         }
 
                     case "portalurlwithoutculture":
                         {
                             var portalUrl = $"https://{this.PortalSettings.DefaultPortalAlias}";
-                            return PropertyAccess.FormatString(Utilities.RemoveCultureFromUrl(url: Utilities.ResolveUrl(url: portalUrl, portalSettings: this.PortalSettings), portalAlias: this.portalSettings.PortalAlias), format);
+                            return PropertyAccess.FormatString(Utilities.RemoveCultureFromUrl(url: Utilities.ResolveUrl(url: portalUrl, portalSettings: this.PortalSettings), portalSettings: this.portalSettings), format);
                         }
 
                     case "loginlink":

--- a/Dnn.CommunityForums/class/ForumsConfig.cs
+++ b/Dnn.CommunityForums/class/ForumsConfig.cs
@@ -1672,7 +1672,7 @@ namespace DotNetNuke.Modules.ActiveForums
                     {
                         if (match.Groups["src"].Success && (match.Groups["src"].Value.EndsWith(originalAttachmentFileName, StringComparison.InvariantCultureIgnoreCase) || (!string.IsNullOrEmpty(originalUrl) && match.Groups["src"].Value.ToLowerInvariant().Contains(originalUrl.ToLowerInvariant()))))
                         {
-                            var url = Utilities.RemoveCultureFromUrl(url: Utilities.ResolveUrl($"https://{content.Post.Forum.PortalSettings.DefaultPortalAlias}{fileManager.GetUrl(file)}", content.Post.Forum.PortalSettings), portalAlias: content.Post.Forum.PortalSettings.PortalAlias);
+                            var url = Utilities.RemoveCultureFromUrl(url: Utilities.ResolveUrl($"https://{content.Post.Forum.PortalSettings.DefaultPortalAlias}{fileManager.GetUrl(file)}", content.Post.Forum.PortalSettings), portalSettings: content.Post.Forum.PortalSettings);
                             var tag = $"<img src=\"{url}\" width=\"{width}\" height=\"{height}\" loading=\"lazy\" />";
                             content.Body = content.Body.Replace(match.Groups["tag"].Value, tag);
                             DotNetNuke.Modules.ActiveForums.Controllers.ContentController.Instance.Save(content, content.ContentId);

--- a/Dnn.CommunityForums/class/Globals.cs
+++ b/Dnn.CommunityForums/class/Globals.cs
@@ -394,12 +394,15 @@ namespace DotNetNuke.Modules.ActiveForums
         public const string ModerateTopics = "modtopics";
         public const string ModerateBan = "modban";
         public const string ModerateReport = "modreport";
-        public const string Likes = "likes";
         public const string RecycleBin = "recyclebin";
         public const string BadgeUsers = "badgeusers";
         public const string UserBadges = "userbadges";
         public const string SendTo = "sendto";
         public const string ConfirmAction = "confirmaction";
+        public const string tag = "tag";
+        public const string likes = "likes";
+        public const string category = "category";
+        public const string views = "views";
     }
 
     internal static class GridTypes

--- a/Dnn.CommunityForums/class/ModuleSettings.cs
+++ b/Dnn.CommunityForums/class/ModuleSettings.cs
@@ -155,23 +155,21 @@ namespace DotNetNuke.Modules.ActiveForums
 
         public bool URLRewriteEnabled => this.MainSettings.GetBoolean(SettingKeys.EnableURLRewriter);
 
-        public string PrefixURLBase => this.MainSettings.GetString(SettingKeys.PrefixURLBase, string.Empty);
-
         public string PrefixURLOther => !this.URLRewriteEnabled
                            ? string.Empty
-                           : this.MainSettings.GetString(SettingKeys.PrefixURLOther, "other");
+                           : this.MainSettings.GetString(SettingKeys.PrefixURLOther, Views.views);
 
         public string PrefixURLTag => !this.URLRewriteEnabled
                            ? string.Empty
-                           : this.MainSettings.GetString(SettingKeys.PrefixURLTags, "tag");
+                           : this.MainSettings.GetString(SettingKeys.PrefixURLTags, Views.tag);
 
         public string PrefixURLCategory => !this.URLRewriteEnabled
                            ? string.Empty
-                           : this.MainSettings.GetString(SettingKeys.PrefixURLCategories, "category");
+                           : this.MainSettings.GetString(SettingKeys.PrefixURLCategories, Views.category);
 
         public string PrefixURLLikes => !this.URLRewriteEnabled
                     ? string.Empty
-                    : this.MainSettings.GetString(SettingKeys.PrefixURLLikes, Views.Likes);
+                    : this.MainSettings.GetString(SettingKeys.PrefixURLLikes, Views.likes);
 
         public int DefaultPermissionId => this.MainSettings.GetInt(SettingKeys.DefaultPermissionId);
 

--- a/Dnn.CommunityForums/class/Utilities.cs
+++ b/Dnn.CommunityForums/class/Utilities.cs
@@ -1945,14 +1945,9 @@ namespace DotNetNuke.Modules.ActiveForums
 
         internal static string RemoveCultureFromUrl(string url, DotNetNuke.Entities.Portals.PortalSettings portalSettings)
         {
-            return RemoveCultureFromUrl(url, portalSettings.PortalAlias);
-        }
-
-        internal static string RemoveCultureFromUrl(string url, DotNetNuke.Abstractions.Portals.IPortalAliasInfo portalAlias)
-        {
-            if (!string.IsNullOrEmpty(portalAlias?.CultureCode) && url.ToLowerInvariant().Contains($"/{portalAlias?.CultureCode?.ToLowerInvariant()}/"))
+            if (!string.IsNullOrEmpty(portalSettings?.CultureCode) && url.ToLowerInvariant().Contains($"/{portalSettings?.CultureCode?.ToLowerInvariant()}/"))
             {
-                url = url.ToLowerInvariant().Replace($"/{portalAlias.CultureCode.ToLowerInvariant()}/", "/");
+                url = url.ToLowerInvariant().Replace($"/{portalSettings.CultureCode.ToLowerInvariant()}/", "/");
             }
 
             return url;

--- a/Dnn.CommunityForums/components/Common/ForumSettingsBase.cs
+++ b/Dnn.CommunityForums/components/Common/ForumSettingsBase.cs
@@ -239,19 +239,6 @@ namespace DotNetNuke.Modules.ActiveForums
             }
         }
 
-        public string PrefixURLBase
-        {
-            get
-            {
-                return this.Settings.GetString(SettingKeys.PrefixURLBase, string.Empty);
-            }
-
-            set
-            {
-                this.UpdateModuleSettingCaseSensitive(SettingKeys.PrefixURLBase, value);
-            }
-        }
-
         public string PrefixURLTag
         {
             get
@@ -295,7 +282,7 @@ namespace DotNetNuke.Modules.ActiveForums
         {
             get
             {
-                return this.Settings.GetString(SettingKeys.PrefixURLLikes, Views.Likes);
+                return this.Settings.GetString(SettingKeys.PrefixURLLikes, Views.likes);
             }
 
             set

--- a/Dnn.CommunityForums/components/Controls/ControlUtils.cs
+++ b/Dnn.CommunityForums/components/Controls/ControlUtils.cs
@@ -136,7 +136,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
                 if (contentId > 0)
                 {
-                    if (!string.IsNullOrEmpty(otherPrefix) && otherPrefix.Equals(Views.Likes))
+                    if (!string.IsNullOrEmpty(otherPrefix) && otherPrefix.Equals(Views.likes))
                     {
                         @params.Add($"{ParamKeys.ContentId}={contentId}");
                     }
@@ -157,12 +157,6 @@ namespace DotNetNuke.Modules.ActiveForums
             var sURL = Utilities.NavigateURL(tabId, portalSettings, string.Empty, @params.ToArray());
             var tabInfo = DotNetNuke.Entities.Tabs.TabController.Instance.GetTab(tabId, portalId);
             var moduleInfo = DotNetNuke.Entities.Modules.ModuleController.Instance.GetModule(moduleId, tabId, false);
-
-            /* ONLY include prefix if main forum module, prefix isn't same as tab name, and prefix is filled, e.g. don't include running in viewer module */
-            if (moduleInfo != null && moduleInfo.TabID.Equals(tabId) && !mainSettings.PrefixURLBase.Trim().Equals(tabInfo.TabName.Trim(), StringComparison.InvariantCultureIgnoreCase) && !string.IsNullOrEmpty(mainSettings.PrefixURLBase))
-            {
-                sURL += "/" + mainSettings.PrefixURLBase;
-            }
 
             if (!string.IsNullOrEmpty(groupPrefix))
             {
@@ -187,7 +181,7 @@ namespace DotNetNuke.Modules.ActiveForums
             {
                 sURL += "/" + mainSettings.PrefixURLCategory + "/" + otherPrefix;
             }
-            else if (!string.IsNullOrEmpty(otherPrefix) && (otherPrefix.Equals(Views.Likes, StringComparison.InvariantCultureIgnoreCase) && contentId > 0))
+            else if (!string.IsNullOrEmpty(otherPrefix) && (otherPrefix.Equals(Views.likes, StringComparison.InvariantCultureIgnoreCase) && contentId > 0))
             {
                 sURL += "/" + mainSettings.PrefixURLLikes + "/" + contentId;
             }
@@ -227,11 +221,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
             if (!string.IsNullOrEmpty(forumPrefixUrl) && !string.IsNullOrEmpty(topicUrl) && mainSettings.URLRewriteEnabled)
             {
-                if (!string.IsNullOrWhiteSpace(mainSettings.PrefixURLBase))
-                {
-                    sURL += "/" + mainSettings.PrefixURLBase;
-                }
-
+                sURL = Utilities.NavigateURL(tabId);
                 if (!string.IsNullOrWhiteSpace(forumGroupPrefixUrl))
                 {
                     sURL += "/" + forumGroupPrefixUrl;
@@ -276,10 +266,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
             if (!string.IsNullOrWhiteSpace(forumPrefix) && mainSettings.URLRewriteEnabled)
             {
-                if (!string.IsNullOrWhiteSpace(mainSettings.PrefixURLBase))
-                {
-                    sURL += "/" + mainSettings.PrefixURLBase;
-                }
+                sURL = Utilities.NavigateURL(tabId);
 
                 if (!string.IsNullOrWhiteSpace(groupPrefix))
                 {

--- a/Dnn.CommunityForums/components/Data/Common.cs
+++ b/Dnn.CommunityForums/components/Data/Common.cs
@@ -73,11 +73,6 @@ namespace DotNetNuke.Modules.ActiveForums.Data
                     vanityName = fg.PrefixURL + "/" + vanityName;
                 }
 
-                if (!string.IsNullOrEmpty(_mainSettings.PrefixURLBase))
-                {
-                    vanityName = _mainSettings.PrefixURLBase + "/" + vanityName;
-                }
-
                 int tmpForumId = -1;
                 tmpForumId = Convert.ToInt32(SqlHelper.ExecuteScalar(this.connectionString, this.dbPrefix + "URL_CheckForumVanity", portalId, vanityName));
                 if (tmpForumId > 0 && forumId == -1)
@@ -106,11 +101,7 @@ namespace DotNetNuke.Modules.ActiveForums.Data
             try
             {
                 ModuleSettings _mainSettings = SettingsBase.GetModuleSettings(moduleId);
-                if (!string.IsNullOrEmpty(_mainSettings.PrefixURLBase))
-                {
-                    vanityName = _mainSettings.PrefixURLBase + "/" + vanityName;
-                }
-
+                
                 int tmpForumGroupId = -1;
                 tmpForumGroupId = Convert.ToInt32(SqlHelper.ExecuteScalar(this.connectionString, this.dbPrefix + "URL_CheckGroupVanity", portalId, vanityName));
                 if (tmpForumGroupId > 0 && forumGroupId == -1)

--- a/Dnn.CommunityForums/components/Extensions/ForumsReWriter.cs
+++ b/Dnn.CommunityForums/components/Extensions/ForumsReWriter.cs
@@ -533,7 +533,7 @@ namespace DotNetNuke.Modules.ActiveForums
                 }
                 else if (this.ViewUrlTypeValue.Equals(ViewUrlType.Likes) && this.ContentId > 0)
                 {
-                    sendTo = ResolveUrl(app.Context.Request.ApplicationPath, "~/default.aspx?tabid=" + this.TabId + $"&{ParamKeys.ViewType}={Views.Grid}&{ParamKeys.GridType}={Views.Likes}&{ParamKeys.ContentId}=" + this.ContentId + sPage + qs);
+                    sendTo = ResolveUrl(app.Context.Request.ApplicationPath, "~/default.aspx?tabid=" + this.TabId + $"&{ParamKeys.ViewType}={Views.Grid}&{ParamKeys.GridType}={Views.likes}&{ParamKeys.ContentId}=" + this.ContentId + sPage + qs);
                 }
                 else if ((this.TopicId > 0) || (this.ForumId > 0) || (this.ForumGroupId > 0))
                 {

--- a/Dnn.CommunityForums/components/Helpers/URL.cs
+++ b/Dnn.CommunityForums/components/Helpers/URL.cs
@@ -36,11 +36,7 @@ namespace DotNetNuke.Modules.ActiveForums
             }
             else
             {
-                if (!string.IsNullOrWhiteSpace(mainSettings.PrefixURLBase))
-                {
-                    sURL = "/" + mainSettings.PrefixURLBase;
-                }
-
+                sURL = Utilities.NavigateURL(tabId);
                 if (!string.IsNullOrWhiteSpace(fi.ForumGroup.PrefixURL))
                 {
                     sURL += "/" + fi.ForumGroup.PrefixURL;

--- a/Dnn.CommunityForums/components/Helpers/UpgradeModuleSettings.cs
+++ b/Dnn.CommunityForums/components/Helpers/UpgradeModuleSettings.cs
@@ -85,18 +85,9 @@ namespace DotNetNuke.Modules.ActiveForums.Helpers
             DotNetNuke.Entities.Modules.ModuleController.Instance.UpdateModuleSetting(tabModuleId, SettingKeys.DeleteBehavior, currSettings.DeleteBehavior.ToString());
             DotNetNuke.Entities.Modules.ModuleController.Instance.UpdateModuleSetting(tabModuleId, SettingKeys.EnableAutoLink, currSettings.AutoLinkEnabled.ToString());
             DotNetNuke.Entities.Modules.ModuleController.Instance.UpdateModuleSetting(tabModuleId, SettingKeys.EnableURLRewriter, currSettings.URLRewriteEnabled.ToString());
-            if (string.IsNullOrEmpty(currSettings.PrefixURLBase))
-            {
-                DotNetNuke.Entities.Modules.ModuleController.Instance.UpdateModuleSetting(tabModuleId, SettingKeys.PrefixURLBase, "forums");
-            }
-            else
-            {
-                DotNetNuke.Entities.Modules.ModuleController.Instance.UpdateModuleSetting(tabModuleId, SettingKeys.PrefixURLBase, currSettings.PrefixURLBase);
-            }
-
             if (string.IsNullOrEmpty(currSettings.PrefixURLOther))
             {
-                DotNetNuke.Entities.Modules.ModuleController.Instance.UpdateModuleSetting(tabModuleId, SettingKeys.PrefixURLOther, "views");
+                DotNetNuke.Entities.Modules.ModuleController.Instance.UpdateModuleSetting(tabModuleId, SettingKeys.PrefixURLOther, Views.views);
             }
             else
             {
@@ -105,7 +96,7 @@ namespace DotNetNuke.Modules.ActiveForums.Helpers
 
             if (string.IsNullOrEmpty(currSettings.PrefixURLTag))
             {
-                DotNetNuke.Entities.Modules.ModuleController.Instance.UpdateModuleSetting(tabModuleId, SettingKeys.PrefixURLTags, "tag");
+                DotNetNuke.Entities.Modules.ModuleController.Instance.UpdateModuleSetting(tabModuleId, SettingKeys.PrefixURLTags, Views.tag);
             }
             else
             {
@@ -114,7 +105,7 @@ namespace DotNetNuke.Modules.ActiveForums.Helpers
 
             if (string.IsNullOrEmpty(currSettings.PrefixURLCategory))
             {
-                DotNetNuke.Entities.Modules.ModuleController.Instance.UpdateModuleSetting(tabModuleId, SettingKeys.PrefixURLCategories, "category");
+                DotNetNuke.Entities.Modules.ModuleController.Instance.UpdateModuleSetting(tabModuleId, SettingKeys.PrefixURLCategories, Views.category);
             }
             else
             {
@@ -267,7 +258,7 @@ namespace DotNetNuke.Modules.ActiveForums.Helpers
                 {
                     if (module.DesktopModule.ModuleName.Trim().Equals(Globals.ModuleName, System.StringComparison.InvariantCultureIgnoreCase))
                     {
-                        DotNetNuke.Entities.Modules.ModuleController.Instance.UpdateModuleSetting(module.ModuleID, SettingKeys.PrefixURLLikes, module.ModuleSettings.GetString(SettingKeys.PrefixURLLikes, Views.Likes));
+                        DotNetNuke.Entities.Modules.ModuleController.Instance.UpdateModuleSetting(module.ModuleID, SettingKeys.PrefixURLLikes, module.ModuleSettings.GetString(SettingKeys.PrefixURLLikes, Views.likes));
                     }
                 }
             }
@@ -498,6 +489,29 @@ namespace DotNetNuke.Modules.ActiveForums.Helpers
                     if (module.DesktopModule.ModuleName.Trim().ToLowerInvariant().Equals(Globals.ModuleName.ToLowerInvariant()))
                     {
                         DotNetNuke.Entities.Modules.ModuleController.Instance.DeleteModuleSetting(module.ModuleID, "FULLTEXT");
+                    }
+                }
+            }
+        }
+
+        internal static void DeleteObsoleteModuleSettings_100000()
+        {
+            /* remove URLBASE depending on how old the install is, it might be in ModuleSettings or it might be in activeforums_Settings, or both */
+
+            foreach (DotNetNuke.Abstractions.Portals.IPortalInfo portal in DotNetNuke.Entities.Portals.PortalController.Instance.GetPortals())
+            {
+                foreach (ModuleInfo module in DotNetNuke.Entities.Modules.ModuleController.Instance.GetModules(portal.PortalId))
+                {
+                    if (module.DesktopModule.ModuleName.Trim().ToLowerInvariant().Equals(Globals.ModuleName.ToLowerInvariant()))
+                    {
+                        DotNetNuke.Entities.Modules.ModuleController.Instance.DeleteModuleSetting(module.ModuleID, "URLBASE");
+                        foreach (var settingName in new string[]
+                        {
+                            "URLBASE",
+                        })
+                        {
+                            DotNetNuke.Data.DataContext.Instance().Execute(System.Data.CommandType.Text, "DELETE FROM {databaseOwner}{objectQualifier}activeforums_Settings WHERE ModuleId = @0 AND SettingName = @1", module.ModuleID, settingName);
+                        }
                     }
                 }
             }

--- a/Dnn.CommunityForums/components/Topics/TopicsController.cs
+++ b/Dnn.CommunityForums/components/Topics/TopicsController.cs
@@ -379,6 +379,19 @@ namespace DotNetNuke.Modules.ActiveForums
                     }
 
                     break;
+                case "10.00.00":
+                    try
+                    {
+                        DotNetNuke.Modules.ActiveForums.Helpers.UpgradeModuleSettings.DeleteObsoleteModuleSettings_100000();
+                    }
+                    catch (Exception ex)
+                    {
+                        this.LogError(ex.Message, ex);
+                        Exceptions.LogException(ex);
+                        return "Failed";
+                    }
+
+                    break;
                 default:
                     break;
             }

--- a/Dnn.CommunityForums/config/defaultsetup.config
+++ b/Dnn.CommunityForums/config/defaultsetup.config
@@ -38,7 +38,6 @@
       <setting name="USESKINBC" value="true" />
     <setting name="AUTOLINK" value="true" />
     <setting name="MODE" value="Standard" />
-    <setting name="URLBASE" value="forums" />
 
   </mainsettings>
   <filters>

--- a/Dnn.CommunityForums/controls/af_grid.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_grid.ascx.cs
@@ -24,6 +24,7 @@ namespace DotNetNuke.Modules.ActiveForums
     using System.Collections.Generic;
     using System.Data;
     using System.Linq;
+    using System.Security.Policy;
     using System.Text;
     using System.Web.UI;
     using System.Web.UI.HtmlControls;
@@ -502,11 +503,7 @@ namespace DotNetNuke.Modules.ActiveForums
 
             if (this.ModuleSettings.URLRewriteEnabled)
             {
-                if (!string.IsNullOrEmpty(this.ModuleSettings.PrefixURLBase))
-                {
-                    pager.BaseURL = "/" + this.ModuleSettings.PrefixURLBase;
-                }
-
+                pager.BaseURL = Utilities.NavigateURL(this.TabId);
                 if (!string.IsNullOrEmpty(this.ModuleSettings.PrefixURLOther))
                 {
                     pager.BaseURL += "/" + this.ModuleSettings.PrefixURLOther;

--- a/Dnn.CommunityForums/controls/af_likes.ascx.cs
+++ b/Dnn.CommunityForums/controls/af_likes.ascx.cs
@@ -351,7 +351,7 @@ namespace DotNetNuke.Modules.ActiveForums
             pager.ContentId = this.ContentId;
             pager.PageText = Utilities.GetSharedResource("[RESX:Page]");
             pager.OfText = Utilities.GetSharedResource("[RESX:PageOf]");
-            pager.View = Views.Likes;
+            pager.View = Views.likes;
             pager.PageMode = PagerNav.Mode.Links;
             pager.BaseURL = URL.ForumLink(this.TabId, this.post.Forum) + this.post.Topic.TopicUrl + "/" + this.ModuleSettings.PrefixURLLikes + "/" + this.ContentId;
 

--- a/Dnn.CommunityForums/feeds.aspx.cs
+++ b/Dnn.CommunityForums/feeds.aspx.cs
@@ -195,11 +195,6 @@ namespace DotNetNuke.Modules.ActiveForums
             if (mainSettings.URLRewriteEnabled && !string.IsNullOrEmpty(dr["FullUrl"].ToString()))
             {
                 string sTopicURL = string.Empty;
-                if (!string.IsNullOrEmpty(mainSettings.PrefixURLBase))
-                {
-                    sTopicURL = "/" + mainSettings.PrefixURLBase;
-                }
-
                 sTopicURL += dr["FullUrl"].ToString();
 
                 uRL = sTopicURL;

--- a/Dnn.CommunityForums/sql/10.00.00.SqlDataProvider
+++ b/Dnn.CommunityForums/sql/10.00.00.SqlDataProvider
@@ -181,4 +181,75 @@ GO
 
 /* issue 1909 - end - remove deprecated procedures */
 
+/* issue 1882 - begin - remove URLBASE */
+IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}[{objectQualifier}fn_activeforums_GetURL]') AND type in (N'FN', N'IF', N'TF', N'FS', N'FT'))
+DROP FUNCTION {databaseOwner}[{objectQualifier}fn_activeforums_GetURL]
+GO
+CREATE FUNCTION {databaseOwner}[{objectQualifier}fn_activeforums_GetURL]
+(
+	@ModuleId int,
+	@ForumGroupId int,
+	@ForumId int,
+	@TopicId int,
+	@UserId int,
+	@ContentId int
+)
+RETURNS nvarchar(1000)
+AS
+BEGIN
+DECLARE @PageSize int
+DECLARE @Page int
+SET @Page = 1
+SET @PageSize = 20
+IF @ForumId =-1 AND @TopicId >0
+	SET @ForumId = (SELECT ForumId from {databaseOwner}{objectQualifier}activeforums_ForumTopics WHERE TopicId = @TopicId)
+DECLARE @url nvarchar(max)
+SET @url = ''
 
+DECLARE @grouprefix nvarchar(50)
+set @grouprefix = ''
+SET @grouprefix = (SELECT ISNULL(g.PrefixURL,'') FROM {databaseOwner}{objectQualifier}activeforums_Groups as g WHERE g.ForumGroupId = @ForumGroupId)
+IF @grouprefix <> ''
+	SET @url = @url + @grouprefix + '/'
+
+DECLARE @forumprefix nvarchar(50)
+SET @forumprefix = ''
+DECLARE @topicURL nvarchar(max)
+IF @ForumId > 0
+	BEGIN
+	SET @forumprefix = (SELECT ISNULL(PrefixURL,'') from {databaseOwner}{objectQualifier}activeforums_Forums WHERE ForumId=@ForumId)
+	IF @forumprefix <> ''
+		SET @url = @url + @forumprefix + '/'
+	END
+If @url <> '' AND @TopicId > 0
+	BEGIN
+		SET @topicURL =(SELECT url from {databaseOwner}{objectQualifier}activeforums_Topics WHERE TopicId = @TopicId)
+		If @topicURL = '' OR @topicURL IS NULL
+			SET @url = ''
+		Else
+			BEGIN
+				SET @url = @url + @topicURL + '/'
+			END
+	END
+If @url <> '' AND @TopicId > 0 AND @ContentId > 0
+	BEGIN
+		BEGIN
+			IF @UserId > 0 
+				SET @PageSize = (SELECT TOP 1 PrefPageSize FROM {databaseOwner}{objectQualifier}activeforums_UserProfiles WHERE UserId = @UserId)
+			ELSE
+				SET @PageSize = (SELECT s.SettingValue FROM {databaseOwner}{objectQualifier}activeforums_Settings as s INNER JOIN {databaseOwner}{objectQualifier}activeforums_Forums as f ON f.ModuleId = s.ModuleId WHERE f.ForumId=@ForumId AND s.SettingName='PAGESIZE')
+		END
+		SET @Page = (SELECT ((idx)/@PageSize)+1 FROM (
+							SELECT ReplyId, ROW_NUMBER() OVER(Order By ReplyId) as idx from {databaseOwner}{objectQualifier}activeforums_Replies WHERE TopicId = @TopicId AND IsApproved = 1 AND IsDeleted = 0)
+					as pos WHERE pos.ReplyId = @ContentId)
+		IF @Page > 1
+			SET @url = @url + CAST(@Page as varchar(1000)) + '/'
+	END
+RETURN ISNULL(@url,'')
+
+END
+
+GO
+
+
+/* issue 1882 - end - remove URLBASE */

--- a/Dnn.CommunityForumsTests/class/UtilitiesTests.cs
+++ b/Dnn.CommunityForumsTests/class/UtilitiesTests.cs
@@ -645,7 +645,7 @@ namespace DotNetNuke.Modules.ActiveForumsTests
             // Arrange
 
             // Act
-            return Utilities.RemoveCultureFromUrl(url, this.mockPortalAliasInfo.Object);
+            return Utilities.RemoveCultureFromUrl(url: url, portalSettings: this.mockPortalSettings.Object);
 
             // Assert
         }


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Remove deprecated "URLBASE" (PrefixURLBase) setting and refactors URL construction to use modern DNN patterns, ensuring consistent and culture-agnostic URLs.

- ForumSettings.ascx(.cs/.designer.cs), ForumSettingsBase.cs, and ModuleSettings.cs: Remove PrefixURLBase property, UI, and related logic.
- ControlUtils.cs, Common.cs, URL.cs, af_grid.ascx.cs, feeds.aspx.cs: Refactor URL-building logic to eliminate PrefixURLBase and use NavigateURL as the base.
- UpgradeModuleSettings.cs, TopicsController.cs, 10.00.00.SqlDataProvider: Add upgrade logic to remove URLBASE from settings and database.
- Utilities.cs and all usages: Update RemoveCultureFromUrl to accept PortalSettings and update all call sites.
- Globals.cs: Standardize Views.likes casing and add missing view constants.


## How did you test these updates?  
<!-- Please be as descriptive as possible. -->

## PR Template Checklist

- [ ] Fixes Bug
- [x] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1882 
Close #514