### PR TITLE
FIX: Quietly redirect to main forums tab on bad requests -- don't log admin alerts

### DIFF
--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicView.cs
@@ -114,6 +114,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     {
                         this.Response.Redirect(Utilities.NavigateURL(this.TabId), false);
                         this.Context.ApplicationInstance.CompleteRequest();
+                        return;
                     }
                 }
 
@@ -158,10 +159,14 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 }
 
                 this.LoadData(this.PageId);
+                if (this.dtTopic?.Rows?.Count == 0)
+                {
+                    this.Response.Redirect(Utilities.NavigateURL(this.TabId), false);
+                    this.Context.ApplicationInstance.CompleteRequest();
+                    return;
+                }
 
                 this.BindTopic();
-                var tempVar = this.BasePage;
-                DotNetNuke.Modules.ActiveForums.Environment.UpdateMeta(ref tempVar, this.MetaTitle, this.MetaDescription, this.MetaKeywords);
             }
             catch (Exception ex)
             {
@@ -219,6 +224,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             {
                 this.Response.Redirect(Utilities.NavigateURL(this.TabId), false);
                 this.Context.ApplicationInstance.CompleteRequest();
+                return;
             }
 
             // Load our values
@@ -235,11 +241,13 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     {
                         this.Response.Redirect(Utilities.NavigateURL(this.TabId, string.Empty, new[] { ParamKeys.TopicId + "=" + this.TopicId }), false);
                         this.Context.ApplicationInstance.CompleteRequest();
+                        return;
                     }
                     else
                     {
                         this.Response.Redirect(Utilities.NavigateURL(this.TabId, string.Empty, new[] { ParamKeys.ForumId + "=" + this.ForumId, ParamKeys.ViewType + "=" + Views.Topic, ParamKeys.TopicId + "=" + this.TopicId }), false);
                         this.Context.ApplicationInstance.CompleteRequest();
+                        return;
                     }
                 }
                 else
@@ -248,11 +256,13 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                     {
                         this.Response.Redirect(Utilities.NavigateURL(this.TabId, string.Empty, new[] { ParamKeys.ForumId + "=" + this.ForumId }), false);
                         this.Context.ApplicationInstance.CompleteRequest();
+                        return;
                     }
                     else
                     {
                         this.Response.Redirect(Utilities.NavigateURL(this.TabId, string.Empty, new[] { ParamKeys.ForumId + "=" + this.ForumId, ParamKeys.ViewType + "=" + Views.Topics }), false);
                         this.Context.ApplicationInstance.CompleteRequest();
+                        return;
                     }
                 }
             }
@@ -266,11 +276,13 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 {
                     this.Response.Redirect(Utilities.NavigateURL(this.PortalSettings.LoginTabId, string.Empty, "returnUrl=" + this.Request.RawUrl), false);
                     this.Context.ApplicationInstance.CompleteRequest();
+                    return;
                 }
                 else
                 {
                     this.Response.Redirect(Utilities.NavigateURL(this.TabId, string.Empty, "ctl=login&returnUrl=" + this.Request.RawUrl), false);
                     this.Context.ApplicationInstance.CompleteRequest();
+                    return;
                 }
             }
 
@@ -421,6 +433,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
             {
                 this.Response.Redirect(sURL, false);
                 this.Context.ApplicationInstance.CompleteRequest();
+                return;
             }
 
             // Not sure why we're doing this.  I assume it may have something to do with search engines - JB
@@ -521,6 +534,9 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                 this.MetaDescription = TemplateUtils.GetTemplateSection(this.MetaTemplate, "[DESCRIPTION]", "[/DESCRIPTION]").Replace("[DESCRIPTION]", string.Empty).Replace("[/DESCRIPTION]", string.Empty);
                 this.MetaDescription = this.MetaDescription.TruncateAtWord(SEOConstants.MaxMetaDescriptionLength);
                 this.MetaKeywords = TemplateUtils.GetTemplateSection(this.MetaTemplate, "[KEYWORDS]", "[/KEYWORDS]").Replace("[KEYWORDS]", string.Empty).Replace("[/KEYWORDS]", string.Empty);
+
+                var tempVar = this.BasePage;
+                DotNetNuke.Modules.ActiveForums.Environment.UpdateMeta(ref tempVar, this.MetaTitle, this.MetaDescription, this.MetaKeywords);
             }
 
             #endregion "Populate Metadata"

--- a/Dnn.CommunityForums/CustomControls/UserControls/TopicsView.cs
+++ b/Dnn.CommunityForums/CustomControls/UserControls/TopicsView.cs
@@ -76,22 +76,11 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
 
             try
             {
-                if (this.ForumId < 1)
+                if (this.ForumId < 1 || this.ForumInfo == null || this.ForumInfo.Active == false)
                 {
                     this.Response.Redirect(this.NavigateUrl(this.TabId), false);
                     this.Context.ApplicationInstance.CompleteRequest();
-                }
-
-                if (this.ForumInfo == null)
-                {
-                    this.Response.Redirect(this.NavigateUrl(this.TabId), false);
-                    this.Context.ApplicationInstance.CompleteRequest();
-                }
-
-                if (this.ForumInfo.Active == false)
-                {
-                    this.Response.Redirect(this.NavigateUrl(this.TabId), false);
-                    this.Context.ApplicationInstance.CompleteRequest();
+                    return;
                 }
 
                 this.AppRelativeVirtualPath = "~/";
@@ -177,80 +166,79 @@ namespace DotNetNuke.Modules.ActiveForums.Controls
                         DotNetNuke.Modules.ActiveForums.Services.Cache.ContentCache.Store(this.ModuleId, cacheKey, ds);
                     }
 
-                    if (ds.Tables.Count > 0)
+                    if (ds?.Tables?.Count <= 0 || ds?.Tables[0]?.Rows?.Count < 1 || ds?.Tables[1]?.Rows?.Count < 1 || ds?.Tables[3]?.Rows?.Count < 1)
                     {
-                        this.drForum = ds.Tables[0].Rows[0];
-                        this.drSecurity = ds.Tables[1].Rows[0];
-                        this.dtSubForums = ds.Tables[2];
-                        this.dtTopics = ds.Tables[3];
-                        if (this.PageId == 1)
+                        this.Response.Redirect(this.NavigateUrl(this.TabId), false);
+                        this.Context.ApplicationInstance.CompleteRequest();
+                        return;
+                    }
+
+                    this.drForum = ds.Tables[0].Rows[0];
+                    this.drSecurity = ds.Tables[1].Rows[0];
+                    this.dtSubForums = ds.Tables[2];
+                    this.dtTopics = ds.Tables[3];
+                    if (this.PageId == 1)
+                    {
+                        this.dtAnnounce = ds.Tables[4];
+                    }
+
+                    this.bView = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasRequiredPerm(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(this.drSecurity["CanView"].ToString()), this.ForumUser.UserRoleIds);
+                    this.bSubscribe = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasRequiredPerm(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(this.drSecurity["CanSubscribe"].ToString()), this.ForumUser.UserRoleIds);
+
+                    if (this.bView)
+                    {
+                        this.topicRowCount = Convert.ToInt32(this.drForum["TopicRowCount"]);
+                        if (this.UserId > 0)
                         {
-                            this.dtAnnounce = ds.Tables[4];
+                            this.isSubscribedForum = new DotNetNuke.Modules.ActiveForums.Controllers.SubscriptionController().Subscribed(this.PortalId, this.ForumModuleId, this.UserId, this.ForumId);
                         }
 
-                        this.bView = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasRequiredPerm(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(this.drSecurity["CanView"].ToString()), this.ForumUser.UserRoleIds);
-                        this.bSubscribe = DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasRequiredPerm(DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.GetRoleIdsFromPermSet(this.drSecurity["CanSubscribe"].ToString()), this.ForumUser.UserRoleIds);
-
-                        if (this.bView)
+                        if (this.ModuleSettings.UseSkinBreadCrumb)
                         {
-
-                            this.topicRowCount = Convert.ToInt32(this.drForum["TopicRowCount"]);
-                            if (this.UserId > 0)
-                            {
-                                this.isSubscribedForum = new DotNetNuke.Modules.ActiveForums.Controllers.SubscriptionController().Subscribed(this.PortalId, this.ForumModuleId, this.UserId, this.ForumId);
-                            }
-
-                            if (this.ModuleSettings.UseSkinBreadCrumb)
-                            {
-                                string groupURL = new ControlUtils().BuildUrl(portalId: this.PortalId, tabId: this.TabId, moduleId: this.ModuleId, groupPrefix: this.ForumInfo.ForumGroup.PrefixURL, forumPrefix: string.Empty, forumGroupId: this.ForumInfo.ForumGroupId, forumID: -1, tagId: -1, categoryId: -1, otherPrefix: string.Empty, pageId: 1, contentId: -1, socialGroupId: this.SocialGroupId);
-                                DotNetNuke.Modules.ActiveForums.Environment.UpdateBreadCrumb(this.Page.Controls, "<a href=\"" + groupURL + "\">" + this.ForumInfo.ForumGroup.GroupName + "</a>");
-                                topicsTemplate = topicsTemplate.Replace("<div class=\"afcrumb\">[FORUM:FORUMMAINLINK] > [FORUMGROUP:FORUMGROUPLINK]</div>", string.Empty);
-                            }
-
-                            if (topicsTemplate.Contains("[META]"))
-                            {
-                                this.MetaTemplate = TemplateUtils.GetTemplateSection(topicsTemplate, "[META]", "[/META]");
-                                topicsTemplate = TemplateUtils.ReplaceSubSection(topicsTemplate, string.Empty, "[META]", "[/META]");
-                            }
-
-                            // Parse Meta Template
-                            if (!string.IsNullOrEmpty(this.MetaTemplate))
-                            {
-                                this.MetaTemplate = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.RemoveObsoleteTokens(new StringBuilder(this.MetaTemplate)).ToString();
-                                this.MetaTemplate = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.ReplaceForumTokens(new StringBuilder(this.MetaTemplate), this.ForumInfo, this.PortalSettings, this.ModuleSettings, new Services.URLNavigator().NavigationManager(), this.ForumUser, this.TabId, this.ForumUser.CurrentUserType, this.Request.Url, this.Request.RawUrl).ToString();
-                                this.MetaTitle = TemplateUtils.GetTemplateSection(this.MetaTemplate, "[TITLE]", "[/TITLE]").Replace("[TITLE]", string.Empty).Replace("[/TITLE]", string.Empty);
-                                this.MetaTitle = this.MetaTitle.TruncateAtWord(SEOConstants.MaxMetaTitleLength);
-                                this.MetaDescription = TemplateUtils.GetTemplateSection(this.MetaTemplate, "[DESCRIPTION]", "[/DESCRIPTION]").Replace("[DESCRIPTION]", string.Empty).Replace("[/DESCRIPTION]", string.Empty);
-                                this.MetaDescription = this.MetaDescription.TruncateAtWord(SEOConstants.MaxMetaDescriptionLength);
-                                this.MetaKeywords = TemplateUtils.GetTemplateSection(this.MetaTemplate, "[KEYWORDS]", "[/KEYWORDS]").Replace("[KEYWORDS]", string.Empty).Replace("[/KEYWORDS]", string.Empty);
-                            }
-
-                            this.BindTopics(topicsTemplate);
-                        }
-                        else
-                        {
-                            this.Response.Redirect(this.NavigateUrl(this.TabId), false);
-                            this.Context.ApplicationInstance.CompleteRequest();
+                            string groupURL = new ControlUtils().BuildUrl(portalId: this.PortalId, tabId: this.TabId, moduleId: this.ModuleId, groupPrefix: this.ForumInfo.ForumGroup.PrefixURL, forumPrefix: string.Empty, forumGroupId: this.ForumInfo.ForumGroupId, forumID: -1, tagId: -1, categoryId: -1, otherPrefix: string.Empty, pageId: 1, contentId: -1, socialGroupId: this.SocialGroupId);
+                            DotNetNuke.Modules.ActiveForums.Environment.UpdateBreadCrumb(this.Page.Controls, "<a href=\"" + groupURL + "\">" + this.ForumInfo.ForumGroup.GroupName + "</a>");
+                            topicsTemplate = topicsTemplate.Replace("<div class=\"afcrumb\">[FORUM:FORUMMAINLINK] > [FORUMGROUP:FORUMGROUPLINK]</div>", string.Empty);
                         }
 
-                        try
+                        if (topicsTemplate.Contains("[META]"))
                         {
-                            DotNetNuke.Framework.CDefault tempVar = this.BasePage;
-                            DotNetNuke.Modules.ActiveForums.Environment.UpdateMeta(ref tempVar, this.MetaTitle, this.MetaDescription, this.MetaKeywords);
+                            this.MetaTemplate = TemplateUtils.GetTemplateSection(topicsTemplate, "[META]", "[/META]");
+                            topicsTemplate = TemplateUtils.ReplaceSubSection(topicsTemplate, string.Empty, "[META]", "[/META]");
                         }
-                        catch (Exception ex)
+
+                        // Parse Meta Template
+                        if (!string.IsNullOrEmpty(this.MetaTemplate))
                         {
-                            DotNetNuke.Services.Exceptions.Exceptions.LogException(ex);
-                            if (ex.InnerException != null)
-                            {
-                                DotNetNuke.Services.Exceptions.Exceptions.LogException(ex.InnerException);
-                            }
+                            this.MetaTemplate = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.RemoveObsoleteTokens(new StringBuilder(this.MetaTemplate)).ToString();
+                            this.MetaTemplate = DotNetNuke.Modules.ActiveForums.Services.Tokens.TokenReplacer.ReplaceForumTokens(new StringBuilder(this.MetaTemplate), this.ForumInfo, this.PortalSettings, this.ModuleSettings, new Services.URLNavigator().NavigationManager(), this.ForumUser, this.TabId, this.ForumUser.CurrentUserType, this.Request.Url, this.Request.RawUrl).ToString();
+                            this.MetaTitle = TemplateUtils.GetTemplateSection(this.MetaTemplate, "[TITLE]", "[/TITLE]").Replace("[TITLE]", string.Empty).Replace("[/TITLE]", string.Empty);
+                            this.MetaTitle = this.MetaTitle.TruncateAtWord(SEOConstants.MaxMetaTitleLength);
+                            this.MetaDescription = TemplateUtils.GetTemplateSection(this.MetaTemplate, "[DESCRIPTION]", "[/DESCRIPTION]").Replace("[DESCRIPTION]", string.Empty).Replace("[/DESCRIPTION]", string.Empty);
+                            this.MetaDescription = this.MetaDescription.TruncateAtWord(SEOConstants.MaxMetaDescriptionLength);
+                            this.MetaKeywords = TemplateUtils.GetTemplateSection(this.MetaTemplate, "[KEYWORDS]", "[/KEYWORDS]").Replace("[KEYWORDS]", string.Empty).Replace("[/KEYWORDS]", string.Empty);
                         }
+
+                        this.BindTopics(topicsTemplate);
                     }
                     else
                     {
                         this.Response.Redirect(this.NavigateUrl(this.TabId), false);
                         this.Context.ApplicationInstance.CompleteRequest();
+                        return;
+                    }
+
+                    try
+                    {
+                        DotNetNuke.Framework.CDefault tempVar = this.BasePage;
+                        DotNetNuke.Modules.ActiveForums.Environment.UpdateMeta(ref tempVar, this.MetaTitle, this.MetaDescription, this.MetaKeywords);
+                    }
+                    catch (Exception ex)
+                    {
+                        DotNetNuke.Services.Exceptions.Exceptions.LogException(ex);
+                        if (ex.InnerException != null)
+                        {
+                            DotNetNuke.Services.Exceptions.Exceptions.LogException(ex.InnerException);
+                        }
                     }
                 }
                 else

--- a/Dnn.CommunityForums/ReleaseNotes.txt
+++ b/Dnn.CommunityForums/ReleaseNotes.txt
@@ -83,6 +83,7 @@
             <li>ENHANCED: Remove deprecated URLBASE friendly URL module setting (<a target="_blank" href="https://github.com/DNNCommunity/Dnn.CommunityForums/pull/1918">PR 1918</a>)</li>
             <li>ENHANCED: Reposition "Mark All Read" button in "Not Read" filtered topics view (<a target="_blank" href="https://github.com/DNNCommunity/Dnn.CommunityForums/pull/1907">PR 1907</a>)</li>
             <li>ENHANCED: Button styling for TipTap content editor (<a target="_blank" href="https://github.com/DNNCommunity/Dnn.CommunityForums/pull/1962">PR 1962</a>)</li>
+            <li>ENHANCED: Don't log admin alerts on bad (bots) request; quietly redirect to main forums page (<a target="_blank" href="https://github.com/DNNCommunity/Dnn.CommunityForums/issue/1523">Issue 1523</a>)</li>
 
 
 <!--


### PR DESCRIPTION


<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
On topics/topic view, quietly redirect to main forums page when no data returned from database (i.e. on bad URLs which return no topics)
 
## How did you test these updates?  
<!-- Please be as descriptive as possible. -->
Local install

## PR Template Checklist

- [x] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1523
Close #984 