### PR TITLE
FIX: Update SQL script to include cascading deletes when renaming database objects

### DIFF
--- a/Dnn.CommunityForums/sql/10.00.00.SqlDataProvider
+++ b/Dnn.CommunityForums/sql/10.00.00.SqlDataProvider
@@ -236,7 +236,21 @@ BEGIN TRY
             SELECT STRING_AGG(COL_NAME(fkc.referenced_object_id, fkc.referenced_column_id), ',')
             FROM sys.foreign_key_columns fkc
             WHERE fkc.constraint_object_id = fk.object_id
-        ) + ')'
+        ) + ')' +
+        ' ON DELETE ' + CASE fk.delete_referential_action
+            WHEN 0 THEN 'NO ACTION'
+            WHEN 1 THEN 'CASCADE'
+            WHEN 2 THEN 'SET NULL'
+            WHEN 3 THEN 'SET DEFAULT'
+            ELSE 'NO ACTION'
+        END +
+        ' ON UPDATE ' + CASE fk.update_referential_action
+            WHEN 0 THEN 'NO ACTION'
+            WHEN 1 THEN 'CASCADE'
+            WHEN 2 THEN 'SET NULL'
+            WHEN 3 THEN 'SET DEFAULT'
+            ELSE 'NO ACTION'
+        END
     FROM sys.foreign_keys fk    
     WHERE SCHEMA_NAME(fk.schema_id) = @SchemaName
     AND (OBJECT_NAME(fk.referenced_object_id) LIKE @OldPattern OR OBJECT_NAME(fk.parent_object_id) LIKE @OldPattern)


### PR DESCRIPTION
…ects from activeforums_* to communityforums_*

<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
FIX: Update SQL to include cascading deletes when rename database objects from `activeforums_*` to `communityforums_*`
 
 

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1974