### PR TITLE
FIX: URL rewriter needs to ignore deleted instances of the forum module

### DIFF
--- a/Dnn.CommunityForums/ReleaseNotes.txt
+++ b/Dnn.CommunityForums/ReleaseNotes.txt
@@ -119,7 +119,8 @@
             <li>FIX: Update embedded image URLs to accommodate child portals (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1941">Issue 1941</a>)</li>
             <li>FIX: Last reply name tokens showing original topic author's name rather than last replier (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1905">Issue 1905</a>)</li>
             <li>FIX: "Ranks" page not loading in control panel (<a href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1942">Issue 1942</a>)</li>
-            <li>FIX: Update block highlighting in TipTap content editor (<a target="_blank" href="https://github.com/DNNCommunity/Dnn.CommunityForums/pull/1957">PR 1957</a>)</li>
+            <li>FIX: Update block highlighting in TipTap content editor (<a target="_blank" href="https://github.com/DNNCommunity/Dnn.CommunityForums/pull/1957">PR 1957</a>)</li>            
+            <li>FIX: URL rewriter needs to ignore deleted instances of the forums module (<a target="_blank" href="https://github.com/DNNCommunity/Dnn.CommunityForums/issues/1981">Issue 1981</a>)</li>
             
 
         </ul>

--- a/Dnn.CommunityForums/components/Extensions/ForumsReWriter.cs
+++ b/Dnn.CommunityForums/components/Extensions/ForumsReWriter.cs
@@ -243,16 +243,16 @@ namespace DotNetNuke.Modules.ActiveForums
                 var forumModuleInstances = DotNetNuke.Entities.Modules.ModuleController.Instance.GetModules(this.PortalId)
                 .Cast<DotNetNuke.Entities.Modules.ModuleInfo>()
                 .Where(
-                    module =>
+                    module => !module.IsDeleted && (
                     module.ModuleDefinition.DefinitionName.Equals(Globals.ModuleFriendlyName, StringComparison.OrdinalIgnoreCase) ||
                     module.ModuleDefinition.DefinitionName.Equals($"{Globals.ModuleFriendlyName} Viewer", StringComparison.OrdinalIgnoreCase) ||
                     module.ModuleDefinition.DefinitionName.Equals(Globals.ModuleName, StringComparison.OrdinalIgnoreCase) ||
-                    module.ModuleDefinition.DefinitionName.Equals($"{Globals.ModuleName} Viewer", StringComparison.OrdinalIgnoreCase));
+                    module.ModuleDefinition.DefinitionName.Equals($"{Globals.ModuleName} Viewer", StringComparison.OrdinalIgnoreCase)));
 
                 var tabs = new List<ModuleInfo>();
                 foreach (var module in forumModuleInstances)
                 {
-                    tabs.AddRange(DotNetNuke.Entities.Modules.ModuleController.Instance.GetAllTabsModulesByModuleID(module.ModuleID).Cast<DotNetNuke.Entities.Modules.ModuleInfo>());
+                    tabs.AddRange(DotNetNuke.Entities.Modules.ModuleController.Instance.GetAllTabsModulesByModuleID(module.ModuleID).Cast<DotNetNuke.Entities.Modules.ModuleInfo>().Where(module => !module.IsDeleted));
                 }
 
                 // base path for each tab


### PR DESCRIPTION
<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...

Ignore deleted instances of the forums module in the URL rewriter

## How did you test these updates?  
<!-- Please be as descriptive as possible. -->

Local install

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1981