### PR TITLE
FIX: Avoid "open DataReader" conflicts where DNN's shared connection may already have an active DataReader open

### DIFF
--- a/Dnn.CommunityForums/Controllers/ContentController.cs
+++ b/Dnn.CommunityForums/Controllers/ContentController.cs
@@ -88,7 +88,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                     timeFrameMinutes = 0;
                 }
 
-                postCount = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<int?>(
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                postCount = ctx.ExecuteQuery<int?>(
                     System.Data.CommandType.Text,
                     $@"SELECT COUNT(DISTINCT ContentId)
                         FROM (
@@ -139,7 +140,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                     timeFrameMinutes = 0;
                 }
 
-                var postInfo = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<PostIdResult>(
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                var postInfo = ctx.ExecuteQuery<PostIdResult>(
                     System.Data.CommandType.Text,
                     $@"SELECT ContentId, TopicId, ReplyId
                         FROM (

--- a/Dnn.CommunityForums/Controllers/ForumController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumController.cs
@@ -136,7 +136,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             if (forums == null)
             {
                 forums = new DotNetNuke.Modules.ActiveForums.Entities.ForumCollection();
-                foreach (DotNetNuke.Modules.ActiveForums.Entities.ForumInfo forum in this._repositoryControllerBase.Find("WHERE ParentForumId = @0", forumId).OrderBy(f => f.ForumGroup?.SortOrder).ThenBy(f => f.SortOrder))
+                foreach (DotNetNuke.Modules.ActiveForums.Entities.ForumInfo forum in this._repositoryControllerBase.Find("WHERE ParentForumId = @0", forumId).OrderBy(f => f.ForumGroup?.SortOrder).ThenBy(f => f.SortOrder).ToList())
                 {
                     forum.LoadForumGroup();
                     forum.LoadProperties();
@@ -372,7 +372,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             DotNetNuke.Modules.ActiveForums.Controllers.ForumTopicController.Instance.DeleteForForum(moduleId, forumId);
             new DotNetNuke.Modules.ActiveForums.Controllers.SubscriptionController().DeleteForForum(moduleId, forumId);
             this._repositoryControllerBase.DeleteById(forumId);
-            DataContext.Instance().Execute(System.Data.CommandType.StoredProcedure, "{databaseOwner}{objectQualifier}communityforums_Forums_RepairSort", forumId, parentForumId);
+            using var ctx = DotNetNuke.Data.DataContext.Instance();
+            ctx.Execute(System.Data.CommandType.StoredProcedure, "{databaseOwner}{objectQualifier}communityforums_Forums_RepairSort", forumId, parentForumId);
             DotNetNuke.Modules.ActiveForums.Services.Cache.SettingsCache.ClearAll(moduleId);
         }
 
@@ -546,7 +547,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
         {
             try
             {
-                return DataContext.Instance().ExecuteQuery<DateTime>(System.Data.CommandType.Text, "SELECT LastAccessDate FROM {databaseOwner}{objectQualifier}communityforums_Forums_Tracking WHERE ForumId = @0 AND UserId = @1", forumId, userId).FirstOrDefault();
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                return ctx.ExecuteQuery<DateTime>(System.Data.CommandType.Text, "SELECT LastAccessDate FROM {databaseOwner}{objectQualifier}communityforums_Forums_Tracking WHERE ForumId = @0 AND UserId = @1", forumId, userId).FirstOrDefault();
             }
             catch (Exception ex)
             {
@@ -559,7 +561,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
         {
             try
             {
-                DataContext.Instance().Execute(System.Data.CommandType.StoredProcedure, "{databaseOwner}{objectQualifier}communityforums_SaveTopicNextPrev", forumId);
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                ctx.Execute(System.Data.CommandType.StoredProcedure, "{databaseOwner}{objectQualifier}communityforums_SaveTopicNextPrev", forumId);
                 return true;
             }
             catch (Exception ex)
@@ -573,7 +576,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
         {
             try
             {
-                DataContext.Instance().Execute(System.Data.CommandType.StoredProcedure, "{databaseOwner}{objectQualifier}communityforums_Forums_LastUpdates", forumId);
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                ctx.Execute(System.Data.CommandType.StoredProcedure, "{databaseOwner}{objectQualifier}communityforums_Forums_LastUpdates", forumId);
                 return true;
             }
             catch (Exception ex)

--- a/Dnn.CommunityForums/Controllers/ForumUserController.cs
+++ b/Dnn.CommunityForums/Controllers/ForumUserController.cs
@@ -269,7 +269,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
 
                 var postsRemoved = new StringBuilder();
 
-                var contentForBannedUser = DataContext.Instance().ExecuteQuery<JournalContentForUser>(System.Data.CommandType.StoredProcedure, "{databaseOwner}{objectQualifier}communityforums_Content_GetJournalKeysForUser", authorId, moduleId).ToList();
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                var contentForBannedUser = ctx.ExecuteQuery<JournalContentForUser>(System.Data.CommandType.StoredProcedure, "{databaseOwner}{objectQualifier}communityforums_Content_GetJournalKeysForUser", authorId, moduleId).ToList();
                 string objectKey;
                 contentForBannedUser.ForEach(c =>
                 {
@@ -613,7 +614,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             sSql += "INNER JOIN {databaseOwner}{objectQualifier}communityforums_Forums as f ON f.ForumId = ft.ForumId ";
             sSql += "WHERE c.AuthorId = @1 AND t.IsApproved = 1 AND t.IsDeleted=0 AND f.PortalId=@0),0) ";
             sSql += "WHERE UserId = @1 AND PortalId = @0";
-            DataContext.Instance().Execute(System.Data.CommandType.Text, sSql, portalId, userId);
+            using var ctx = DotNetNuke.Data.DataContext.Instance();
+            ctx.Execute(System.Data.CommandType.Text, sSql, portalId, userId);
             DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.ClearCache(portalId, userId);
         }
 
@@ -626,7 +628,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             sSql += "INNER JOIN {databaseOwner}{objectQualifier}communityforums_Forums as f ON f.ForumId = ft.ForumId ";
             sSql += "WHERE c.AuthorId = @1 AND r.IsApproved = 1 AND r.IsDeleted=0 AND f.PortalId=@0),0) ";
             sSql += "WHERE UserId = @1 AND PortalId = @0";
-            DataContext.Instance().Execute(System.Data.CommandType.Text, sSql, portalId, userId);
+            using var ctx = DotNetNuke.Data.DataContext.Instance();
+            ctx.Execute(System.Data.CommandType.Text, sSql, portalId, userId);
             DotNetNuke.Modules.ActiveForums.Controllers.ForumUserController.ClearCache(portalId, userId);
         }
 

--- a/Dnn.CommunityForums/Controllers/PermissionController.cs
+++ b/Dnn.CommunityForums/Controllers/PermissionController.cs
@@ -850,9 +850,13 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                 sForums = string.Empty;
                 if (!string.IsNullOrEmpty(forumIds))
                 {
-                    foreach (string forumId in forumIds.Split(":".ToCharArray(), StringSplitOptions.RemoveEmptyEntries))
+                    var requestedForumIds = new HashSet<int>(
+                        forumIds.Split(":".ToCharArray(), StringSplitOptions.RemoveEmptyEntries)
+                                .Select(id => Convert.ToInt32(id)));
+
+                    var allForums = DotNetNuke.Modules.ActiveForums.Controllers.ForumController.Instance.GetForums(moduleId);
+                    foreach (var forum in allForums.Where(f => requestedForumIds.Contains(f.ForumID)))
                     {
-                        DotNetNuke.Modules.ActiveForums.Entities.ForumInfo forum = DotNetNuke.Modules.ActiveForums.Controllers.ForumController.Instance.GetById(moduleId, Convert.ToInt32(forumId));
                         if (forum.FeatureSettings.AllowRSS && DotNetNuke.Modules.ActiveForums.Controllers.PermissionController.HasRequiredPerm(forum.Security?.ViewRoleIds, userRoleIds))
                         {
                             sForums += forum.ForumID.ToString() + ":";

--- a/Dnn.CommunityForums/Controllers/TopicController.cs
+++ b/Dnn.CommunityForums/Controllers/TopicController.cs
@@ -28,6 +28,7 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
 
     using DotNetNuke.Collections;
     using DotNetNuke.Common.Utilities;
+    using DotNetNuke.Data;
     using DotNetNuke.Modules.ActiveForums.Entities;
     using DotNetNuke.Modules.ActiveForums.Enums;
     using DotNetNuke.Modules.ActiveForums.Extensions;
@@ -118,8 +119,9 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             var topicCount = DotNetNuke.Modules.ActiveForums.Services.Cache.ContentCache.Retrieve(moduleId, cachekey) as int?;
             if (topicCount == null || !topicCount.HasValue)
             {
-                var forumsIdsList = forumIds.FromHashSetToDelimitedString<int>(",");
-                topicCount = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<int?>(
+                var forumsIdsList = forumIds.FromHashSetToDelimitedString<int>(",");-
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                topicCount = ctx.ExecuteQuery<int?>(
                     System.Data.CommandType.Text,
                     $@"SELECT COUNT(t.TopicId)
                        FROM {{databaseOwner}}[{{objectQualifier}}communityforums_Topics] t
@@ -156,7 +158,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                 {
                     var skip = (pageId - 1) * pageSize;
                     var forumsIdsList = forumIds.FromHashSetToDelimitedString<int>(",");
-                    var topicIds = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<int?>(
+                    using var ctx = DotNetNuke.Data.DataContext.Instance();
+                    var topicIds = ctx.ExecuteQuery<int?>(
                         System.Data.CommandType.Text,
                         $@"SELECT t.TopicId
                            FROM {{databaseOwner}}[{{objectQualifier}}communityforums_Topics] t
@@ -196,7 +199,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                     timeFrameMinutes = 0;
                 }
 
-                topicCount = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<int?>(
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                topicCount = ctx.ExecuteQuery<int?>(
                     System.Data.CommandType.Text,
                     $@"SELECT COUNT(t.TopicId)
                        FROM {{databaseOwner}}[{{objectQualifier}}vw_communityforums_TopicsView] t
@@ -230,7 +234,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                     timeFrameMinutes = 0;
                 }
 
-                var topicIds = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<int?>(
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                var topicIds = ctx.ExecuteQuery<int?>(
                     System.Data.CommandType.Text,
                     $@"SELECT t.TopicId
                         FROM {{databaseOwner}}[{{objectQualifier}}vw_communityforums_TopicsView] t
@@ -266,7 +271,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                     timeFrameMinutes = 0;
                 }
 
-                topicCount = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<int?>(
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                topicCount = ctx.ExecuteQuery<int?>(
                     System.Data.CommandType.Text,
                     $@"SELECT COUNT(t.TopicId)
                        FROM {{databaseOwner}}[{{objectQualifier}}vw_communityforums_TopicsView] t
@@ -306,7 +312,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                     timeFrameMinutes = 0;
                 }
 
-                var topicIds = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<int?>(
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                var topicIds = ctx.ExecuteQuery<int?>(
                     System.Data.CommandType.Text,
                     $@"SELECT t.TopicId
                         FROM {{databaseOwner}}[{{objectQualifier}}vw_communityforums_TopicsView] t
@@ -343,7 +350,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                     timeFrameMinutes = 0;
                 }
 
-                topicCount = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<int?>(
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                topicCount = ctx.ExecuteQuery<int?>(
                     System.Data.CommandType.Text,
                     $@"SELECT COUNT(t.TopicId)
                        FROM {{databaseOwner}}[{{objectQualifier}}vw_communityforums_TopicsView] t
@@ -379,7 +387,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                     timeFrameMinutes = 0;
                 }
 
-                var topicIds = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<int?>(
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                var topicIds = ctx.ExecuteQuery<int?>(
                     System.Data.CommandType.Text,
                     $@"SELECT t.TopicId
                         FROM {{databaseOwner}}[{{objectQualifier}}vw_communityforums_TopicsView] t
@@ -417,7 +426,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                     timeFrameMinutes = 0;
                 }
 
-                topicCount = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<int?>(
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                topicCount = ctx.ExecuteQuery<int?>(
                     System.Data.CommandType.Text,
                     $@"SELECT COUNT(t.TopicId)
                        FROM {{databaseOwner}}[{{objectQualifier}}vw_communityforums_TopicsView] t
@@ -451,7 +461,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                         timeFrameMinutes = 0;
                     }
 
-                    var topicIds = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<int?>(
+                    using var ctx = DotNetNuke.Data.DataContext.Instance();
+                    var topicIds = ctx.ExecuteQuery<int?>(
                         System.Data.CommandType.Text,
                         $@"SELECT t.TopicId
                            FROM {{databaseOwner}}[{{objectQualifier}}vw_communityforums_TopicsView] t
@@ -488,7 +499,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                     timeFrameMinutes = 0;
                 }
 
-                topicCount = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<int?>(
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                topicCount = ctx.ExecuteQuery<int?>(
                     System.Data.CommandType.Text,
                     $@"SELECT COUNT(DISTINCT TopicId)
                         FROM (
@@ -549,7 +561,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                         timeFrameMinutes = 0;
                     }
 
-                    var topicIds = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<int?>(
+                    using var ctx = DotNetNuke.Data.DataContext.Instance();
+                    var topicIds = ctx.ExecuteQuery<int?>(
                         System.Data.CommandType.Text,
                         $@"SELECT DISTINCT TopicId
                             FROM (
@@ -620,7 +633,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                     timeFrameMinutes = 0;
                 }
 
-                topicCount = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<int?>(
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                topicCount = ctx.ExecuteQuery<int?>(
                     System.Data.CommandType.Text,
                     $@"SELECT COUNT(DISTINCT TopicId)
                             FROM (
@@ -674,7 +688,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                         timeFrameMinutes = 0;
                     }
 
-                    var topicIds = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<int?>(
+                    using var ctx = DotNetNuke.Data.DataContext.Instance();
+                    var topicIds = ctx.ExecuteQuery<int?>(
                         System.Data.CommandType.Text,
                         $@"SELECT DISTINCT TopicId
                             FROM (
@@ -731,7 +746,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                     timeFrameMinutes = 0;
                 }
 
-                topicCount = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<int?>(
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                topicCount = ctx.ExecuteQuery<int?>(
                     System.Data.CommandType.Text,
                     $@"SELECT COUNT(DISTINCT t.TopicId)
                        FROM {{databaseOwner}}[{{objectQualifier}}vw_communityforums_TopicsView] t
@@ -767,7 +783,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                     timeFrameMinutes = 0;
                 }
 
-                var topicIds = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<int?>(
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                var topicIds = ctx.ExecuteQuery<int?>(
                     System.Data.CommandType.Text,
                     $@"SELECT DISTINCT TopicId
                             FROM (
@@ -801,17 +818,18 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             {
                 if (!string.IsNullOrWhiteSpace(topicUrl))
                 {
-                    var topicId = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<int?>(
-                        System.Data.CommandType.Text,
-                        $@"SELECT t.TopicId
-                           FROM {{databaseOwner}}[{{objectQualifier}}communityforums_Topics] t
-                           INNER JOIN {{databaseOwner}}[{{objectQualifier}}communityforums_ForumTopics] ft
-                               ON ft.TopicId = t.TopicId
-                           WHERE ft.ForumId = @0
-                             AND t.URL_Hash = HASHBYTES('MD5', CONVERT(varbinary(8000), @1))
-                             AND t.URL = @1",
-                        forumId,
-                        topicUrl.Trim()).FirstOrDefault();
+                    using var ctx = DotNetNuke.Data.DataContext.Instance();
+                    var topicId = ctx.ExecuteQuery<int?>(
+                    System.Data.CommandType.Text,
+                    $@"SELECT t.TopicId
+                        FROM {{databaseOwner}}[{{objectQualifier}}communityforums_Topics] t
+                        INNER JOIN {{databaseOwner}}[{{objectQualifier}}communityforums_ForumTopics] ft
+                            ON ft.TopicId = t.TopicId
+                        WHERE ft.ForumId = @0
+                            AND t.URL_Hash = HASHBYTES('MD5', CONVERT(varbinary(8000), @1))
+                            AND t.URL = @1",
+                    forumId,
+                    topicUrl.Trim()).FirstOrDefault();
                     if (topicId.HasValue)
                     {
                         topicInfo = this.GetById(moduleId: moduleId, topicId: topicId.Value);

--- a/Dnn.CommunityForums/Controllers/TopicTrackingController.cs
+++ b/Dnn.CommunityForums/Controllers/TopicTrackingController.cs
@@ -53,7 +53,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             var topicReadCount = DotNetNuke.Modules.ActiveForums.Services.Cache.ContentCache.Retrieve(moduleId, cachekey);
             if (topicReadCount == null)
             {
-                topicReadCount = DataContext.Instance().ExecuteQuery<int>(
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                topicReadCount = ctx.ExecuteQuery<int>(
                     System.Data.CommandType.Text,
                     "SELECT COUNT(*) FROM {databaseOwner}{objectQualifier}communityforums_Topics_Tracking tt LEFT OUTER JOIN {databaseOwner}{objectQualifier}communityforums_Topics t ON t.TopicId = tt.TopicId WHERE tt.UserId = @0 AND tt.ForumId = @1 AND t.IsDeleted = 0",
                     userId,
@@ -67,7 +68,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
 
         public int GetTopicsReadCountByUser(int moduleId, int userId)
         {
-            return DataContext.Instance().ExecuteQuery<int>(
+            using var ctx = DotNetNuke.Data.DataContext.Instance();
+            return ctx.ExecuteQuery<int>(
                 System.Data.CommandType.Text,
                 "SELECT COUNT(*) FROM {databaseOwner}{objectQualifier}communityforums_Topics_Tracking tt WHERE tt.UserId = @0",
                 userId).FirstOrDefault();
@@ -75,7 +77,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
 
         public int GetTopicsReadCountByUser(int moduleId, int userId, DateTime minDateTime)
         {
-            return DataContext.Instance().ExecuteQuery<int>(
+            using var ctx = DotNetNuke.Data.DataContext.Instance();
+            return ctx.ExecuteQuery<int>(
                 System.Data.CommandType.Text,
                 "SELECT COUNT(*) FROM {databaseOwner}{objectQualifier}communityforums_Topics_Tracking tt WHERE tt.UserId = @0 AND DateAdded IS NOT NULL AND DateAdded >= @1",
                 userId,

--- a/Dnn.CommunityForums/Controllers/UrlController.cs
+++ b/Dnn.CommunityForums/Controllers/UrlController.cs
@@ -78,14 +78,16 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
 
         internal static void ArchiveURL(int portalId, int forumGroupId, int forumId, int topicId, string uRL)
         {
-            DotNetNuke.Data.DataContext.Instance().Execute(CommandType.StoredProcedure, "{databaseOwner}{objectQualifier}communityforums_URL_Archive", portalId, forumGroupId, forumId, topicId, uRL);
+            using var ctx = DotNetNuke.Data.DataContext.Instance();
+            ctx.Execute(CommandType.StoredProcedure, "{databaseOwner}{objectQualifier}communityforums_URL_Archive", portalId, forumGroupId, forumId, topicId, uRL);
         }
 
         internal static string GetUrl(int moduleId, int forumGroupId, int forumId, int topicId, int userId, int contentId)
         {
             try
             {
-                return DotNetNuke.Data.DataContext.Instance().ExecuteScalar<string>(CommandType.StoredProcedure, "{databaseOwner}{objectQualifier}communityforums_Util_GetUrl", moduleId, forumGroupId, forumId, topicId, userId, contentId);
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                return ctx.ExecuteScalar<string>(CommandType.StoredProcedure, "{databaseOwner}{objectQualifier}communityforums_Util_GetUrl", moduleId, forumGroupId, forumId, topicId, userId, contentId);
             }
             catch
             {
@@ -104,7 +106,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                 }
 
                 int tmpForumId = -1;
-                tmpForumId = DotNetNuke.Data.DataContext.Instance().ExecuteScalar<int>(CommandType.StoredProcedure, "{databaseOwner}{objectQualifier}communityforums_URL_CheckForumVanity", portalId, vanityName);
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                tmpForumId = ctx.ExecuteScalar<int>(CommandType.StoredProcedure, "{databaseOwner}{objectQualifier}communityforums_URL_CheckForumVanity", portalId, vanityName);
                 if (tmpForumId > 0 && forumId == -1)
                 {
                     return false;
@@ -131,7 +134,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
             try
             {
                 int tmpForumGroupId = -1;
-                tmpForumGroupId = DotNetNuke.Data.DataContext.Instance().ExecuteScalar<int>(CommandType.StoredProcedure, "{databaseOwner}{objectQualifier}communityforums_URL_CheckGroupVanity", portalId, vanityName);
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                tmpForumGroupId = ctx.ExecuteScalar<int>(CommandType.StoredProcedure, "{databaseOwner}{objectQualifier}communityforums_URL_CheckGroupVanity", portalId, vanityName);
                 if (tmpForumGroupId > 0 && forumGroupId == -1)
                 {
                     return false;
@@ -189,7 +193,8 @@ namespace DotNetNuke.Modules.ActiveForums.Controllers
                 uRL = uRL.Substring(0, uRL.Length - 1);
             }
 
-            return DotNetNuke.Data.DataContext.Instance().ExecuteScalar<int>(CommandType.StoredProcedure, "{databaseOwner}{objectQualifier}communityforums_TopicIdByURL", portalId, moduleId, uRL);
+            using var ctx = DotNetNuke.Data.DataContext.Instance();
+            return ctx.ExecuteScalar<int>(CommandType.StoredProcedure, "{databaseOwner}{objectQualifier}communityforums_TopicIdByURL", portalId, moduleId, uRL);
         }
     }
 }

--- a/Dnn.CommunityForums/Entities/ForumInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumInfo.cs
@@ -114,18 +114,26 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         public int TotalReplies { get; set; }
 
         [IgnoreColumn]
-        public int TotalLikeCount => this.totalLikeCount ?? (this.totalLikeCount = DataContext.Instance().ExecuteQuery<int>(
-            CommandType.Text,
-            @"SELECT COUNT(1)
-                FROM {databaseOwner}{objectQualifier}communityforums_Likes l
-                INNER JOIN {databaseOwner}{objectQualifier}communityforums_Content c ON c.ContentId = l.PostId
-                LEFT OUTER JOIN {databaseOwner}{objectQualifier}communityforums_Topics t ON t.ContentId = c.ContentId
-                LEFT OUTER JOIN {databaseOwner}{objectQualifier}communityforums_Replies r ON r.ContentId = c.ContentId
-                LEFT OUTER JOIN {databaseOwner}{objectQualifier}communityforums_ForumTopics ftTopic ON ftTopic.TopicId = t.TopicId
-                LEFT OUTER JOIN {databaseOwner}{objectQualifier}communityforums_ForumTopics ftReply ON ftReply.TopicId = r.TopicId
-                WHERE l.Checked = 1
-                  AND COALESCE(ftTopic.ForumId, ftReply.ForumId) = @0",
-            this.ForumID).FirstOrDefault()).Value;
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:Parameter should not span multiple lines", Justification = "Readability")]
+        public int TotalLikeCount
+        {
+            get
+            {
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                return this.totalLikeCount ?? (this.totalLikeCount = ctx.ExecuteQuery<int>(
+                        CommandType.Text,
+                        @"SELECT COUNT(1)
+                            FROM {databaseOwner}{objectQualifier}communityforums_Likes l
+                            INNER JOIN {databaseOwner}{objectQualifier}communityforums_Content c ON c.ContentId = l.PostId
+                            LEFT OUTER JOIN {databaseOwner}{objectQualifier}communityforums_Topics t ON t.ContentId = c.ContentId
+                            LEFT OUTER JOIN {databaseOwner}{objectQualifier}communityforums_Replies r ON r.ContentId = c.ContentId
+                            LEFT OUTER JOIN {databaseOwner}{objectQualifier}communityforums_ForumTopics ftTopic ON ftTopic.TopicId = t.TopicId
+                            LEFT OUTER JOIN {databaseOwner}{objectQualifier}communityforums_ForumTopics ftReply ON ftReply.TopicId = r.TopicId
+                            WHERE l.Checked = 1
+                                AND COALESCE(ftTopic.ForumId, ftReply.ForumId) = @0",
+                        this.ForumID).FirstOrDefault()).Value;
+            }
+        }
 
         [IgnoreColumn]
         public double AverageLikeScore => this.TotalTopics > 0 ? (double)this.TotalLikeCount / this.TotalTopics : 0D;

--- a/Dnn.CommunityForums/Entities/ForumUserInfo.cs
+++ b/Dnn.CommunityForums/Entities/ForumUserInfo.cs
@@ -558,13 +558,15 @@ namespace DotNetNuke.Modules.ActiveForums.Entities
         public int GetTopicCountSince(DateTime minDateTime)
         {
             string sSql = "SELECT COUNT(*) FROM {databaseOwner}{objectQualifier}communityforums_Content c INNER JOIN {databaseOwner}{objectQualifier}communityforums_Topics t ON t.ContentId = c.ContentId WHERE c.ModuleId = @0 AND c.AuthorId = @1 AND c.IsDeleted = 0 AND c.DateCreated >= @2";
-            return DataContext.Instance().ExecuteQuery<int>(System.Data.CommandType.Text, sSql, this.ModuleId, this.UserId, minDateTime).FirstOrDefault();
+            using var ctx = DotNetNuke.Data.DataContext.Instance();
+            return ctx.ExecuteQuery<int>(System.Data.CommandType.Text, sSql, this.ModuleId, this.UserId, minDateTime).FirstOrDefault();
         }
 
         public int GetReplyCountSince(DateTime minDateTime)
         {
             string sSql = "SELECT COUNT(*) FROM {databaseOwner}{objectQualifier}communityforums_Content c INNER JOIN {databaseOwner}{objectQualifier}communityforums_Replies r ON r.ContentId = c.ContentId WHERE c.ModuleId = @0 AND c.AuthorId = @1 AND c.IsDeleted = 0 AND c.DateCreated >= @2";
-            return DataContext.Instance().ExecuteQuery<int>(System.Data.CommandType.Text, sSql, this.ModuleId, this.UserId, minDateTime).FirstOrDefault();
+            using var ctx = DotNetNuke.Data.DataContext.Instance();
+            return ctx.ExecuteQuery<int>(System.Data.CommandType.Text, sSql, this.ModuleId, this.UserId, minDateTime).FirstOrDefault();
         }
 
         [IgnoreColumn]

--- a/Dnn.CommunityForums/Services/Sitemap/ForumsSitemapProvider.cs
+++ b/Dnn.CommunityForums/Services/Sitemap/ForumsSitemapProvider.cs
@@ -91,7 +91,8 @@ namespace DotNetNuke.Modules.ActiveForums.Services.Sitemap
             var sitemapMetricsByUrl = new Dictionary<string, SitemapUrlMetrics>(StringComparer.OrdinalIgnoreCase);
             var forumAverageLikeScoreByForumId = new Dictionary<int, double>();
 
-            var results = DataContext.Instance().ExecuteQuery<SearchSitemapResult>(
+            using var ctx = DotNetNuke.Data.DataContext.Instance();
+            var results = ctx.ExecuteQuery<SearchSitemapResult>(
                 CommandType.StoredProcedure,
                 "{databaseOwner}{objectQualifier}communityforums_Search_GetSearchItemsFromBegDate",
                 module.ModuleID,

--- a/Dnn.CommunityForums/class/ForumsConfig.cs
+++ b/Dnn.CommunityForums/class/ForumsConfig.cs
@@ -291,7 +291,8 @@ namespace DotNetNuke.Modules.ActiveForums
                     attachmentFileNames.Add(new System.IO.FileInfo(attachmentFileName).Name);
                 }
 
-                var databaseFileNames = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<string>(System.Data.CommandType.Text, "SELECT FileName FROM {databaseOwner}{objectQualifier}communityforums_Attachments ORDER BY FileName").ToList();
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                var databaseFileNames = ctx.ExecuteQuery<string>(System.Data.CommandType.Text, "SELECT FileName FROM {databaseOwner}{objectQualifier}communityforums_Attachments ORDER BY FileName").ToList();
 
                 foreach (var attachmentFileName in attachmentFileNames)
                 {
@@ -1064,7 +1065,8 @@ namespace DotNetNuke.Modules.ActiveForums
                 log.AddProperty("Message", message);
                 DotNetNuke.Services.Log.EventLog.LogController.Instance.AddLog(log);
 
-                DotNetNuke.Data.DataContext.Instance().Execute(System.Data.CommandType.Text, "IF EXISTS(SELECT * FROM sys.columns WHERE [name] = N'FileData' AND [object_id] = OBJECT_ID(N'{databaseOwner}[{objectQualifier}communityforums_Attachments]')) ALTER TABLE {databaseOwner}[{objectQualifier}communityforums_Attachments] DROP COLUMN FileData");
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                ctx.Execute(System.Data.CommandType.Text, "IF EXISTS(SELECT * FROM sys.columns WHERE [name] = N'FileData' AND [object_id] = OBJECT_ID(N'{databaseOwner}[{objectQualifier}communityforums_Attachments]')) ALTER TABLE {databaseOwner}[{objectQualifier}communityforums_Attachments] DROP COLUMN FileData");
             }
             catch (Exception ex)
             {
@@ -1154,10 +1156,11 @@ namespace DotNetNuke.Modules.ActiveForums
                     {
                         /* use direct SQL command rather than DAL2 entity so the column can be removed after data is migrated */
                         byte[] fileBytes = null;
-                        var fileDataColumnObjectId = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<int?>(System.Data.CommandType.Text, "SELECT object_id FROM sys.columns WHERE [name] = N'FileData' AND [object_id] = OBJECT_ID(N'{databaseOwner}[{objectQualifier}communityforums_Attachments]')").FirstOrDefault();
+                        using var ctx = DotNetNuke.Data.DataContext.Instance();
+                        var fileDataColumnObjectId = ctx.ExecuteQuery<int?>(System.Data.CommandType.Text, "SELECT object_id FROM sys.columns WHERE [name] = N'FileData' AND [object_id] = OBJECT_ID(N'{databaseOwner}[{objectQualifier}communityforums_Attachments]')").FirstOrDefault();
                         if (fileDataColumnObjectId != null)
                         {
-                            var fileData = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<byte[]>(System.Data.CommandType.Text, "SELECT FileData FROM {databaseOwner}[{objectQualifier}communityforums_Attachments] WHERE AttachmentId = @0", attachment.AttachmentId).FirstOrDefault();
+                            var fileData = ctx.ExecuteQuery<byte[]>(System.Data.CommandType.Text, "SELECT FileData FROM {databaseOwner}[{objectQualifier}communityforums_Attachments] WHERE AttachmentId = @0", attachment.AttachmentId).FirstOrDefault();
                             if (fileData != null && fileData.Length > 0)
                             {
                                 fileBytes = fileData;
@@ -1203,7 +1206,7 @@ namespace DotNetNuke.Modules.ActiveForums
                                         filelocation = orphanedAttachmentsPath + attachment.FileName;
                                         if (!System.IO.File.Exists(filelocation))
                                         {
-                                         filelocation = System.IO.Directory.EnumerateFiles(path: orphanedAttachmentsPath, searchPattern: string.Format(fileNameTemplate, attachment.ContentId, "*", attachment.FileName), searchOption: System.IO.SearchOption.AllDirectories).FirstOrDefault();
+                                            filelocation = System.IO.Directory.EnumerateFiles(path: orphanedAttachmentsPath, searchPattern: string.Format(fileNameTemplate, attachment.ContentId, "*", attachment.FileName), searchOption: System.IO.SearchOption.AllDirectories).FirstOrDefault();
                                         }
                                     }
                                 }
@@ -1363,161 +1366,168 @@ namespace DotNetNuke.Modules.ActiveForums
                     else
                     {
                         /* use direct SQL command rather than DAL2 entity so the column can be removed after data is migrated */
-                        byte[] fileBytes = null;
-                        var fileDataColumnObjectId = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<int?>(System.Data.CommandType.Text, "SELECT object_id FROM sys.columns WHERE [name] = N'FileData' AND [object_id] = OBJECT_ID(N'{databaseOwner}[{objectQualifier}communityforums_Attachments]')").FirstOrDefault();
-                        if (fileDataColumnObjectId != null)
+
+                        // Use an isolated DataContext scope to avoid "open DataReader" conflicts
+                        // when called during BeginRequest where DNN's shared connection may already
+                        // have an active DataReader open.
+                        using (var ctx = DotNetNuke.Data.DataContext.Instance())
                         {
-                            var fileData = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<byte[]>(System.Data.CommandType.Text, "SELECT FileData FROM {databaseOwner}[{objectQualifier}communityforums_Attachments] WHERE AttachmentId = @0", attachment.AttachmentId).FirstOrDefault();
-                            if (fileData != null && fileData.Length > 0)
+                            byte[] fileBytes = null;
+                            var fileDataColumnObjectId = ctx.ExecuteQuery<int?>(System.Data.CommandType.Text, "SELECT object_id FROM sys.columns WHERE [name] = N'FileData' AND [object_id] = OBJECT_ID(N'{databaseOwner}[{objectQualifier}communityforums_Attachments]')").FirstOrDefault();
+                            if (fileDataColumnObjectId != null)
                             {
-                                fileBytes = fileData;
-                            }
-
-                            if (fileBytes != null && fileBytes.Length > 0)
-                            {
-                                System.Drawing.Imaging.ImageFormat saveFormat = null;
-                                switch (attachment.ContentType.ToLowerInvariant())
+                                var fileData = ctx.ExecuteQuery<byte[]>(System.Data.CommandType.Text, "SELECT FileData FROM {databaseOwner}[{objectQualifier}communityforums_Attachments] WHERE AttachmentId = @0", attachment.AttachmentId).FirstOrDefault();
+                                if (fileData != null && fileData.Length > 0)
                                 {
-                                    case "image/jpeg":
-                                    case "image/jpg":
-                                        saveFormat = System.Drawing.Imaging.ImageFormat.Jpeg;
-                                        break;
-                                    case "image/gif":
-                                        saveFormat = System.Drawing.Imaging.ImageFormat.Gif;
-                                        break;
-                                    case "image/png":
-                                    case "image/x-png":
-                                        saveFormat = System.Drawing.Imaging.ImageFormat.Png;
-                                        break;
-                                    default:
-                                        // Unsupported image type
-                                        var log = new DotNetNuke.Services.Log.EventLog.LogInfo { LogTypeKey = DotNetNuke.Abstractions.Logging.EventLogType.HOST_ALERT.ToString() };
-                                        log.LogProperties.Add(new LogDetailInfo("Module", Globals.ModuleFriendlyName));
-                                        var message = $"Unable to determine or invalid content type {attachment.ContentType} for file {attachment.FileName} with user id {attachment.UserId} while relocating attachment with id {attachment.AttachmentId} and content id {attachment.ContentId}";
-                                        log.AddProperty("Message", message);
-                                        DotNetNuke.Services.Log.EventLog.LogController.Instance.AddLog(log);
-                                        return;
+                                    fileBytes = fileData;
                                 }
 
-                                attachment.FileName = System.IO.Path.ChangeExtension(attachment.FileName, saveFormat.ToString().ToLowerInvariant());
-                                using (var ms = new MemoryStream())
+                                if (fileBytes != null && fileBytes.Length > 0)
                                 {
-                                    ms.Write(fileBytes, 0, fileBytes.Length);
-                                    ms.Position = 0;
-
-                                    attachment.FileName = DotNetNuke.Modules.ActiveForums.Controllers.AttachmentController.CreateUniqueFileName(embeddedImagesFolder.PhysicalPath, attachment.FileName);
-                                    file = fileManager.AddFile(embeddedImagesFolder, attachment.FileName, ms, true);
-                                }
-
-                                if (file != null)
-                                {
-                                    attachment.FileId = file.FileId;
-                                }
-                            }
-                        }
-
-                        if (fileDataColumnObjectId == null || fileBytes == null)
-                        {
-                            const string fileNameTemplate = Globals.LegacyAttachmentFileNameFormatString;
-                            var filelocation = legacyAttachmentsPath + attachment.FileName;
-                            if (!System.IO.File.Exists(filelocation))
-                            {
-                                filelocation = System.IO.Directory.EnumerateFiles(path: legacyAttachmentsPath, searchPattern: string.Format(fileNameTemplate, attachment.ContentId, "*", attachment.FileName), searchOption: System.IO.SearchOption.AllDirectories).FirstOrDefault();
-                                if (filelocation == null || !System.IO.File.Exists(filelocation))
-                                {
-                                    // If the file doesn't exist in the legacy attachment location, attempt to find it in the user's folder (legacy location for user-uploaded attachments)
-                                    var userInfo = DotNetNuke.Entities.Users.UserController.Instance.GetUserById(content.Post.PortalId, attachment.UserId);
-                                    if (userInfo == null)
+                                    System.Drawing.Imaging.ImageFormat saveFormat = null;
+                                    switch (attachment.ContentType.ToLowerInvariant())
                                     {
-                                        var log = new DotNetNuke.Services.Log.EventLog.LogInfo { LogTypeKey = DotNetNuke.Abstractions.Logging.EventLogType.HOST_ALERT.ToString() };
-                                        log.LogProperties.Add(new LogDetailInfo("Module", Globals.ModuleFriendlyName));
-                                        var message = $"Unable to locate user with id {attachment.UserId} while relocating attachment with id {attachment.AttachmentId} and content id {attachment.ContentId}";
-                                        log.AddProperty("Message", message);
-                                        DotNetNuke.Services.Log.EventLog.LogController.Instance.AddLog(log);
-                                        return;
-                                    }
-
-                                    var userFolder = folderManager.GetUserFolder(userInfo);
-                                    if (userFolder == null)
-                                    {
-                                        var log = new DotNetNuke.Services.Log.EventLog.LogInfo { LogTypeKey = DotNetNuke.Abstractions.Logging.EventLogType.HOST_ALERT.ToString() };
-                                        log.LogProperties.Add(new LogDetailInfo("Module", Globals.ModuleFriendlyName));
-                                        var message = $"Unable to locate user folder for user id {attachment.UserId} while relocating attachment with id {attachment.AttachmentId} and content id {attachment.ContentId}";
-                                        log.AddProperty("Message", message);
-                                        DotNetNuke.Services.Log.EventLog.LogController.Instance.AddLog(log);
-                                        return;
-                                    }
-
-                                    filelocation = System.IO.Directory.EnumerateFiles(path: userFolder.PhysicalPath, searchPattern: string.Format(fileNameTemplate, attachment.ContentId, "*", attachment.FileName), searchOption: System.IO.SearchOption.AllDirectories).FirstOrDefault();
-                                    if (filelocation == null || !System.IO.File.Exists(filelocation))
-                                    {
-                                        // look in orphan attachments folder
-                                        filelocation = orphanedAttachmentsPath + attachment.FileName;
-                                        if (!System.IO.File.Exists(filelocation))
-                                        {
-                                            filelocation = System.IO.Directory.EnumerateFiles(path: orphanedAttachmentsPath, searchPattern: string.Format(fileNameTemplate, attachment.ContentId, "*", attachment.FileName), searchOption: System.IO.SearchOption.AllDirectories).FirstOrDefault();
-                                        }
-                                    }
-                                }
-                            }
-
-                            if (filelocation == null || !System.IO.File.Exists(filelocation))
-                            {
-                                var log = new DotNetNuke.Services.Log.EventLog.LogInfo { LogTypeKey = DotNetNuke.Abstractions.Logging.EventLogType.HOST_ALERT.ToString() };
-                                log.LogProperties.Add(new LogDetailInfo("Module", Globals.ModuleFriendlyName));
-                                var message = $"Unable to locate file for attachment filename {attachment.FileName} for user id {attachment.UserId} while relocating attachment with id {attachment.AttachmentId} and content id {attachment.ContentId}; removing attachment record";
-                                log.AddProperty("Message", message);
-                                DotNetNuke.Services.Log.EventLog.LogController.Instance.AddLog(log);
-                                DotNetNuke.Modules.ActiveForums.Controllers.AttachmentController.Instance.Delete(attachment);
-                                return;
-                            }
-
-                            using (System.Drawing.Image imageFile = System.Drawing.Image.FromFile(filelocation))
-                            {
-                                if (imageFile != null)
-                                {
-                                    using (var ms = new MemoryStream())
-                                    {
-                                        // pick save format by comparing RawFormat GUIDs
-                                        var raw = imageFile.RawFormat;
-                                        var saveFormat = System.Drawing.Imaging.ImageFormat.Png;
-
-                                        if (System.Drawing.Imaging.ImageFormat.Jpeg.Guid == raw.Guid)
-                                        {
+                                        case "image/jpeg":
+                                        case "image/jpg":
                                             saveFormat = System.Drawing.Imaging.ImageFormat.Jpeg;
-                                        }
-                                        else if (System.Drawing.Imaging.ImageFormat.Gif.Guid == raw.Guid)
-                                        {
+                                            break;
+                                        case "image/gif":
                                             saveFormat = System.Drawing.Imaging.ImageFormat.Gif;
-                                        }
-                                        else if (System.Drawing.Imaging.ImageFormat.Bmp.Guid == raw.Guid)
-                                        {
-                                            saveFormat = System.Drawing.Imaging.ImageFormat.Bmp;
-                                        }
-
-                                        attachment.FileName = System.IO.Path.ChangeExtension(attachment.FileName, $".{saveFormat.ToString().ToLowerInvariant()}");
-                                        attachment.FileName = DotNetNuke.Modules.ActiveForums.Controllers.AttachmentController.CreateUniqueFileName(embeddedImagesFolder.PhysicalPath, attachment.FileName);
-
-                                        try
-                                        {
-                                            imageFile.Save(ms, saveFormat);
-                                            ms.Position = 0;
-                                            file = fileManager.AddFile(embeddedImagesFolder, attachment.FileName, ms, true);
-                                        }
-                                        catch (Exception ex)
-                                        {
-                                            DotNetNuke.Modules.ActiveForums.Exceptions.LogException(ex);
+                                            break;
+                                        case "image/png":
+                                        case "image/x-png":
+                                            saveFormat = System.Drawing.Imaging.ImageFormat.Png;
+                                            break;
+                                        default:
+                                            // Unsupported image type
                                             var log = new DotNetNuke.Services.Log.EventLog.LogInfo { LogTypeKey = DotNetNuke.Abstractions.Logging.EventLogType.HOST_ALERT.ToString() };
                                             log.LogProperties.Add(new LogDetailInfo("Module", Globals.ModuleFriendlyName));
-                                            var message = $"Unable to add file to DNN file manager for attachment filename {attachment.FileName} for user id {attachment.UserId} while relocating attachment with id {attachment.AttachmentId} and content id {attachment.ContentId}";
+                                            var message = $"Unable to determine or invalid content type {attachment.ContentType} for file {attachment.FileName} with user id {attachment.UserId} while relocating attachment with id {attachment.AttachmentId} and content id {attachment.ContentId}";
                                             log.AddProperty("Message", message);
                                             DotNetNuke.Services.Log.EventLog.LogController.Instance.AddLog(log);
-                                        }
+                                            return;
+                                    }
+
+                                    attachment.FileName = System.IO.Path.ChangeExtension(attachment.FileName, saveFormat.ToString().ToLowerInvariant());
+                                    using (var ms = new MemoryStream())
+                                    {
+                                        ms.Write(fileBytes, 0, fileBytes.Length);
+                                        ms.Position = 0;
+
+                                        attachment.FileName = DotNetNuke.Modules.ActiveForums.Controllers.AttachmentController.CreateUniqueFileName(embeddedImagesFolder.PhysicalPath, attachment.FileName);
+                                        file = fileManager.AddFile(embeddedImagesFolder, attachment.FileName, ms, true);
+                                    }
+
+                                    if (file != null)
+                                    {
+                                        attachment.FileId = file.FileId;
                                     }
                                 }
                             }
 
-                            System.IO.File.Delete(filelocation);
+                            if (fileDataColumnObjectId == null || fileBytes == null)
+                            {
+                                const string fileNameTemplate = Globals.LegacyAttachmentFileNameFormatString;
+                                var filelocation = legacyAttachmentsPath + attachment.FileName;
+                                if (!System.IO.File.Exists(filelocation))
+                                {
+                                    filelocation = System.IO.Directory.EnumerateFiles(path: legacyAttachmentsPath, searchPattern: string.Format(fileNameTemplate, attachment.ContentId, "*", attachment.FileName), searchOption: System.IO.SearchOption.AllDirectories).FirstOrDefault();
+                                    if (filelocation == null || !System.IO.File.Exists(filelocation))
+                                    {
+                                        // If the file doesn't exist in the legacy attachment location, attempt to find it in the user's folder (legacy location for user-uploaded attachments)
+                                        var userInfo = DotNetNuke.Entities.Users.UserController.Instance.GetUserById(content.Post.PortalId, attachment.UserId);
+                                        if (userInfo == null)
+                                        {
+                                            var log = new DotNetNuke.Services.Log.EventLog.LogInfo { LogTypeKey = DotNetNuke.Abstractions.Logging.EventLogType.HOST_ALERT.ToString() };
+                                            log.LogProperties.Add(new LogDetailInfo("Module", Globals.ModuleFriendlyName));
+                                            var message = $"Unable to locate user with id {attachment.UserId} while relocating attachment with id {attachment.AttachmentId} and content id {attachment.ContentId}";
+                                            log.AddProperty("Message", message);
+                                            DotNetNuke.Services.Log.EventLog.LogController.Instance.AddLog(log);
+                                            return;
+                                        }
+
+                                        var userFolder = folderManager.GetUserFolder(userInfo);
+                                        if (userFolder == null)
+                                        {
+                                            var log = new DotNetNuke.Services.Log.EventLog.LogInfo { LogTypeKey = DotNetNuke.Abstractions.Logging.EventLogType.HOST_ALERT.ToString() };
+                                            log.LogProperties.Add(new LogDetailInfo("Module", Globals.ModuleFriendlyName));
+                                            var message = $"Unable to locate user folder for user id {attachment.UserId} while relocating attachment with id {attachment.AttachmentId} and content id {attachment.ContentId}";
+                                            log.AddProperty("Message", message);
+                                            DotNetNuke.Services.Log.EventLog.LogController.Instance.AddLog(log);
+                                            return;
+                                        }
+
+                                        filelocation = System.IO.Directory.EnumerateFiles(path: userFolder.PhysicalPath, searchPattern: string.Format(fileNameTemplate, attachment.ContentId, "*", attachment.FileName), searchOption: System.IO.SearchOption.AllDirectories).FirstOrDefault();
+                                        if (filelocation == null || !System.IO.File.Exists(filelocation))
+                                        {
+                                            // look in orphan attachments folder
+                                            filelocation = orphanedAttachmentsPath + attachment.FileName;
+                                            if (!System.IO.File.Exists(filelocation))
+                                            {
+                                                filelocation = System.IO.Directory.EnumerateFiles(path: orphanedAttachmentsPath, searchPattern: string.Format(fileNameTemplate, attachment.ContentId, "*", attachment.FileName), searchOption: System.IO.SearchOption.AllDirectories).FirstOrDefault();
+                                            }
+                                        }
+                                    }
+                                }
+
+                                if (filelocation == null || !System.IO.File.Exists(filelocation))
+                                {
+                                    var log = new DotNetNuke.Services.Log.EventLog.LogInfo { LogTypeKey = DotNetNuke.Abstractions.Logging.EventLogType.HOST_ALERT.ToString() };
+                                    log.LogProperties.Add(new LogDetailInfo("Module", Globals.ModuleFriendlyName));
+                                    var message = $"Unable to locate file for attachment filename {attachment.FileName} for user id {attachment.UserId} while relocating attachment with id {attachment.AttachmentId} and content id {attachment.ContentId}; removing attachment record";
+                                    log.AddProperty("Message", message);
+                                    DotNetNuke.Services.Log.EventLog.LogController.Instance.AddLog(log);
+                                    DotNetNuke.Modules.ActiveForums.Controllers.AttachmentController.Instance.Delete(attachment);
+                                    return;
+                                }
+
+                                using (System.Drawing.Image imageFile = System.Drawing.Image.FromFile(filelocation))
+                                {
+                                    if (imageFile != null)
+                                    {
+                                        using (var ms = new MemoryStream())
+                                        {
+                                            // pick save format by comparing RawFormat GUIDs
+                                            var raw = imageFile.RawFormat;
+                                            var saveFormat = System.Drawing.Imaging.ImageFormat.Png;
+
+                                            if (System.Drawing.Imaging.ImageFormat.Jpeg.Guid == raw.Guid)
+                                            {
+                                                saveFormat = System.Drawing.Imaging.ImageFormat.Jpeg;
+                                            }
+                                            else if (System.Drawing.Imaging.ImageFormat.Gif.Guid == raw.Guid)
+                                            {
+                                                saveFormat = System.Drawing.Imaging.ImageFormat.Gif;
+                                            }
+                                            else if (System.Drawing.Imaging.ImageFormat.Bmp.Guid == raw.Guid)
+                                            {
+                                                saveFormat = System.Drawing.Imaging.ImageFormat.Bmp;
+                                            }
+
+                                            attachment.FileName = System.IO.Path.ChangeExtension(attachment.FileName, $".{saveFormat.ToString().ToLowerInvariant()}");
+                                            attachment.FileName = DotNetNuke.Modules.ActiveForums.Controllers.AttachmentController.CreateUniqueFileName(embeddedImagesFolder.PhysicalPath, attachment.FileName);
+
+                                            try
+                                            {
+                                                imageFile.Save(ms, saveFormat);
+                                                ms.Position = 0;
+                                                file = fileManager.AddFile(embeddedImagesFolder, attachment.FileName, ms, true);
+                                            }
+                                            catch (Exception ex)
+                                            {
+                                                DotNetNuke.Modules.ActiveForums.Exceptions.LogException(ex);
+                                                var log = new DotNetNuke.Services.Log.EventLog.LogInfo { LogTypeKey = DotNetNuke.Abstractions.Logging.EventLogType.HOST_ALERT.ToString() };
+                                                log.LogProperties.Add(new LogDetailInfo("Module", Globals.ModuleFriendlyName));
+                                                var message = $"Unable to add file to DNN file manager for attachment filename {attachment.FileName} for user id {attachment.UserId} while relocating attachment with id {attachment.AttachmentId} and content id {attachment.ContentId}";
+                                                log.AddProperty("Message", message);
+                                                DotNetNuke.Services.Log.EventLog.LogController.Instance.AddLog(log);
+                                            }
+                                        }
+                                    }
+                                }
+
+                                System.IO.File.Delete(filelocation);
+                            }
                         }
                     }
 

--- a/Dnn.CommunityForums/components/Helpers/Upgrades.cs
+++ b/Dnn.CommunityForums/components/Helpers/Upgrades.cs
@@ -174,7 +174,8 @@ namespace DotNetNuke.Modules.ActiveForums.Helpers
                 }
             }
 
-            var templates = DotNetNuke.Data.DataContext.Instance().ExecuteQuery<TemplateInfoForConversion>(
+            using var ctx = DotNetNuke.Data.DataContext.Instance();
+            var templates = ctx.ExecuteQuery<TemplateInfoForConversion>(
             System.Data.CommandType.Text,
             @"SELECT ModuleId, TemplateType, FileName, Template FROM {databaseOwner}[{objectQualifier}communityforums_Templates]");
             foreach (var templateInfo in templates)
@@ -300,7 +301,8 @@ namespace DotNetNuke.Modules.ActiveForums.Helpers
                     {
                         try
                         {
-                            var subject = DotNetNuke.Data.DataContext.Instance().ExecuteScalar<string>(
+                            using var ctx = DotNetNuke.Data.DataContext.Instance();
+                            var subject = ctx.ExecuteScalar<string>(
                             System.Data.CommandType.Text,
                             @"SELECT TOP 1 Subject FROM {databaseOwner}[{objectQualifier}communityforums_Templates] WHERE TemplateType = 8 & ModuleId = @0",
                             module.ModuleID);
@@ -441,7 +443,8 @@ namespace DotNetNuke.Modules.ActiveForums.Helpers
                             "PROFILETEMPLATEID",
                         })
                         {
-                            DotNetNuke.Data.DataContext.Instance().Execute(System.Data.CommandType.Text, "DELETE FROM {databaseOwner}{objectQualifier}communityforums_Settings WHERE ModuleId = @0 AND SettingName = @1", module.ModuleID, settingName);
+                            using var ctx = DotNetNuke.Data.DataContext.Instance();
+                            ctx.Execute(System.Data.CommandType.Text, "DELETE FROM {databaseOwner}{objectQualifier}communityforums_Settings WHERE ModuleId = @0 AND SettingName = @1", module.ModuleID, settingName);
                         }
 
                         DotNetNuke.Entities.Modules.ModuleController.Instance.DeleteModuleSetting(module.ModuleID, "FORUMTEMPLATEID");
@@ -655,7 +658,8 @@ namespace DotNetNuke.Modules.ActiveForums.Helpers
 
                         /* remove PMTABID and update PMTYPE from 2 to 1 if needed (removing ventrian messaging) */
                         DotNetNuke.Entities.Modules.ModuleController.Instance.DeleteModuleSetting(module.ModuleID, "PMTABID");
-                        DotNetNuke.Data.DataContext.Instance().Execute(System.Data.CommandType.Text, "UPDATE {databaseOwner}{objectQualifier}ModuleSettings SET SettingValue = 1 WHERE ModuleId = @0 AND SettingName = 'PMTYPE' AND SettingValue = 2", module.ModuleID);
+                        using var ctx = DotNetNuke.Data.DataContext.Instance();
+                        ctx.Execute(System.Data.CommandType.Text, "UPDATE {databaseOwner}{objectQualifier}ModuleSettings SET SettingValue = 1 WHERE ModuleId = @0 AND SettingName = 'PMTYPE' AND SettingValue = 2", module.ModuleID);
 
                         /* remove URLBASE depending on how old the install is, it might be in ModuleSettings or it might be in communityforums_Settings, or both */
                         DotNetNuke.Entities.Modules.ModuleController.Instance.DeleteModuleSetting(module.ModuleID, "URLBASE");
@@ -664,7 +668,7 @@ namespace DotNetNuke.Modules.ActiveForums.Helpers
                             "URLBASE",
                         })
                         {
-                            DotNetNuke.Data.DataContext.Instance().Execute(System.Data.CommandType.Text, "DELETE FROM {databaseOwner}{objectQualifier}communityforums_Settings WHERE ModuleId = @0 AND SettingName = @1", module.ModuleID, settingName);
+                            ctx.Execute(System.Data.CommandType.Text, "DELETE FROM {databaseOwner}{objectQualifier}communityforums_Settings WHERE ModuleId = @0 AND SettingName = @1", module.ModuleID, settingName);
                         }
                     }
                 }
@@ -682,8 +686,9 @@ namespace DotNetNuke.Modules.ActiveForums.Helpers
                 log.AddProperty("Message", message);
                 DotNetNuke.Services.Log.EventLog.LogController.Instance.AddLog(log);
 
-                DotNetNuke.Data.DataContext.Instance().Execute(System.Data.CommandType.Text, "DROP TABLE IF EXISTS {databaseOwner}[{objectQualifier}communityforums_Templates]");
-                DotNetNuke.Data.DataContext.Instance().Execute(System.Data.CommandType.Text, "DROP SYNONYM IF EXISTS {databaseOwner}[{objectQualifier}activeforums_Templates]");
+                using var ctx = DotNetNuke.Data.DataContext.Instance();
+                ctx.Execute(System.Data.CommandType.Text, "DROP TABLE IF EXISTS {databaseOwner}[{objectQualifier}communityforums_Templates]");
+                ctx.Execute(System.Data.CommandType.Text, "DROP SYNONYM IF EXISTS {databaseOwner}[{objectQualifier}activeforums_Templates]");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
…flicts where DNN's shared connection may already have an active DataReader open

<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...
FIX: Use an isolated DataContext scope to avoid "open DataReader" conflicts where DNN's shared connection may already have an active DataReader open. Refactored all usages of `DotNetNuke.Data.DataContext.Instance()` to ensure proper disposal with using statements, enhancing resource management and preventing connection leaks. No business logic or SQL changes were made.
 

## Changes made
- Controllers (ContentController, ForumController, ForumUserController, PermissionController, TopicController, TopicTrackingController, UrlController): Updated to use using var ctx for DataContext.
- Entities (ForumInfo, ForumUserInfo): Refactored DataContext usage for proper disposal.
- Upgrade/configuration scripts (ForumsConfig, Upgrades, ForumsSitemapProvider): Applied consistent DataContext scoping.
- ForumInfo: Added StyleCop suppression and justification for multi-line parameter formatting in TotalLikeCount.

 
## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other
- [ ] Requires documentation updates  
- [ ] I've updated the documentation already  


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #1987