### PR TITLE
TASK: Refactor install checks to use IsInstalled property

### DIFF
--- a/Dnn.CommunityForums/Classic.ascx.cs
+++ b/Dnn.CommunityForums/Classic.ascx.cs
@@ -58,26 +58,15 @@ namespace DotNetNuke.Modules.ActiveForums
             base.OnLoad(e);
 
 #if DEBUG
-            //ForumsConfig.Install_Upgrade_CreateForumDefaultSettingsAndSecurity_080200();
-            //DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.Instance.RemoveUnused(this.ForumModuleId);
-            //DotNetNuke.Modules.ActiveForums.Helpers.UpgradeModuleSettings.AddUrlPrefixLikes_080200();
-            //ForumsConfig.Install_LikeNotificationType_080200();
-            //ForumsConfig.Install_PinNotificationType_080200();
-            //ForumsConfig.Sort_PermissionSets_080200();
-            //ForumsConfig.Upgrade_PermissionSets_090000();
-            //DotNetNuke.Modules.ActiveForums.Helpers.UpgradeModuleSettings.DeleteObsoleteModuleSettings_090000();
-            //DotNetNuke.Modules.ActiveForums.Helpers.UpgradeModuleSettings.AddAvatarModuleSettings_090100();
-            //new ForumsConfig().Install_DefaultBadges_090100();
-            //DotNetNuke.Modules.ActiveForums.Helpers.UpgradeModuleSettings.UpgradeSocialGroupForumConfigModuleSettings_090300();
-
-
             //new ForumsConfig().RemoveLegacyAvatarsFolder_090700();
             //new ForumsConfig().RelocateAttachments_090700();
+
+            //DotNetNuke.Modules.ActiveForums.Helpers.Upgrades.DeleteObsoleteModuleSettings_100000();
 #endif
 
             try
             {
-                if (this.ModuleSettings != null && this.ModuleSettings.InstallDate > Utilities.NullDate())
+                if (this.ModuleSettings != null && this.ModuleSettings.IsInstalled)
                 {
                     if (this.ForumModuleId < 1)
                     {
@@ -498,7 +487,7 @@ namespace DotNetNuke.Modules.ActiveForums
         #endregion
         protected override void Render(System.Web.UI.HtmlTextWriter writer)
         {
-            if ((this.ModuleSettings == null || this.ModuleSettings.InstallDate == Utilities.NullDate()) && !this.UserInfo.IsAdmin)
+            if ((this.ModuleSettings == null || !this.ModuleSettings.IsInstalled) && !this.UserInfo.IsAdmin)
             {
                 return;
             }
@@ -516,7 +505,7 @@ namespace DotNetNuke.Modules.ActiveForums
         {
             base.OnPreRender(e);
 
-            if ((this.ModuleSettings == null || this.ModuleSettings.InstallDate == Utilities.NullDate()) && !this.UserInfo.IsAdmin)
+            if ((this.ModuleSettings == null || !this.ModuleSettings.IsInstalled) && !this.UserInfo.IsAdmin)
             {
                 return;
             }

--- a/Dnn.CommunityForums/ControlPanel.ascx.cs
+++ b/Dnn.CommunityForums/ControlPanel.ascx.cs
@@ -52,14 +52,14 @@ namespace DotNetNuke.Modules.ActiveForums
 
             if (!this.Page.IsPostBack)
             {
-                Hashtable settings = DotNetNuke.Entities.Modules.ModuleController.Instance.GetModule(moduleId: this.ModuleId, tabId: this.TabId, ignoreCache: false).ModuleSettings;
-                if (Convert.ToBoolean(settings["AFINSTALLED"]) == false)
+                var settings = SettingsBase.GetTabModuleSettings(moduleId: this.ModuleId, tabModuleId: this.TabModuleId);
+                if (!settings.IsInstalled)
                 {
                     try
                     {
                         var fc = new ForumsConfig();
                         bool configComplete = fc.ForumsInit(this.PortalId, this.ModuleId);
-                        DotNetNuke.Entities.Modules.ModuleController.Instance.UpdateModuleSetting(this.ModuleId, "AFINSTALLED", configComplete.ToString());
+                        DotNetNuke.Entities.Modules.ModuleController.Instance.UpdateModuleSetting(this.ModuleId, SettingKeys.IsInstalled, configComplete.ToString());
                         DotNetNuke.Modules.ActiveForums.Services.Cache.CacheBase.ClearAllCache();
                     }
                     catch (Exception ex)

--- a/Dnn.CommunityForums/ReleaseNotes.txt
+++ b/Dnn.CommunityForums/ReleaseNotes.txt
@@ -135,6 +135,7 @@
             <li>Remove deprecated Ventrian messaging option (<a target="_blank" href="https://github.com/DNNCommunity/Dnn.CommunityForums/pull/1920">PR 1920</a>)</li>
             <li>Remove deprecated methods and properties, and SQL procedures (<a target="_blank" href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1909">Issue 1909</a>)</li>
             <li>Remove deprecated/legacy URL rewriter and unused procedures (<a target="_blank" href="https://github.com/DNNCommunity/Dnn.CommunityForums/pull/1910">PR 1910</a>)</li>
+            <li>Remove obsolete "AFINSTALLED" module setting(<a target="_blank" href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1967">Issue 1967</a>)</li>
             <li>Remove legacy Data/CommonDB/Null classes and change Microsoft.ApplicationBlocks.Data usage to use DotNetNuke.Data.SqlDataProvider.Instance() methods (<a target="_blank" href="https://github.com/DNNCommunity/Dnn.CommunityForums/pull/1926">PR 1926</a>)</li>
             <li>Update build process to use modern/ESM gulpfile.mjs rather than gulpfile.js (<a target="_blank" href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1959">Issue 1959</a>)</li>
             <li>10.00.00 Release Prep (<a target="_blank" href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1954">Issue 1954</a>)</li>

--- a/Dnn.CommunityForums/class/ForumsConfig.cs
+++ b/Dnn.CommunityForums/class/ForumsConfig.cs
@@ -111,7 +111,6 @@ namespace DotNetNuke.Modules.ActiveForums
                 }
 
                 DotNetNuke.Entities.Modules.ModuleController.Instance.UpdateModuleSetting(moduleId, SettingKeys.IsInstalled, "True");
-                DotNetNuke.Entities.Modules.ModuleController.Instance.UpdateModuleSetting(moduleId, "NeedsConvert", "False");
                 try
                 {
                     System.Globalization.DateTimeFormatInfo nfi = new System.Globalization.CultureInfo("en-US", true).DateTimeFormat;

--- a/Dnn.CommunityForums/components/Helpers/Upgrades.cs
+++ b/Dnn.CommunityForums/components/Helpers/Upgrades.cs
@@ -643,14 +643,21 @@ namespace DotNetNuke.Modules.ActiveForums.Helpers
 
         internal static void DeleteObsoleteModuleSettings_100000()
         {
-            /* remove URLBASE depending on how old the install is, it might be in ModuleSettings or it might be in communityforums_Settings, or both */
-
             foreach (DotNetNuke.Abstractions.Portals.IPortalInfo portal in DotNetNuke.Entities.Portals.PortalController.Instance.GetPortals())
             {
                 foreach (ModuleInfo module in DotNetNuke.Entities.Modules.ModuleController.Instance.GetModules(portal.PortalId))
                 {
                     if (module.DesktopModule.ModuleName.Trim().ToLowerInvariant().Equals(Globals.ModuleName.ToLowerInvariant()))
                     {
+                        /* remove obsolete AFINSTALLED & NeedsConvert flags */
+                        DotNetNuke.Entities.Modules.ModuleController.Instance.DeleteModuleSetting(module.ModuleID, "AFINSTALLED");
+                        DotNetNuke.Entities.Modules.ModuleController.Instance.DeleteModuleSetting(module.ModuleID, "NeedsConvert");
+
+                        /* remove PMTABID and update PMTYPE from 2 to 1 if needed (removing ventrian messaging) */
+                        DotNetNuke.Entities.Modules.ModuleController.Instance.DeleteModuleSetting(module.ModuleID, "PMTABID");
+                        DotNetNuke.Data.DataContext.Instance().Execute(System.Data.CommandType.Text, "UPDATE {databaseOwner}{objectQualifier}ModuleSettings SET SettingValue = 1 WHERE ModuleId = @0 AND SettingName = 'PMTYPE' AND SettingValue = 2", module.ModuleID);
+
+                        /* remove URLBASE depending on how old the install is, it might be in ModuleSettings or it might be in communityforums_Settings, or both */
                         DotNetNuke.Entities.Modules.ModuleController.Instance.DeleteModuleSetting(module.ModuleID, "URLBASE");
                         foreach (var settingName in new string[]
                         {
@@ -659,19 +666,6 @@ namespace DotNetNuke.Modules.ActiveForums.Helpers
                         {
                             DotNetNuke.Data.DataContext.Instance().Execute(System.Data.CommandType.Text, "DELETE FROM {databaseOwner}{objectQualifier}communityforums_Settings WHERE ModuleId = @0 AND SettingName = @1", module.ModuleID, settingName);
                         }
-                    }
-                }
-            }
-
-            /* remove PMTABID and update PMTYPE from 2 to 1 if needed (removing ventrian messaging) */
-            foreach (DotNetNuke.Abstractions.Portals.IPortalInfo portal in DotNetNuke.Entities.Portals.PortalController.Instance.GetPortals())
-            {
-                foreach (ModuleInfo module in DotNetNuke.Entities.Modules.ModuleController.Instance.GetModules(portal.PortalId))
-                {
-                    if (module.DesktopModule.ModuleName.Trim().ToLowerInvariant().Equals(Globals.ModuleName.ToLowerInvariant()))
-                    {
-                        DotNetNuke.Entities.Modules.ModuleController.Instance.DeleteModuleSetting(module.ModuleID, "PMTABID");
-                        DotNetNuke.Data.DataContext.Instance().Execute(System.Data.CommandType.Text, "UPDATE {databaseOwner}{objectQualifier}ModuleSettings SET SettingValue = 1 WHERE ModuleId = @0 AND SettingName = 'PMTYPE' AND SettingValue = 2", module.ModuleID);
                     }
                 }
             }

--- a/Dnn.CommunityForums/controls/_default.ascx.cs
+++ b/Dnn.CommunityForums/controls/_default.ascx.cs
@@ -42,7 +42,7 @@ namespace DotNetNuke.Modules.ActiveForums
             init = fc.ForumsInit(this.PortalId, this.ModuleId);
             if (init == true)
             {
-                DotNetNuke.Entities.Modules.ModuleController.Instance.UpdateModuleSetting(this.ModuleId, "AFINSTALLED", init.ToString());
+                DotNetNuke.Entities.Modules.ModuleController.Instance.UpdateModuleSetting(this.ModuleId, SettingKeys.IsInstalled, true.ToString());
                 DotNetNuke.Modules.ActiveForums.Services.Cache.CacheBase.ClearAllCache();
                 DotNetNuke.Modules.ActiveForums.Services.Cache.CacheBase.ClearAllCacheForTabId(this.TabId);
                 this.Response.Redirect(this.EditUrl(), false);


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
Refactors installation flags.

## Changes made
- Refactored module installation checks to use the strongly-typed IsInstalled property from SettingsBase, replacing legacy "AFINSTALLED" string flags.
- Updated Classic.ascx.cs, ControlPanel.ascx.cs, and _default.ascx.cs to reference SettingKeys.IsInstalled for improved clarity and maintainability.
- Removed obsolete "NeedsConvert" and "AFINSTALLED" settings during DeleteObsoleteModuleSettings_100000 upgrade and consolidated PMTABID/PMTYPE cleanup.
- Ensured all install/update logic and UI checks consistently use the new property.

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->

## PR Template Checklist

- [ ] Fixes Bug
- [ ] Feature solution
- [X] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1967